### PR TITLE
Implements most of the strategy in #4.

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,8 +1,16 @@
 use reactor::{Reactor};
 
+#[deriving(Show)]
+pub enum ReadHint {
+    DataHint,
+    HupHint,
+    ErrorHint,
+    UnknownHint
+}
+
 #[allow(unused_variable)]
 pub trait Handler<T: Token> {
-    fn readable(&mut self, reactor: &mut Reactor<T>, token: T) {
+    fn readable(&mut self, reactor: &mut Reactor<T>, token: T, hint: ReadHint) {
         println!("Handler: readable");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,10 @@ pub use error::{
     MioResult,
     MioError
 };
-pub use handler::Handler;
+pub use handler::{
+    Handler,
+    ReadHint
+};
 pub use io::{
     NonBlock,
     IoReader,

--- a/test/test_echo_server.rs
+++ b/test/test_echo_server.rs
@@ -223,7 +223,7 @@ impl EchoHandler {
 }
 
 impl Handler<uint> for EchoHandler {
-    fn readable(&mut self, reactor: &mut Reactor<uint>, token: uint) {
+    fn readable(&mut self, reactor: &mut Reactor<uint>, token: uint, _hint: ReadHint) {
         match token {
             0 => self.server.accept(reactor),
             1 => self.client.readable(reactor),


### PR DESCRIPTION
Closes #4.

We will also need to move IoError to a hint, since it's not supported by
all backends.
