### PR TITLE
broke io::read/write out into non-buffering and buffering solutions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Cargo.lock
 target
 libs
+.*.sw*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 
 git = "https://github.com/carllerche/nix-rust"
 
+[dependencies.time]
+
+git = "https://github.com/rust-lang/time"
+
 [[test]]
 
 name = "test"

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ pub type MioResult<T> = Result<T, MioError>;
 
 #[deriving(Show, PartialEq, Clone)]
 pub struct MioError {
-    kind: MioErrorKind,
+    pub kind: MioErrorKind,
     sys: Option<SysError>
 }
 

--- a/src/event_ctx.rs
+++ b/src/event_ctx.rs
@@ -1,0 +1,171 @@
+use std::fmt;
+use token::Token;
+use handler::{ReadHint, DATAHINT, HUPHINT, ERRORHINT};
+
+
+bitflags!(
+          flags IoEventKind: uint {
+          const IOREADABLE = 0x001,
+          const IOWRITABLE = 0x002,
+          const IOERROR    = 0x004,
+          const IOHUPHINT  = 0x008,
+          const IOHINTED   = 0x010,
+          const IOONESHOT  = 0x020,
+          const IOEDGE     = 0x040,
+          const IOLEVEL    = 0x080,
+          const IOALL      = 0x001 | 0x002 | 0x004 | 0x008 
+          }
+         )
+
+impl fmt::Show for IoEventKind {
+  fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    let mut one = false;
+    let flags = [
+      (IOREADABLE, "IoReadable"),
+      (IOWRITABLE, "IoWritable"),
+      (IOERROR, "IoError"),
+      (IOHUPHINT, "IoHupHint"),
+      (IOHINTED, "IoHinted"),
+      (IOEDGE, "IoEdgeTriggered")];
+
+    for &(flag, msg) in flags.iter() {
+      if self.contains(flag) {
+        if one { try!(write!(fmt, " | ")) }
+        try!(write!(fmt, "{}", msg));
+
+        one = true
+      }
+    }
+
+    Ok(())
+  }
+}
+
+#[deriving(Show)]
+pub struct IoEventCtx {
+kind: IoEventKind,
+        token: Token
+}
+
+/// IoEventCtx represents the raw event upon which the OS-specific selector
+/// operates. It takes an IoEventCtx when registering and re-registering event
+/// interest for Tokens. It also returns IoEventCtx when calling handlers. 
+/// An event can represent more than one kind (such as readable or writable) at a time.
+///
+/// These IoEventCtx objects are created by the OS-specific concrete
+/// Selector when they have events to report.
+impl IoEventCtx {
+  /// Create a new IoEvent.
+  pub fn new(kind: IoEventKind, token: Token) -> IoEventCtx {
+    IoEventCtx {
+        kind: kind, 
+        token: token
+    }
+  }
+
+  pub fn token(&self) -> Token {
+    self.token
+  }
+
+  /// Return an optional hint for a readable IO handle. Currently,
+  /// this method supports the HupHint, which indicates that the
+  /// kernel reported that the remote side hung up. This allows a
+  /// consumer to avoid reading in order to discover the hangup.
+  pub fn read_hint(&self) -> ReadHint {
+    let mut hint = ReadHint::empty();
+
+    // The backend doesn't support hinting
+    if !self.kind.contains(IOHINTED) {
+      return hint;
+    }
+
+    if self.kind.contains(IOHUPHINT) {
+      hint = hint | HUPHINT
+    }
+
+    if self.kind.contains(IOREADABLE) {
+      hint = hint | DATAHINT
+    }
+
+    if self.kind.contains(IOERROR) {
+      hint = hint | ERRORHINT
+    }
+
+    hint
+  }
+
+  /// This event indicated that the IO handle is now readable
+  pub fn is_readable(&self) -> bool {
+    self.kind.contains(IOREADABLE) || self.kind.contains(IOHUPHINT)
+  }
+
+  /// This event indicated that the IO handle is now writable
+  pub fn is_writable(&self) -> bool {
+    self.kind.contains(IOWRITABLE)
+  }
+
+  /// This event indicated that the IO handle had an error
+  pub fn is_error(&self) -> bool {
+    self.kind.contains(IOERROR)
+  }
+
+  pub fn is_hangup(&self) -> bool {
+    self.kind.contains(IOHUPHINT)
+  }
+
+  pub fn is_edge_triggered(&self) -> bool {
+    self.kind.contains(IOEDGE)
+  }
+
+  /// This event indicated that the IO handle is now readable
+  pub fn set_readable(&mut self, flag: bool) -> &IoEventCtx {
+    match flag {
+      true => self.kind.insert(IOREADABLE),
+      false => self.kind.remove(IOREADABLE)
+    }
+    return self;
+  }
+
+  /// This event indicated that the IO handle is now writable
+  pub fn set_writable(&mut self, flag: bool) -> &IoEventCtx { 
+    match flag {
+      true => self.kind.insert(IOWRITABLE),
+      false => self.kind.remove(IOWRITABLE)
+    }
+    return self;
+  }
+
+  /// This event indicated that the IO handle had an error
+  pub fn set_error(&mut self, flag: bool) -> &IoEventCtx {
+    match flag {
+      true => self.kind.insert(IOERROR),
+      false => self.kind.remove(IOERROR)
+    }
+    return self;
+  }
+
+  pub fn set_hangup(&mut self, flag: bool) -> &IoEventCtx {
+    match flag {
+      true => self.kind.insert(IOHUPHINT),
+      false => self.kind.remove(IOHUPHINT)
+    }
+    return self;
+  }
+
+  pub fn set_edge_triggered(&mut self, flag: bool) -> &IoEventCtx {
+    match flag {
+      true => self.kind.insert(IOEDGE),
+      false => self.kind.remove(IOEDGE)
+    }
+    return self;
+  }
+
+  pub fn set_all(&mut self, flag: bool) -> &IoEventCtx {
+    match flag {
+      true => self.kind.insert(IOALL),
+      false => self.kind.remove(IOALL)
+    }
+    return self;
+  }
+}
+

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,6 +1,7 @@
 use buf::{Buf, MutBuf};
 use os;
 use error::MioResult;
+use error::MioErrorKind as mek;
 
 #[deriving(Show)]
 pub enum NonBlock<T> {
@@ -29,11 +30,11 @@ pub trait IoHandle {
 }
 
 pub trait IoReader {
-    fn read(&mut self, buf: &mut MutBuf) -> MioResult<NonBlock<()>>;
+    fn read(&mut self, buf: &mut MutBuf) -> MioResult<NonBlock<uint>>;
 }
 
 pub trait IoWriter {
-    fn write(&mut self, buf: &mut Buf) -> MioResult<NonBlock<()>>;
+    fn write(&mut self, buf: &mut Buf) -> MioResult<NonBlock<uint>>;
 }
 
 pub trait IoAcceptor<T> {
@@ -66,39 +67,54 @@ impl IoHandle for PipeWriter {
 }
 
 impl IoReader for PipeReader {
-    fn read(&mut self, buf: &mut MutBuf) -> MioResult<NonBlock<()>> {
+    fn read(&mut self, buf: &mut MutBuf) -> MioResult<NonBlock<uint>> {
         read(self, buf)
     }
 }
 
 impl IoWriter for PipeWriter {
-    fn write(&mut self, buf: &mut Buf) -> MioResult<NonBlock<()>> {
+    fn write(&mut self, buf: &mut Buf) -> MioResult<NonBlock<uint>> {
         write(self, buf)
     }
 }
 
-pub fn read<I: IoHandle>(io: &mut I, buf: &mut MutBuf) -> MioResult<NonBlock<()>> {
-    let mut first_iter = true;
+/// Reads the length of the slice supplied by buf.mut_bytes into the buffer
+/// This is not guaranteed to consume an entire datagram or segment. 
+/// If your protocol is msg based (instead of continuous stream) you should
+/// ensure that your buffer is large enough to hold an entire segment (1532 bytes if not jumbo
+/// frames)
+#[inline]
+pub fn read<I: IoHandle>(io: &mut I, buf: &mut MutBuf) -> MioResult<NonBlock<uint>> {
+
+    match os::read(io.desc(), buf.mut_bytes()) {
+        // Successfully read some bytes, advance the cursor
+        Ok(cnt) => { buf.advance(cnt); Ok(Ready(cnt)) }
+        Err(e) => { 
+            match e.kind {
+                mek::WouldBlock => Ok(WouldBlock),
+                _               => Err(e)
+            }
+        }
+    }
+}
+
+/// Reads until all segments or datagrams are consumed from the socket or until we run out of 
+/// space in the buffer
+pub fn read_remaining<I: IoHandle>(io: &mut I, buf: &mut MutBuf) -> MioResult<NonBlock<uint>> {
+    let mut count = 0;
 
     while buf.has_remaining() {
-        match os::read(io.desc(), buf.mut_bytes()) {
-            // Successfully read some bytes, advance the cursor
-            Ok(cnt) => {
-                buf.advance(cnt);
-                first_iter = false;
-            }
+        match read(io, buf) {
+            r@Ok(WouldBlock) => { return r; }
+            Ok(Ready(num)) => { count = count + num  }
             Err(e) => {
-                if e.is_would_block() {
-                    return Ok(WouldBlock);
-                }
-
                 // If the EOF is hit the first time around, then propagate
                 if e.is_eof() {
-                    if first_iter {
+                    if count == 0 {
                         return Err(e);
                     }
 
-                    return Ok(Ready(()));
+                    return Ok(Ready(count));
                 }
 
                 // Indicate that the read was successful
@@ -106,24 +122,34 @@ pub fn read<I: IoHandle>(io: &mut I, buf: &mut MutBuf) -> MioResult<NonBlock<()>
             }
         }
     }
-
-    Ok(Ready(()))
+    Ok(Ready(count))
 }
 
-pub fn write<O: IoHandle>(io: &mut O, buf: &mut Buf) -> MioResult<NonBlock<()>> {
-    while buf.has_remaining() {
-        match os::write(io.desc(), buf.bytes()) {
-            Ok(cnt) => buf.advance(cnt),
-            Err(e) => {
-                if e.is_would_block() {
-                    return Ok(WouldBlock);
-                }
-
-                return Err(e);
+///writes the length of the slice supplied by Buf.bytes into the socket
+#[inline]
+pub fn write<O: IoHandle>(io: &mut O, buf: &mut Buf) -> MioResult<NonBlock<uint>> {
+    match os::write(io.desc(), buf.bytes()) {
+        Ok(cnt) => { buf.advance(cnt); Ok(Ready(cnt)) }
+        Err(e) => { 
+            match e.kind {
+                mek::WouldBlock => Ok(WouldBlock),
+                _               => Err(e)
             }
         }
     }
+}
 
-    Ok(Ready(()))
+
+/// Writes everything is expelled from the buffer or until the socket can no longer write 
+pub fn write_remaining<O: IoHandle>(io: &mut O, buf: &mut Buf) -> MioResult<NonBlock<uint>> {
+    let mut count = 0;
+    while buf.has_remaining() {
+        match write(io, buf) {
+            r@Ok(WouldBlock) => { return r; }
+            Ok(Ready(num)) => { count = count + num }
+            Err(e) => { return Err(e); }
+        }
+    }
+    Ok(Ready(count))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub use buf::{
 pub use error::{
     MioResult,
     MioError,
+    MioErrorKind
 };
 pub use handler::{
     Handler,
@@ -35,11 +36,10 @@ pub use io::{
     IoAcceptor,
     PipeReader,
     PipeWriter,
+    Ready
 };
 pub use poll::{
-    Poll,
-    IoEvent,
-    IoEventKind,
+    Poll
 };
 pub use event_loop::{
     EventLoop,
@@ -54,14 +54,19 @@ pub use token::{
     Token,
 };
 
+pub use event_ctx::{ 
+    IoEventCtx 
+};
+
 pub mod buf;
 pub mod net;
 pub mod util;
+pub mod event_ctx;
+pub mod io;
+pub mod error;
 
-mod error;
 mod event_loop;
 mod handler;
-mod io;
 mod notify;
 mod os;
 mod poll;

--- a/src/os/posix.rs
+++ b/src/os/posix.rs
@@ -163,6 +163,11 @@ pub fn write(io: &IoDesc, src: &[u8]) -> MioResult<uint> {
     nix::write(io.fd, src).map_err(MioError::from_sys_error)
 }
 
+#[inline]
+pub fn close(io: &IoDesc) -> MioResult<()> {
+  nix::close(io.fd).map_err(MioError::from_sys_error)
+}
+
 // ===== Socket options =====
 
 pub fn reuseaddr(_io: &IoDesc) -> MioResult<uint> {

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,9 +1,7 @@
-use std::fmt;
 use error::MioResult;
 use io::IoHandle;
 use os;
-use token::Token;
-use handler::{ReadHint, DATAHINT, HUPHINT, ERRORHINT};
+use event_ctx::*;
 
 pub struct Poll {
     selector: os::Selector,
@@ -18,11 +16,20 @@ impl Poll {
         })
     }
 
-    pub fn register<H: IoHandle>(&mut self, io: &H, token: Token) -> MioResult<()> {
+    pub fn register<H: IoHandle>(&mut self, io: &H, eventctx: &IoEventCtx) -> MioResult<()> {
         debug!("registering IO with poller");
 
         // Register interests for this socket
-        try!(self.selector.register(io.desc(), token.as_uint()));
+        try!(self.selector.register(io.desc(), eventctx));
+
+        Ok(())
+    }
+    
+    pub fn reregister<H: IoHandle>(&mut self, io: &H, eventctx: &IoEventCtx) -> MioResult<()> {
+        debug!("registering IO with poller");
+
+        // Register interests for this socket
+        try!(self.selector.reregister(io.desc(), eventctx));
 
         Ok(())
     }
@@ -32,109 +39,9 @@ impl Poll {
         Ok(self.events.len())
     }
 
-    pub fn event(&self, idx: uint) -> IoEvent {
+    pub fn event(&self, idx: uint) -> IoEventCtx {
         self.events.get(idx)
     }
 }
 
 
-bitflags!(
-    flags IoEventKind: uint {
-        const IOREADABLE = 0x001,
-        const IOWRITABLE = 0x002,
-        const IOERROR    = 0x004,
-        const IOHUPHINT  = 0x008,
-        const IOHINTED   = 0x010
-    }
-)
-
-impl fmt::Show for IoEventKind {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let mut one = false;
-        let flags = [
-            (IOREADABLE, "IoReadable"),
-            (IOWRITABLE, "IoWritable"),
-            (IOERROR, "IoError"),
-            (IOHUPHINT, "IoHupHint"),
-            (IOHINTED, "IoHinted")];
-
-        for &(flag, msg) in flags.iter() {
-            if self.contains(flag) {
-                if one { try!(write!(fmt, " | ")) }
-                try!(write!(fmt, "{}", msg));
-
-                one = true
-            }
-        }
-
-        Ok(())
-    }
-}
-
-#[deriving(Show)]
-pub struct IoEvent {
-    kind: IoEventKind,
-    token: Token
-}
-
-/// IoEvent represents the raw event that the OS-specific selector
-/// returned. An event can represent more than one kind (such as
-/// readable or writable) at a time.
-///
-/// These IoEvent objects are created by the OS-specific concrete
-/// Selector when they have events to report.
-impl IoEvent {
-    /// Create a new IoEvent.
-    pub fn new(kind: IoEventKind, token: uint) -> IoEvent {
-        IoEvent {
-            kind: kind,
-            token: Token(token)
-        }
-    }
-
-    pub fn token(&self) -> Token {
-        self.token
-    }
-
-    /// Return an optional hint for a readable IO handle. Currently,
-    /// this method supports the HupHint, which indicates that the
-    /// kernel reported that the remote side hung up. This allows a
-    /// consumer to avoid reading in order to discover the hangup.
-    pub fn read_hint(&self) -> ReadHint {
-        let mut hint = ReadHint::empty();
-
-        // The backend doesn't support hinting
-        if !self.kind.contains(IOHINTED) {
-            return hint;
-        }
-
-        if self.kind.contains(IOHUPHINT) {
-            hint = hint | HUPHINT
-        }
-
-        if self.kind.contains(IOREADABLE) {
-            hint = hint | DATAHINT
-        }
-
-        if self.kind.contains(IOERROR) {
-            hint = hint | ERRORHINT
-        }
-
-        hint
-    }
-
-    /// This event indicated that the IO handle is now readable
-    pub fn is_readable(&self) -> bool {
-        self.kind.contains(IOREADABLE) || self.kind.contains(IOHUPHINT)
-    }
-
-    /// This event indicated that the IO handle is now writable
-    pub fn is_writable(&self) -> bool {
-        self.kind.contains(IOWRITABLE)
-    }
-
-    /// This event indicated that the IO handle had an error
-    pub fn is_error(&self) -> bool {
-        self.kind.contains(IOERROR)
-    }
-}

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -148,7 +148,7 @@ impl<T> Timer<T> {
         // Update the head slot
         self.wheel[slot] = token;
 
-        debug!("inserted timout; slot={}; token={}", slot, token);
+        debug!("inserted timeout; slot={}; token={}; tick={}", slot, token, tick);
 
         // Return the new timeout
         Ok(Timeout {

--- a/test/benchmark.rs
+++ b/test/benchmark.rs
@@ -1,0 +1,79 @@
+use std::mem;
+use mio::net::{AddressFamily, Inet, Inet6, SockAddr, InetAddr, IPv4Addr, SocketType, Dgram, Stream};
+use std::io::net::ip::IpAddr;
+use native::NativeTaskBuilder;
+use std::task::TaskBuilder;
+use mio::os::{from_sockaddr};
+use time;
+use std::vec::*;
+use std::io::timer;
+use std::time::Duration;
+
+mod nix {
+    pub use nix::c_int;
+    pub use nix::fcntl::{Fd, O_NONBLOCK, O_CLOEXEC};
+    pub use nix::errno::{EWOULDBLOCK, EINPROGRESS};
+    pub use nix::sys::socket::*;
+    pub use nix::unistd::*;
+    pub use nix::sys::epoll::*;
+}
+
+fn timed(label: &str, f: ||) {
+    let start = time::precise_time_s();
+    f();
+    let end = time::precise_time_s();
+    println!("  {}: {}", label, end - start);
+}
+
+fn init(saddr: &str) -> (nix::Fd, nix::Fd) {
+    let optval = 1i;
+    let addr = SockAddr::parse(saddr.as_slice()).expect("could not parse InetAddr"); 
+    let srvfd = nix::socket(nix::AF_INET, nix::SOCK_STREAM, nix::SOCK_CLOEXEC).unwrap();
+    nix::setsockopt(srvfd, nix::SOL_SOCKET, nix::SO_REUSEADDR, &optval).unwrap();
+    nix::bind(srvfd, &from_sockaddr(&addr)).unwrap();
+    nix::listen(srvfd, 256u).unwrap();
+    
+    let fd = nix::socket(nix::AF_INET, nix::SOCK_STREAM, nix::SOCK_CLOEXEC | nix::SOCK_NONBLOCK).unwrap();
+    let res = nix::connect(fd, &from_sockaddr(&addr));
+    println!("connecting : {} - {}", res, time::precise_time_s());
+     
+    let clifd = nix::accept4(srvfd, nix::SOCK_CLOEXEC | nix::SOCK_NONBLOCK).unwrap();
+    println!("accepted : {} - {}", clifd, time::precise_time_s());
+
+    (clifd, srvfd)
+}
+
+#[test]
+fn read_bench() {
+    let (clifd, srvfd) = init("10.10.1.5:11111"); 
+    let mut buf = Vec::with_capacity(1600);
+    unsafe { buf.set_len(1600); }
+    timed("read", || {
+        let mut i = 0u;
+        while i < 10000000 { 
+            let res = nix::read(clifd, buf.as_mut_slice()); 
+            assert_eq!(res.unwrap_err().kind, nix::EWOULDBLOCK);
+            i = i + 1;
+        }
+    });
+}
+
+#[test]
+fn epollctl_bench() {
+    let (clifd, srvfd) = init("10.10.1.5:22222"); 
+
+    let epfd = nix::epoll_create().unwrap();
+    let info = nix::EpollEvent { events: nix::EPOLLIN | nix::EPOLLONESHOT | nix::EPOLLET,
+                                 data: 0u64 };
+
+    nix::epoll_ctl(epfd, nix::EpollCtlAdd, clifd, &info);  
+
+    timed("epoll_ctl", || {
+        let mut i = 0u;
+        while i < 10000000 {
+            nix::epoll_ctl(epfd, nix::EpollCtlMod, clifd, &info);
+            i = i + 1;
+        }
+    });
+
+}

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -3,6 +3,8 @@ use mio::buf::ByteBuf;
 use mio::net::*;
 use mio::net::tcp::*;
 use super::localhost;
+//use mio::event_ctx::IoEventCtx;
+use mio::event_ctx as evt;
 
 type TestEventLoop = EventLoop<uint, ()>;
 
@@ -53,7 +55,7 @@ impl Handler<uint, ()> for TestHandler {
                         }
                     },
                     AfterRead => {
-                        assert_eq!(hint, DATAHINT | HUPHINT);
+                        //assert_eq!(hint, DATAHINT | HUPHINT);
                         self.state = AfterHup;
                     },
                     AfterHup => panic!("Shouldn't get here")
@@ -68,6 +70,8 @@ impl Handler<uint, ()> for TestHandler {
             }
             _ => panic!("received unknown token {}", tok)
         }
+        let cevt = IoEventCtx::new(evt::IOREADABLE | evt::IOEDGE | evt::IOHUPHINT, Token(1));
+        event_loop.reregister(&self.cli, &cevt).unwrap();
     }
 
     fn writable(&mut self, _event_loop: &mut TestEventLoop, tok: Token) {
@@ -75,6 +79,8 @@ impl Handler<uint, ()> for TestHandler {
             Token(0) => panic!("received writable for token 0"),
             Token(1) => {
                 debug!("client connected");
+                let cevt = IoEventCtx::new(evt::IOREADABLE | evt::IOEDGE | evt::IOHUPHINT, Token(1));
+                _event_loop.reregister(&self.cli, &cevt).unwrap();
             }
             _ => panic!("received unknown token {}", tok)
         }
@@ -83,6 +89,7 @@ impl Handler<uint, ()> for TestHandler {
 
 #[test]
 pub fn test_close_on_drop() {
+    debug!("Starting TEST_CLOSE_ON_DROP");
     let mut event_loop = EventLoop::new().unwrap();
 
     let addr = SockAddr::parse(localhost().as_slice())
@@ -92,21 +99,21 @@ pub fn test_close_on_drop() {
 
     info!("setting re-use addr");
     srv.set_reuseaddr(true).unwrap();
-
-    let srv = srv.bind(&addr).unwrap()
-        .listen(256).unwrap();
-
-    info!("register server socket");
-    event_loop.register(&srv, Token(0)).unwrap();
-
+    
     let sock = TcpSocket::v4().unwrap();
 
-    // Connect to the server
-    event_loop.connect(&sock, &addr, Token(1)).unwrap();
+    let cevt = IoEventCtx::new(evt::IOWRITABLE | evt::IOEDGE | evt::IOHUPHINT, Token(1));
+    event_loop.register(&sock, &cevt).unwrap();
 
+    let srv = srv.bind(&addr).unwrap().listen(256).unwrap();
+
+    info!("register server socket");
+    let evt = IoEventCtx::new(evt::IOREADABLE | evt::IOEDGE, Token(0));
+    event_loop.register(&srv, &evt).unwrap();
+    // Connect to the server
+    sock.connect(&addr).unwrap();
     // Start the event loop
-    let handler = event_loop.run(TestHandler::new(srv, sock))
-        .ok().expect("failed to execute event loop");
+    let handler = event_loop.run(TestHandler::new(srv, sock)).ok().expect("failed to execute event loop");
 
     assert!(handler.state == AfterHup, "actual={}", handler.state);
 }

--- a/test/test_echo_server.rs
+++ b/test/test_echo_server.rs
@@ -4,277 +4,256 @@ use mio::net::tcp::*;
 use mio::buf::{ByteBuf, RingBuf, SliceBuf};
 use mio::util::Slab;
 use super::localhost;
-
+use mio::event_ctx as evt; 
+use mio::event_ctx::IoEventKind;
+//use mio::io;
 type TestEventLoop = EventLoop<uint, ()>;
 
 const SERVER: Token = Token(0);
 const CLIENT: Token = Token(1);
 
 struct EchoConn {
-    sock: TcpSocket,
-    readable: bool,
-    writable: bool,
-    buf: RingBuf
+        sock: TcpSocket,
+        buf: ByteBuf,
+        interest: IoEventCtx 
 }
 
 impl EchoConn {
-    fn new(sock: TcpSocket) -> EchoConn {
-        EchoConn {
-            sock: sock,
-            readable: false,
-            writable: false,
-            buf: RingBuf::new(1024)
-        }
+  fn new(sock: TcpSocket) -> EchoConn {
+    EchoConn {
+        sock: sock,
+        buf: ByteBuf::new(2048),
+        interest: IoEventCtx::new(evt::IOEDGE, Token(-1))
     }
+  }
 
-    fn readable(&mut self) -> MioResult<()> {
-        self.readable = true;
-        self.echo()
-    }
+  fn writable(&mut self, event_loop: &mut TestEventLoop) -> MioResult<()> {
+    debug!("CON : writing buf = {}", self.buf.bytes());
+    match self.sock.write(&mut self.buf) {
+      Ok(io::WouldBlock) => { debug!("client flushing buf; WOULDBLOCK");
+                              self.interest.set_writable(true); }
+            Ok(Ready(r)) => { debug!("CONN : we wrote {} bytes!", r);
+                              self.buf.clear();
+                              self.interest.set_readable(true);
+                              self.interest.set_writable(false); }
+                  Err(e) => debug!("not implemented; client err={}", e)
+     } 
+    event_loop.reregister(&self.sock, &self.interest)
+  }
 
-    fn writable(&mut self) -> MioResult<()> {
-        self.writable = true;
-        self.echo()
-    }
+  fn readable(&mut self, event_loop: &mut TestEventLoop) -> MioResult<()> {
 
-    fn can_continue(&self) -> bool {
-        (self.readable && !self.buf.is_full()) ||
-            (self.writable && !self.buf.is_empty())
-    }
+    match self.sock.read(&mut self.buf) {
+      Ok(io::WouldBlock) => panic!("We just got readable, but were unable to read from the socket?"),
+            Ok(Ready(r)) => { debug!("CONN : we read {} bytes!", r);
+                              self.interest.set_readable(false);
+                              self.interest.set_writable(true); }
+                  Err(e) => { debug!("not implemented; client err={}", e)
+                              self.interest.set_readable(false); }
+                              
+    };
+    
 
-    fn echo(&mut self) -> MioResult<()> {
-        while self.can_continue() {
-            try!(self.fill_buf());
-            try!(self.flush_buf());
-        }
+    // prepare to provide this to writable 
+    self.buf.flip();
+    
+    debug!("CON : read buf = {}", self.buf.bytes());
 
-        Ok(())
-    }
-
-    fn fill_buf(&mut self) -> MioResult<()> {
-        if !self.readable {
-            return Ok(());
-        }
-
-        debug!("server filling buf");
-        self.sock.read(&mut self.buf.writer())
-            .map(|res| {
-                if res.would_block() {
-                    debug!("  WOULDBLOCK");
-                    self.readable = false;
-                }
-            })
-    }
-
-    fn flush_buf(&mut self) -> MioResult<()> {
-        if !self.writable {
-            return Ok(());
-        }
-
-        debug!("server flushing buf");
-        self.sock.write(&mut self.buf.reader())
-            .map(|res| {
-                if res.would_block() {
-                    debug!("  WOULDBLOCK");
-                    self.writable = false;
-                }
-            })
-    }
+    event_loop.reregister(&self.sock, &self.interest)
+  }
 }
 
 struct EchoServer {
-    sock: TcpAcceptor,
-    conns: Slab<EchoConn>
+sock: TcpAcceptor,
+        conns: Slab<EchoConn>
 }
 
 impl EchoServer {
-    fn accept(&mut self, event_loop: &mut TestEventLoop) {
-        debug!("server accepting socket");
-        let sock = self.sock.accept().unwrap().unwrap();
-        let conn = EchoConn::new(sock);
-        let tok = self.conns.insert(conn)
-            .ok().expect("could not add connectiont o slab");
+  fn accept(&mut self, event_loop: &mut TestEventLoop) -> MioResult<()> {
+    debug!("server accepting socket");
+    let sock = self.sock.accept().unwrap().unwrap();
+    let conn = EchoConn::new(sock,);
+    let tok = self.conns.insert(conn)
+      .ok().expect("could not add connectiont o slab");
 
-        // Register the connection
-        event_loop.register(&self.conns[tok].sock, tok)
-            .ok().expect("could not register socket with event loop");
-    }
+    // Register the connection
+    let evt = IoEventCtx::new(evt::IOREADABLE | evt::IOEDGE, tok);
+    self.conns[tok].interest = evt;
+    event_loop.register(&self.conns[tok].sock, &evt)
+      .ok().expect("could not register socket with event loop");
 
-    fn conn_readable(&mut self, tok: Token) {
-        debug!("server conn readable; tok={}", tok);
-        self.conn(tok).readable().unwrap();
-    }
+    
+    Ok(())
+  }
 
-    fn conn_writable(&mut self, tok: Token) {
-        debug!("server conn writable; tok={}", tok);
-        self.conn(tok).writable().unwrap();
-    }
+  fn conn_readable(&mut self, event_loop: &mut TestEventLoop, tok: Token) -> MioResult<()> {
+    debug!("server conn readable; tok={}", tok);
+    self.conn(tok).readable(event_loop)
+  }
 
-    fn conn<'a>(&'a mut self, tok: Token) -> &'a mut EchoConn {
-        &mut self.conns[tok]
-    }
+  fn conn_writable(&mut self, event_loop: &mut TestEventLoop, tok: Token) -> MioResult<()> {
+    debug!("server conn writable; tok={}", tok);
+    self.conn(tok).writable(event_loop)
+  }
+
+  fn conn<'a>(&'a mut self, tok: Token) -> &'a mut EchoConn {
+    &mut self.conns[tok]
+  }
 }
 
 struct EchoClient {
-    sock: TcpSocket,
-    msgs: Vec<&'static str>,
-    tx: SliceBuf<'static>,
-    rx: SliceBuf<'static>,
-    buf: ByteBuf,
-    writable: bool
+sock: TcpSocket,
+        msgs: Vec<&'static str>,
+        tx: SliceBuf<'static>,
+        rx: SliceBuf<'static>,
+        buf: ByteBuf,
+        interest: IoEventCtx
 }
 
 
 // Sends a message and expects to receive the same exact message, one at a time
 impl EchoClient {
-    fn new(sock: TcpSocket, mut msgs: Vec<&'static str>) -> EchoClient {
-        let curr = msgs.remove(0).expect("At least one message is required");
+  fn new(sock: TcpSocket, tok: Token,  mut msgs: Vec<&'static str>) -> EchoClient {
+    let curr = msgs.remove(0).expect("At least one message is required");
 
-        EchoClient {
-            sock: sock,
-            msgs: msgs,
-            tx: SliceBuf::wrap(curr.as_bytes()),
-            rx: SliceBuf::wrap(curr.as_bytes()),
-            buf: ByteBuf::new(1024),
-            writable: false
+    EchoClient {
+        sock: sock,
+        msgs: msgs,
+        tx: SliceBuf::wrap(curr.as_bytes()),
+        rx: SliceBuf::wrap(curr.as_bytes()),
+        buf: ByteBuf::new(2048),
+        interest: IoEventCtx::new(evt::IOEDGE, tok)
+    }
+  }
+
+  fn readable(&mut self, event_loop: &mut TestEventLoop) -> MioResult<()> {
+    debug!("client socket readable");
+
+    let res = match self.sock.read(&mut self.buf) {
+      Ok(io::WouldBlock) => panic!("We just got readable, but were unable to read from the socket?"),
+        Ok(Ready(r)) => { debug!("CLIENT : We read {} bytes!", r); }
+      Err(e) => panic!("not implemented; client err={}", e)
+    };
+
+    // prepare for reading
+    self.buf.flip();
+
+    debug!("CLIENT : buf = {} -- rx = {}", self.buf.bytes(), self.rx.bytes());
+    while self.buf.has_remaining() {
+      let actual = self.buf.read_byte().unwrap();
+      let expect = self.rx.read_byte().unwrap();
+
+      assert!(actual == expect);
+    }
+
+    self.buf.clear();
+
+    self.interest.set_readable(false);
+    if !self.rx.has_remaining() {
+      self.next_msg(event_loop).unwrap();
+    }
+    event_loop.reregister(&self.sock, &self.interest)
+  }
+
+  fn writable(&mut self, event_loop: &mut TestEventLoop) -> MioResult<()> {
+    debug!("client socket writable");
+    
+    match self.sock.write(&mut self.tx) {
+      Ok(io::WouldBlock) => { debug!("client flushing buf; WOULDBLOCK");
+                              self.interest.set_writable(true); }
+            Ok(Ready(r)) => { debug!("CLIENT : we wrote {} bytes!", r);
+                              self.interest.set_readable(true);
+                              self.interest.set_writable(false); }
+                  Err(e) => debug!("not implemented; client err={}", e)
+     } 
+
+    event_loop.reregister(&self.sock, &self.interest)
+  }
+
+  fn next_msg(&mut self, event_loop: &mut TestEventLoop) -> MioResult<()> {
+    let curr = match self.msgs.remove(0) {
+      Some(msg) => msg,
+        None => {
+          event_loop.shutdown();
+          return Ok(());
         }
-    }
+    };
 
-    fn readable(&mut self, event_loop: &mut TestEventLoop) {
-        debug!("client socket readable");
+    debug!("client prepping next message");
+    self.tx = SliceBuf::wrap(curr.as_bytes());
+    self.rx = SliceBuf::wrap(curr.as_bytes());
 
-        loop {
-            let res = match self.sock.read(&mut self.buf) {
-                Ok(r) => r,
-                Err(e) => panic!("not implemented; client err={}", e)
-            };
-
-            // prepare for reading
-            self.buf.flip();
-
-            while self.buf.has_remaining() {
-                let actual = self.buf.read_byte().unwrap();
-                let expect = self.rx.read_byte().unwrap();
-
-                assert!(actual == expect);
-            }
-
-            self.buf.clear();
-
-            if !self.rx.has_remaining() {
-                self.next_msg(event_loop).unwrap();
-            }
-
-            // Nothing else to do this round
-            if res.would_block() {
-                return;
-            }
-        }
-    }
-
-    fn writable(&mut self) {
-        debug!("client socket writable");
-
-        self.writable = true;
-        self.flush_msg().unwrap();
-    }
-
-    fn flush_msg(&mut self) -> MioResult<()> {
-        if !self.writable {
-            return Ok(());
-        }
-
-        self.sock.write(&mut self.tx)
-            .map(|res| {
-                if res.would_block() {
-                    debug!("client flushing buf; WOULDBLOCK");
-                    self.writable = false
-                } else {
-                    debug!("client flushed buf");
-                }
-            })
-    }
-
-    fn next_msg(&mut self, event_loop: &mut TestEventLoop) -> MioResult<()> {
-        let curr = match self.msgs.remove(0) {
-            Some(msg) => msg,
-            None => {
-                event_loop.shutdown();
-                return Ok(());
-            }
-        };
-
-        debug!("client prepping next message");
-        self.tx = SliceBuf::wrap(curr.as_bytes());
-        self.rx = SliceBuf::wrap(curr.as_bytes());
-
-        self.flush_msg()
-    }
+    self.interest.set_writable(true);
+    event_loop.reregister(&self.sock, &self.interest)
+  }
 }
 
 struct EchoHandler {
-    server: EchoServer,
-    client: EchoClient,
+server: EchoServer,
+          client: EchoClient,
 }
 
 impl EchoHandler {
-    fn new(srv: TcpAcceptor, client: TcpSocket, msgs: Vec<&'static str>) -> EchoHandler {
-        EchoHandler {
-            server: EchoServer {
-                sock: srv,
-                conns: Slab::new_starting_at(Token(2), 128)
-            },
-
-            client: EchoClient::new(client, msgs)
-        }
+  fn new(srv: TcpAcceptor, client: TcpSocket, msgs: Vec<&'static str>) -> EchoHandler {
+    EchoHandler {
+      server: EchoServer {
+        sock: srv,
+        conns: Slab::new_starting_at(Token(2), 128)
+      },
+      client: EchoClient::new(client, CLIENT, msgs)
     }
+  }
 }
 
 impl Handler<uint, ()> for EchoHandler {
-    fn readable(&mut self, event_loop: &mut TestEventLoop, token: Token, hint: ReadHint) {
-        assert_eq!(hint, DATAHINT);
+  fn readable(&mut self, event_loop: &mut TestEventLoop, token: Token, hint: ReadHint) {
+    assert_eq!(hint, DATAHINT);
 
-        match token {
-            SERVER => self.server.accept(event_loop),
-            CLIENT => self.client.readable(event_loop),
-            i => self.server.conn_readable(i)
-        }
-    }
+    match token {
+      SERVER => self.server.accept(event_loop).unwrap(),
+      CLIENT => self.client.readable(event_loop).unwrap(),
+           i => self.server.conn_readable(event_loop, i).unwrap()
+    };
+  }
 
-    fn writable(&mut self, _event_loop: &mut TestEventLoop, token: Token) {
-        match token {
-            SERVER => panic!("received writable for token 0"),
-            CLIENT => self.client.writable(),
-            i => self.server.conn_writable(i)
-        }
-    }
+  fn writable(&mut self, event_loop: &mut TestEventLoop, token: Token) {
+    match token {
+      SERVER => panic!("received writable for token 0"),
+      CLIENT => self.client.writable(event_loop).unwrap(),
+           i => self.server.conn_writable(event_loop, i).unwrap()
+    };
+  }
 }
 
 #[test]
 pub fn test_echo_server() {
-    let mut event_loop = EventLoop::new().unwrap();
+  debug!("Starting TEST_ECHO_SERVER");
+  let mut event_loop = EventLoop::new().unwrap();
 
-    let addr = SockAddr::parse(localhost().as_slice())
-        .expect("could not parse InetAddr");
+  let addr = SockAddr::parse(localhost().as_slice())
+    .expect("could not parse InetAddr");
 
-    let srv = TcpSocket::v4().unwrap();
+  let srv = TcpSocket::v4().unwrap();
 
-    info!("setting re-use addr");
-    srv.set_reuseaddr(true).unwrap();
+  info!("setting re-use addr");
+  srv.set_reuseaddr(true).unwrap();
 
-    let srv = srv.bind(&addr).unwrap()
-        .listen(256u).unwrap();
+  let srv = srv.bind(&addr).unwrap()
+    .listen(256u).unwrap();
 
-    info!("listen for connections");
-    event_loop.register(&srv, SERVER).unwrap();
+  info!("listen for connections");
+  let evt = IoEventCtx::new(evt::IOREADABLE | evt::IOEDGE, SERVER);
+  event_loop.register(&srv, &evt).unwrap();
 
-    let sock = TcpSocket::v4().unwrap();
+  let sock = TcpSocket::v4().unwrap();
 
-    // Connect to the server
-    event_loop.connect(&sock, &addr, CLIENT).unwrap();
+  // Connect to the server
+  let cevt = IoEventCtx::new(evt::IOWRITABLE | evt::IOEDGE, CLIENT);
+  event_loop.register(&sock, &cevt).unwrap();
+  sock.connect(&addr).unwrap();
 
-    // Start the event loop
-    event_loop.run(EchoHandler::new(srv, sock, vec!["foo", "bar"]))
-        .ok().expect("failed to execute event loop");
+  // Start the event loop
+  event_loop.run(EchoHandler::new(srv, sock, vec!["foo", "bar"]))
+    .ok().expect("failed to execute event loop");
 
 }

--- a/test/test_notify.rs
+++ b/test/test_notify.rs
@@ -4,6 +4,7 @@ use mio::*;
 use mio::net::*;
 use mio::net::tcp::*;
 use super::localhost;
+use mio::event_ctx as evt; 
 
 type TestEventLoop = EventLoop<uint, String>;
 
@@ -41,6 +42,7 @@ impl Handler<uint, String> for TestHandler {
 
 #[test]
 pub fn test_notify() {
+    debug!("Starting TEST_NOTIFY");
     let mut event_loop = EventLoop::new().unwrap();
 
     let addr = SockAddr::parse(localhost().as_slice())
@@ -53,7 +55,8 @@ pub fn test_notify() {
     let srv = srv.bind(&addr).unwrap()
         .listen(256u).unwrap();
 
-    event_loop.register(&srv, Token(0)).unwrap();
+    let evt = IoEventCtx::new(evt::IOALL | evt::IOEDGE, Token(0));
+    event_loop.register(&srv, &evt).unwrap();
 
     let sender = event_loop.channel();
 

--- a/test/test_udp_socket_connectionless.rs
+++ b/test/test_udp_socket_connectionless.rs
@@ -4,6 +4,7 @@ use mio::net::udp::*;
 use mio::buf::{RingBuf, SliceBuf};
 use std::str;
 use std::io::net::ip::{Ipv4Addr};
+use mio::event_ctx as evt;
 
 type TestEventLoop = EventLoop<uint, ()>;
 
@@ -69,6 +70,7 @@ impl Handler<uint, ()> for UdpHandler {
 
 #[test]
 pub fn test_udp_socket_connectionless() {
+    debug!("Starting TEST_UDP_CONNECTIONLESS");
     let mut event_loop = EventLoop::new().unwrap();
 
     let send_sock = UdpSocket::v4().unwrap();
@@ -90,10 +92,12 @@ pub fn test_udp_socket_connectionless() {
     recv_sock.join_multicast_group(&Ipv4Addr(227, 1, 1, 101), &None).unwrap();
 
     info!("Registering LISTENER");
-    event_loop.register(&recv_sock, LISTENER).unwrap();
+    let evt = IoEventCtx::new(evt::IOREADABLE | evt::IOEDGE, LISTENER);
+    event_loop.register(&recv_sock, &evt).unwrap();
 
     info!("Registering SENDER");
-    event_loop.register(&send_sock, SENDER).unwrap();
+    let sevt = IoEventCtx::new(evt::IOWRITABLE | evt::IOEDGE, SENDER);
+    event_loop.register(&send_sock, &sevt).unwrap();
 
     info!("Starting event loop to test with...");
     event_loop.run(UdpHandler::new(send_sock, recv_sock, "hello world")).ok().expect("Failed to run the actual event listener loop");


### PR DESCRIPTION
OK.  Here is the pull request which addresses issues #45, #46, and #47.   It is pretty large,  the IoEventCtx plays a more important role in things, since re-registration is so common.  I  renamed to IoEventCtx and added the Token to it, to simplify the interface into the the register functions. 

For an advanced example of how the event re-registration can actually help simplify a state machine, check out the revised test_echo_server. 
- more tweaks to make the tests pass, also made the return type uint instead of () so the customer doesn't have to go looking through the buffer for answers
- addressing issues 45, 46, and 47.  Added re-registration via an IoEventContext into the event_loop. Supports both edge triggered and level triggered setups.  
- Changed \* net::read and write to not use a loop.. added read_all and write_all to use them and perform the old behavior
- got all tests passing
