### PR TITLE
Implements ReadHint for Hup for Linux

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -261,7 +261,7 @@ impl<T, M: Send> EventLoop<T, M> {
         let tok = evt.token();
 
         if evt.is_readable() {
-            handler.readable(self, tok);
+            handler.readable(self, tok, evt.read_hint());
         }
 
         if evt.is_writable() {
@@ -333,7 +333,7 @@ mod tests {
     use std::sync::atomics::{AtomicInt, SeqCst};
     use super::EventLoop;
     use io::{IoWriter, IoReader};
-    use {io, buf, Buf, Handler, Token};
+    use {io, buf, Buf, Handler, Token, ReadHint};
 
     type TestEventLoop = EventLoop<uint, ()>;
 
@@ -352,7 +352,7 @@ mod tests {
     }
 
     impl Handler<uint, ()> for Funtimes {
-        fn readable(&mut self, _event_loop: &mut TestEventLoop, token: Token) {
+        fn readable(&mut self, _event_loop: &mut TestEventLoop, token: Token, hint: ReadHint) {
             (*self.rcount).fetch_add(1, SeqCst);
             assert_eq!(token, Token(10));
         }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,9 +1,18 @@
 use event_loop::EventLoop;
 use token::Token;
 
+bitflags!(
+    #[deriving(Show)]
+    flags ReadHint: uint {
+        static DataHint    = 0x001,
+        static HupHint     = 0x002,
+        static ErrorHint   = 0x004
+    }
+)
+
 #[allow(unused_variable)]
 pub trait Handler<T, M: Send> {
-    fn readable(&mut self, event_loop: &mut EventLoop<T, M>, token: Token) {
+    fn readable(&mut self, event_loop: &mut EventLoop<T, M>, token: Token, hint: ReadHint) {
     }
 
     fn writable(&mut self, event_loop: &mut EventLoop<T, M>, token: Token) {

--- a/src/io.rs
+++ b/src/io.rs
@@ -2,6 +2,7 @@ use buf::{Buf, MutBuf};
 use os;
 use error::MioResult;
 
+#[deriving(Show)]
 pub enum NonBlock<T> {
     Ready(T),
     WouldBlock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,10 @@ pub use error::{
     MioResult,
     MioError,
 };
-pub use handler::Handler;
+pub use handler::{
+    Handler,
+    ReadHint
+};
 pub use io::{
     pipe,
     NonBlock,
@@ -62,7 +65,7 @@ pub use token::{
 pub mod buf;
 mod error;
 mod event_loop;
-mod handler;
+pub mod handler;
 mod io;
 mod notify;
 mod os;

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -2,6 +2,7 @@ use error::MioResult;
 use io::IoHandle;
 use os;
 use token::Token;
+use handler::{ReadHint, DataHint, HupHint, ErrorHint};
 
 pub struct Poll {
     selector: os::Selector,
@@ -41,7 +42,9 @@ bitflags!(
     flags IoEventKind: uint {
         static IoReadable = 0x001,
         static IoWritable = 0x002,
-        static IoError    = 0x004
+        static IoError    = 0x004,
+        static IoHupHint  = 0x008,
+        static IoHinted   = 0x010
     }
 )
 
@@ -70,9 +73,36 @@ impl IoEvent {
         self.token
     }
 
+    /// Return an optional hint for a readable IO handle. Currently,
+    /// this method supports the HupHint, which indicates that the
+    /// kernel reported that the remote side hung up. This allows a
+    /// consumer to avoid reading in order to discover the hangup.
+    pub fn read_hint(&self) -> ReadHint {
+        let mut hint = ReadHint::empty();
+
+        // The backend doesn't support hinting
+        if !self.kind.contains(IoHinted) {
+            return hint;
+        }
+
+        if self.kind.contains(IoHupHint) {
+            hint = hint | HupHint
+        }
+
+        if self.kind.contains(IoReadable) {
+            hint = hint | DataHint
+        }
+
+        if self.kind.contains(IoError) {
+            hint = hint | ErrorHint
+        }
+
+        hint
+    }
+
     /// This event indicated that the IO handle is now readable
     pub fn is_readable(&self) -> bool {
-        self.kind.contains(IoReadable)
+        self.kind.contains(IoReadable) || self.kind.contains(IoHupHint)
     }
 
     /// This event indicated that the IO handle is now writable

--- a/test/test_echo_server.rs
+++ b/test/test_echo_server.rs
@@ -228,7 +228,9 @@ impl EchoHandler {
 }
 
 impl Handler<uint, ()> for EchoHandler {
-    fn readable(&mut self, event_loop: &mut TestEventLoop, token: Token) {
+    fn readable(&mut self, event_loop: &mut TestEventLoop, token: Token, hint: ReadHint) {
+        assert_eq!(hint, handler::DataHint);
+
         match token {
             SERVER => self.server.accept(event_loop),
             CLIENT => self.client.readable(event_loop),


### PR DESCRIPTION
This implements the first part of the strategy outlined in #4.

It updates the tests to take the read hint in the handlers, and
specifically confirm that they get the DataHint first and then the
HupHint.

I believe that the hints are implementable on all of the backends we
intend to support, so I consider it a bug if those tests don't pass on a
supported platform.

Note that this information is called a "hint" because you still need to
handle errors in your read handler, but this may allow you to skip the
extra `read` syscall as an optimization.

This PR supersedes #5.
