### PR TITLE
Add a .deregister() method to the event loop.

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -117,6 +117,11 @@ impl<T, M: Send> EventLoop<T, M> {
         self.poll.register(io, token)
     }
 
+    /// Deregisters an IO handle with the event loop.
+    pub fn deregister<H: IoHandle>(&mut self, io: &H) -> MioResult<()> {
+        self.poll.deregister(io)
+    }
+
     /// Connects the socket to the specified address. When the operation
     /// completes, the handler will be notified with the supplied token.
     ///

--- a/src/os/epoll.rs
+++ b/src/os/epoll.rs
@@ -39,6 +39,21 @@ impl Selector {
         epoll_ctl(self.epfd, EpollCtlAdd, io.fd, &info)
             .map_err(MioError::from_sys_error)
     }
+
+    /// Deregister event interests for the given IO handle with the OS
+    pub fn deregister(&mut self, io: &IoDesc) -> MioResult<()> {
+
+        // The &info argument should be ignored by the system,
+        // but linux < 2.6.9 required it to be not null.
+        // For compatibility, we provide a dummy EpollEvent.
+        let info = EpollEvent {
+            events: EpollEventKind::empty(),
+            data: 0
+        };
+
+        epoll_ctl(self.epfd, EpollCtlDel, io.fd, &info)
+            .map_err(MioError::from_sys_error)
+    }
 }
 
 impl Drop for Selector {

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -38,6 +38,15 @@ impl Selector {
         Ok(())
     }
 
+    pub fn deregister(&mut self, io: &IoDesc) -> MioResult<()> {
+        let flag = EV_DELETE;
+
+        try!(self.ev_push(io, EVFILT_READ, flag, FilterFlag::empty(), 0));
+        try!(self.ev_push(io, EVFILT_WRITE, flag, FilterFlag::empty(), 0));
+
+        Ok(())
+    }
+
     // Queues an event change. Events will get submitted to the OS on the next
     // call to select or when the change buffer fills up.
     fn ev_push(&mut self,

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -27,6 +27,15 @@ impl Poll {
         Ok(())
     }
 
+    pub fn deregister<H: IoHandle>(&mut self, io: &H) -> MioResult<()> {
+        debug!("deregistering IO with poller");
+
+        // Deregister interests for this socket
+        try!(self.selector.deregister(io.desc()));
+
+        Ok(())
+    }
+
     pub fn poll(&mut self, timeout_ms: uint) -> MioResult<uint> {
         try!(self.selector.select(&mut self.events, timeout_ms));
         Ok(self.events.len())


### PR DESCRIPTION
Closes #29

This is mainly doc-reading an mimicking the `.register()` methods.
I didn't make intensive testing and couldn't test the kqueue part.
