### PR TITLE
Refactored EventLoop::timeout_ms to use Duration instead of u64

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -1,4 +1,5 @@
 use std::default::Default;
+use std::time::duration::Duration;
 use std::uint;
 use error::{MioResult, MioError};
 use handler::Handler;
@@ -95,8 +96,8 @@ impl<T, M: Send> EventLoop<T, M> {
 
     /// After the requested time interval, the handler's `timeout` function
     /// will be called with the supplied token.
-    pub fn timeout_ms(&mut self, token: T, delay: u64) -> TimerResult<Timeout> {
-        self.timer.timeout_ms(token, delay)
+    pub fn timeout(&mut self, token: T, delay: Duration) -> TimerResult<Timeout> {
+        self.timer.timeout(token, delay)
     }
 
     /// If the supplied timeout has not been triggered, cancel it such that it

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,4 +1,6 @@
 use std::uint;
+use std::cmp::max;
+use std::time::duration::Duration;
 use std::num;
 use time::precise_time_ns;
 use token::Token;
@@ -94,8 +96,8 @@ impl<T> Timer<T> {
      *
      */
 
-    pub fn timeout_ms(&mut self, token: T, delay: u64) -> TimerResult<Timeout> {
-        let at = self.now_ms() + delay;
+    pub fn timeout(&mut self, token: T, delay: Duration) -> TimerResult<Timeout> {
+        let at = self.now_ms() + (max(0, delay.num_milliseconds()) as u64);
         self.timeout_at_ms(token, at)
     }
 

--- a/test/test_timer.rs
+++ b/test/test_timer.rs
@@ -1,3 +1,4 @@
+use std::time::duration::Duration;
 use mio::*;
 use mio::net::*;
 use mio::net::tcp::*;
@@ -37,7 +38,7 @@ impl Handler<TcpSocket, ()> for TestHandler {
             SERVER => {
                 debug!("server connection ready for accept");
                 let conn = self.srv.accept().unwrap().unwrap();
-                event_loop.timeout_ms(conn, 200).unwrap();
+                event_loop.timeout(conn, Duration::milliseconds(200)).unwrap();
             }
             CLIENT => {
                 debug!("client readable");


### PR DESCRIPTION
Addresses #32. Removed `_ms` from the method name since the Duration class can represent a range of units.
