### PR TITLE
Track rust's master

### DIFF
--- a/src/os/event.rs
+++ b/src/os/event.rs
@@ -93,7 +93,6 @@ impl fmt::Show for PollOpt {
 }
 
 bitflags!(
-    #[deriving(Copy)]
     flags Interest: uint {
         const READABLE = 0x001,
         const WRITABLE = 0x002,
@@ -129,7 +128,6 @@ impl fmt::Show for Interest {
 }
 
 bitflags!(
-    #[deriving(Copy)]
     flags ReadHint: uint {
         const DATAHINT    = 0x001,
         const HUPHINT     = 0x002,

--- a/src/util/mpmc_bounded_queue.rs
+++ b/src/util/mpmc_bounded_queue.rs
@@ -176,7 +176,7 @@ mod tests {
         for _ in range(0, nthreads) {
             let q = q.clone();
             let tx = tx.clone();
-            spawn(proc() {
+            spawn(move || {
                 let q = q;
                 for i in range(0, nmsgs) {
                     assert!(q.push(i));
@@ -190,7 +190,7 @@ mod tests {
             let (tx, rx) = channel();
             completion_rxs.push(rx);
             let q = q.clone();
-            spawn(proc() {
+            spawn(move || {
                 let q = q;
                 let mut i = 0u;
                 loop {


### PR DESCRIPTION
- bitflags! now derives `Copy` internally
- `proc` is removed from language
