### PR TITLE
Slab contains() should accept token and convert index

### DIFF
--- a/src/util/slab.rs
+++ b/src/util/slab.rs
@@ -402,4 +402,13 @@ mod tests {
         let slab = Slab::<uint>::new(16);
         slab[Token(0)];
     }
+
+    #[test]
+    fn test_contains() {
+        let mut slab = Slab::new_starting_at(Token(5),16);
+        assert!(!slab.contains(Token(0)));
+
+        let tok = slab.insert(111u).unwrap();
+        assert!(slab.contains(tok));
+    }
 }


### PR DESCRIPTION
It seems to be a mistake that slab.contains() accepts uint and expects it to be an internal index. Either it's a private method than pub should be removed or it should accept token. 
