### PR TITLE
Remove Socket token generic in favor of a struct

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,72 +1,17 @@
-use reactor::{Reactor};
+use reactor::Reactor;
+use token::Token;
 
 #[allow(unused_variable)]
-pub trait Handler<T: Token, T2, M: Send> {
-    fn readable(&mut self, reactor: &mut Reactor<T, T2, M>, token: T) {
+pub trait Handler<T, M: Send> {
+    fn readable(&mut self, reactor: &mut Reactor<T, M>, token: Token) {
     }
 
-    fn writable(&mut self, reactor: &mut Reactor<T, T2, M>, token: T) {
+    fn writable(&mut self, reactor: &mut Reactor<T, M>, token: Token) {
     }
 
-    fn notify(&mut self, reactor: &mut Reactor<T, T2, M>, msg: M) {
+    fn notify(&mut self, reactor: &mut Reactor<T, M>, msg: M) {
     }
 
-    fn timeout(&mut self, reactor: &mut Reactor<T, T2, M>, timeout: T2) {
-    }
-}
-
-pub trait Token : Copy {
-    fn from_u64(val: u64) -> Self;
-
-    fn to_u64(self) -> u64;
-}
-
-impl Token for int {
-    fn from_u64(val: u64) -> int {
-        val as int
-    }
-
-    fn to_u64(self) -> u64 {
-        self as u64
-    }
-}
-
-impl Token for uint {
-    fn from_u64(val: u64) -> uint {
-        val as uint
-    }
-
-    fn to_u64(self) -> u64 {
-        self as u64
-    }
-}
-
-impl Token for i64 {
-    fn from_u64(val: u64) -> i64 {
-        val as i64
-    }
-
-    fn to_u64(self) -> u64 {
-        self as u64
-    }
-}
-
-impl Token for u64 {
-    fn from_u64(val: u64) -> u64 {
-        val
-    }
-
-    fn to_u64(self) -> u64 {
-        self
-    }
-}
-
-impl Token for () {
-    fn from_u64(_: u64) -> () {
-        ()
-    }
-
-    fn to_u64(self) -> u64 {
-        0
+    fn timeout(&mut self, reactor: &mut Reactor<T, M>, timeout: T) {
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,11 @@ pub use timer::{
     Timer,
     Timeout,
 };
+pub use token::{
+    Token,
+    TOKEN_0,
+    TOKEN_1,
+};
 
 pub mod buf;
 mod error;
@@ -65,3 +70,4 @@ mod reactor;
 mod slab;
 mod socket;
 mod timer;
+mod token;

--- a/src/os/epoll.rs
+++ b/src/os/epoll.rs
@@ -28,12 +28,12 @@ impl Selector {
     }
 
     /// Register event interests for the given IO handle with the OS
-    pub fn register(&mut self, io: &IoDesc, token: u64) -> MioResult<()> {
+    pub fn register(&mut self, io: &IoDesc, token: uint) -> MioResult<()> {
         let interests = EPOLLIN | EPOLLOUT | EPOLLERR;
 
         let info = EpollEvent {
             events: interests | EPOLLET,
-            data: token
+            data: token as u64
         };
 
         epoll_ctl(self.epfd, EpollCtlAdd, io.fd, &info)

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -29,7 +29,7 @@ impl Selector {
         Ok(())
     }
 
-    pub fn register(&mut self, io: &IoDesc, token: u64) -> MioResult<()> {
+    pub fn register(&mut self, io: &IoDesc, token: uint) -> MioResult<()> {
         let flag = EV_ADD | EV_CLEAR;
 
         try!(self.ev_push(io, EVFILT_READ, flag, FilterFlag::empty(), token));
@@ -45,7 +45,7 @@ impl Selector {
                filter: EventFilter,
                flags: EventFlag,
                fflags: FilterFlag,
-               token: u64) -> MioResult<()> {
+               token: uint) -> MioResult<()> {
 
         // If the change buffer is full, flush it
         try!(self.maybe_flush_changes());
@@ -53,8 +53,7 @@ impl Selector {
         let idx = self.changes.len;
         let ev = &mut self.changes.events[idx];
 
-        // TODO: Don't cast to uint
-        ev_set(ev, io.fd as uint, filter, flags, fflags, token as uint);
+        ev_set(ev, io.fd as uint, filter, flags, fflags, token);
 
         self.changes.len += 1;
 
@@ -121,8 +120,7 @@ impl Events {
             }
         }
 
-        // TODO: Don't cast
-        IoEvent::new(kind, token as u64)
+        IoEvent::new(kind, token)
     }
 
     #[inline]

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,6 +1,7 @@
 use error::MioResult;
 use io::IoHandle;
 use os;
+use token::Token;
 
 pub struct Poll {
     selector: os::Selector,
@@ -15,11 +16,11 @@ impl Poll {
         })
     }
 
-    pub fn register<H: IoHandle>(&mut self, io: &H, token: u64) -> MioResult<()> {
+    pub fn register<H: IoHandle>(&mut self, io: &H, token: Token) -> MioResult<()> {
         debug!("registering IO with poller");
 
         // Register interests for this socket
-        try!(self.selector.register(io.desc(), token));
+        try!(self.selector.register(io.desc(), token.as_uint()));
 
         Ok(())
     }
@@ -47,7 +48,7 @@ bitflags!(
 #[deriving(Show)]
 pub struct IoEvent {
     kind: IoEventKind,
-    token: u64
+    token: Token
 }
 
 /// IoEvent represents the raw event that the OS-specific selector
@@ -58,14 +59,14 @@ pub struct IoEvent {
 /// Selector when they have events to report.
 impl IoEvent {
     /// Create a new IoEvent.
-    pub fn new(kind: IoEventKind, token: u64) -> IoEvent {
+    pub fn new(kind: IoEventKind, token: uint) -> IoEvent {
         IoEvent {
             kind: kind,
-            token: token
+            token: Token(token)
         }
     }
 
-    pub fn token(&self) -> u64 {
+    pub fn token(&self) -> Token {
         self.token
     }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -2,8 +2,9 @@ use std::uint;
 use std::num;
 use time::precise_time_ns;
 use slab::Slab;
+use token::Token;
 
-static EMPTY: uint = uint::MAX;
+static EMPTY: Token = Token(uint::MAX);
 static NS_PER_MS: u64 = 1_000_000;
 
 // Implements coarse-grained timeouts using an algorithm based on hashed timing
@@ -20,20 +21,20 @@ pub struct Timer<T> {
     entries: Slab<Entry<T>>,
     // Timeout wheel. Each tick, the timer will look at the next slot for
     // timeouts that match the current tick.
-    wheel: Vec<uint>,
+    wheel: Vec<Token>,
     // Tick 0's time in milliseconds
     start: u64,
     // The current tick
     tick: u64,
     // The next entry to possibly timeout
-    next: uint,
+    next: Token,
     // Masks the target tick to get the slot
     mask: u64,
 }
 
 pub struct Timeout {
     // Reference into the timer entry slab
-    token: uint,
+    token: Token,
     // Tick that it should matchup with
     tick: u64,
 }
@@ -156,7 +157,7 @@ impl<T> Timer<T> {
         })
     }
 
-    fn unlink(&mut self, links: &EntryLinks, token: uint) {
+    fn unlink(&mut self, links: &EntryLinks, token: Token) {
         debug!("unlinking timeout; slot={}; token={}",
                self.slot_for(links.tick), token);
 
@@ -257,7 +258,7 @@ struct Entry<T> {
 }
 
 impl<T> Entry<T> {
-    fn new(token: T, tick: u64, next: uint) -> Entry<T> {
+    fn new(token: T, tick: u64, next: Token) -> Entry<T> {
         Entry {
             token: token,
             links: EntryLinks {
@@ -271,8 +272,8 @@ impl<T> Entry<T> {
 
 struct EntryLinks {
     tick: u64,
-    prev: uint,
-    next: uint
+    prev: Token,
+    next: Token
 }
 
 pub type TimerResult<T> = Result<T, TimerError>;

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,0 +1,14 @@
+#[deriving(Show, PartialEq, Eq)]
+pub struct Token(pub uint);
+
+impl Token {
+    #[inline]
+    pub fn as_uint(self) -> uint {
+        let Token(inner) = self;
+        inner
+    }
+}
+
+// Work around for https://github.com/rust-lang/rust/issues/17169
+pub static TOKEN_0:Token = Token(0);
+pub static TOKEN_1:Token = Token(1);

--- a/test/test_notify.rs
+++ b/test/test_notify.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use mio::*;
 use super::localhost;
 
-type TestReactor = Reactor<uint, uint, String>;
+type TestReactor = Reactor<uint, String>;
 
 struct TestHandler {
     sender: ReactorSender<String>,
@@ -19,7 +19,7 @@ impl TestHandler {
     }
 }
 
-impl Handler<uint, uint, String> for TestHandler {
+impl Handler<uint, String> for TestHandler {
     fn notify(&mut self, reactor: &mut TestReactor, msg: String) {
         match self.notify {
             0 => {
@@ -48,7 +48,7 @@ pub fn test_notify() {
     let srv = TcpSocket::v4().unwrap();
     srv.set_reuseaddr(true).unwrap();
     let srv = srv.bind(&addr).unwrap();
-    reactor.listen(&srv, 256u, 0u).unwrap();
+    reactor.listen(&srv, 256u, Token(0)).unwrap();
 
     let sender = reactor.channel();
 


### PR DESCRIPTION
Token has become a tuple struct wrapping a single uint. Using a generic
is not much use because supporting epoll and kqueue require that:

a) implement Copy
b) fit in the same number of bytes as uint

Given these requirements, it seems easier to just use a uint based
token.

Note that the TOKEN_{N} hack is to work around a rust bug (rust-lang/rust#17722) that has been fixed in a PR but is waiting to be pulled in.
