### PR TITLE
Fix compilation errors due to enums namespacing.

### DIFF
--- a/src/os/epoll.rs
+++ b/src/os/epoll.rs
@@ -34,7 +34,7 @@ impl Selector {
             data: token as u64
         };
 
-        epoll_ctl(self.epfd, EpollCtlAdd, io.fd, &info)
+        epoll_ctl(self.epfd, EpollOp::EpollCtlAdd, io.fd, &info)
             .map_err(MioError::from_sys_error)
     }
 
@@ -45,7 +45,7 @@ impl Selector {
             data: token as u64
         };
 
-        epoll_ctl(self.epfd, EpollCtlMod, io.fd, &info)
+        epoll_ctl(self.epfd, EpollOp::EpollCtlMod, io.fd, &info)
             .map_err(MioError::from_sys_error)
     }
 
@@ -59,7 +59,7 @@ impl Selector {
             data: 0
         };
 
-        epoll_ctl(self.epfd, EpollCtlDel, io.fd, &info)
+        epoll_ctl(self.epfd, EpollOp::EpollCtlDel, io.fd, &info)
             .map_err(MioError::from_sys_error)
     }
 }

--- a/src/os/posix.rs
+++ b/src/os/posix.rs
@@ -259,7 +259,7 @@ fn from_ip_addr_to_inaddr(addr: &Option<IpAddr>) -> nix::in_addr {
 
 fn to_sockaddr(addr: &nix::SockAddr) -> SockAddr {
     match *addr {
-        nix::SockIpV4(sin) => {
+        nix::SockAddr::SockIpV4(sin) => {
             InetAddr(u32be_to_ipv4(sin.sin_addr.s_addr), Int::from_be(sin.sin_port))
         }
         _ => unimplemented!()
@@ -279,7 +279,7 @@ fn from_sockaddr(addr: &SockAddr) -> nix::SockAddr {
                     addr.sin_port = port.to_be();
                     addr.sin_addr = ipv4_to_inaddr(a, b, c, d);
 
-                    nix::SockIpV4(addr)
+                    nix::SockAddr::SockIpV4(addr)
                 }
                 _ => unimplemented!()
             }

--- a/test/test_udp_socket_connectionless.rs
+++ b/test/test_udp_socket_connectionless.rs
@@ -41,7 +41,7 @@ impl Handler<uint, ()> for UdpHandler {
                 match self.listen_sock.recv_from(&mut self.rx_buf.writer()) {
                     Ok(wouldblock) => {
                         match wouldblock.unwrap() {
-                            InetAddr(ip, _) => {
+                            SockAddr::InetAddr(ip, _) => {
                                 assert!(ip == IPv4Addr(127, 0, 0, 1));
                             }
                             _ => panic!("This should be an IPv4 address")


### PR DESCRIPTION
Mio didn't compile on last Rust.
