### PR TITLE
First whack at UDP send/receive sockets for Mio

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -126,3 +126,4 @@ pub fn write<O: IoHandle>(io: &mut O, buf: &mut Buf) -> MioResult<NonBlock<()>> 
 
     Ok(Ready(()))
 }
+

--- a/test/test.rs
+++ b/test/test.rs
@@ -12,6 +12,8 @@ mod test_close_on_drop;
 mod test_echo_server;
 mod test_notify;
 mod test_timer;
+mod test_udp_socket;
+mod test_udp_socket_connectionless;
 
 mod ports {
     use std::sync::atomic::{AtomicUint, SeqCst, INIT_ATOMIC_UINT};

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -1,0 +1,89 @@
+use mio::*;
+use mio::net::*;
+use mio::net::udp::*;
+use mio::buf::{RingBuf, SliceBuf};
+use std::str;
+use super::localhost;
+use std::io::net::ip::{Ipv4Addr};
+
+type TestEventLoop = EventLoop<uint, ()>;
+
+const LISTENER: Token = Token(0);
+const SENDER: Token = Token(1);
+
+pub struct UdpHandler {
+    listen_sock: UdpSocket,
+    send_sock: UdpSocket,
+    msg: &'static str,
+    message_buf: SliceBuf<'static>,
+    rx_buf: RingBuf
+}
+
+impl UdpHandler {
+    fn new(send_sock: UdpSocket, listen_sock: UdpSocket, msg : &'static str) -> UdpHandler {
+        UdpHandler {
+            listen_sock: listen_sock,
+            send_sock: send_sock,
+            msg: msg,
+            message_buf: SliceBuf::wrap(msg.as_bytes()),
+            rx_buf: RingBuf::new(1024)
+        }
+    }
+}
+
+impl Handler<uint, ()> for UdpHandler {
+    fn readable(&mut self, event_loop: &mut TestEventLoop, token: Token, _: ReadHint) {
+        match token {
+            LISTENER => {
+                debug!("We are receiving a datagram now...");
+                self.listen_sock.read(&mut self.rx_buf.writer()).unwrap();
+                assert!(str::from_utf8(self.rx_buf.reader().bytes()).unwrap() == self.msg);
+                event_loop.shutdown();
+            },
+            _ => ()
+        }
+    }
+
+    fn writable(&mut self, _: &mut TestEventLoop, token: Token) {
+        match token {
+            SENDER => {
+                self.send_sock.write(&mut self.message_buf).unwrap();
+            },
+            _ => ()
+        }
+    }
+}
+
+#[test]
+pub fn test_udp_socket() {
+    let mut event_loop = EventLoop::new().unwrap();
+
+    let send_sock = UdpSocket::v4().unwrap();
+    let recv_sock = UdpSocket::v4().unwrap();
+    let addr = SockAddr::parse(localhost().as_slice())
+        .expect("could not parse InetAddr for localhost");
+
+    info!("Binding both listener and sender to localhost...");
+    send_sock.connect(&addr).unwrap();
+    recv_sock.bind(&addr).unwrap();
+
+    info!("Setting SO_REUSEADDR");
+    send_sock.set_reuseaddr(true).unwrap();
+    recv_sock.set_reuseaddr(true).unwrap();
+
+    info!("Joining group 227.1.1.100");
+    recv_sock.join_multicast_group(&Ipv4Addr(227, 1, 1, 100), &None).unwrap();
+
+    info!("Joining group 227.1.1.101");
+    recv_sock.join_multicast_group(&Ipv4Addr(227, 1, 1, 101), &None).unwrap();
+
+    info!("Registering LISTENER");
+    event_loop.register(&recv_sock, LISTENER).unwrap();
+
+    info!("Registering SENDER");
+    event_loop.register(&send_sock, SENDER).unwrap();
+
+    info!("Starting event loop to test with...");
+    event_loop.run(UdpHandler::new(send_sock, recv_sock, "hello world")).ok().expect("Failed to run the actual event listener loop");
+}
+

--- a/test/test_udp_socket_connectionless.rs
+++ b/test/test_udp_socket_connectionless.rs
@@ -1,0 +1,101 @@
+use mio::*;
+use mio::net::*;
+use mio::net::udp::*;
+use mio::buf::{RingBuf, SliceBuf};
+use std::str;
+use std::io::net::ip::{Ipv4Addr};
+
+type TestEventLoop = EventLoop<uint, ()>;
+
+const LISTENER: Token = Token(0);
+const SENDER: Token = Token(1);
+
+pub struct UdpHandler {
+    listen_sock: UdpSocket,
+    send_sock: UdpSocket,
+    sock_addr: SockAddr,
+    msg: &'static str,
+    message_buf: SliceBuf<'static>,
+    rx_buf: RingBuf
+}
+
+impl UdpHandler {
+    fn new(send_sock: UdpSocket, listen_sock: UdpSocket, msg : &'static str) -> UdpHandler {
+        UdpHandler {
+            listen_sock: listen_sock,
+            send_sock: send_sock,
+            sock_addr: SockAddr::parse("127.0.0.1:24601".as_slice()).expect("could not parse localhost address"),
+            msg: msg,
+            message_buf: SliceBuf::wrap(msg.as_bytes()),
+            rx_buf: RingBuf::new(1024)
+        }
+    }
+}
+
+impl Handler<uint, ()> for UdpHandler {
+    fn readable(&mut self, event_loop: &mut TestEventLoop, token: Token, _: ReadHint) {
+        match token {
+            LISTENER => {
+                debug!("We are receiving a datagram now...");
+                match self.listen_sock.recv_from(&mut self.rx_buf.writer()) {
+                    Ok(wouldblock) => {
+                        match wouldblock.unwrap() {
+                            InetAddr(ip, _) => {
+                                assert!(ip == IPv4Addr(127, 0, 0, 1));
+                            }
+                            _ => fail!("This should be an IPv4 address")
+                        }
+                    }
+                    ret => {
+                        ret.unwrap();
+                    }
+                }
+                assert!(str::from_utf8(self.rx_buf.reader().bytes()).unwrap() == self.msg);
+                event_loop.shutdown();
+            },
+            _ => ()
+        }
+    }
+
+    fn writable(&mut self, _: &mut TestEventLoop, token: Token) {
+        match token {
+            SENDER => {
+                self.send_sock.send_to(&mut self.message_buf, &self.sock_addr).unwrap();
+            },
+            _ => ()
+        }
+    }
+}
+
+#[test]
+pub fn test_udp_socket_connectionless() {
+    let mut event_loop = EventLoop::new().unwrap();
+
+    let send_sock = UdpSocket::v4().unwrap();
+    let recv_sock = UdpSocket::v4().unwrap();
+    let addr = SockAddr::parse("127.0.0.1:24601".as_slice())
+        .expect("could not parse InetAddr for localhost");
+
+    info!("Binding the listener socket");
+    recv_sock.bind(&addr).unwrap();
+
+    info!("Setting SO_REUSEADDR");
+    send_sock.set_reuseaddr(true).unwrap();
+    recv_sock.set_reuseaddr(true).unwrap();
+
+    info!("Joining group 227.1.1.100");
+    recv_sock.join_multicast_group(&Ipv4Addr(227, 1, 1, 100), &None).unwrap();
+
+    info!("Joining group 227.1.1.101");
+    recv_sock.join_multicast_group(&Ipv4Addr(227, 1, 1, 101), &None).unwrap();
+
+    info!("Registering LISTENER");
+    event_loop.register(&recv_sock, LISTENER).unwrap();
+
+    info!("Registering SENDER");
+    event_loop.register(&send_sock, SENDER).unwrap();
+
+    info!("Starting event loop to test with...");
+    event_loop.run(UdpHandler::new(send_sock, recv_sock, "hello world")).ok().expect("Failed to run the actual event listener loop");
+}
+


### PR DESCRIPTION
Add initial support to MIO for UDP sockets, including the ability to
join multicast groups and listen. Still need to add support for
recvfrom/sendto, but works just fine for connected UDP sockets.

Depends on nix-rust having pull request https://github.com/carllerche/nix-rust/pull/12
