### PR TITLE
Changed source of 'time' to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,12 @@ name = "mio"
 version = "0.0.1"
 authors = ["Carl Lerche <me@carllerche.com>"]
 
+[dependencies]
+time = "*"
+
 [dependencies.nix]
 
 git = "https://github.com/carllerche/nix-rust"
-
-[dependencies.time]
-
-git = "https://github.com/rust-lang/time"
 
 [[test]]
 


### PR DESCRIPTION
Hi,

I constantly receive warning "using multiple versions of crate `time`" because all of my dependencies use 'time' from crates.io. But 'mio' uses 'time' from github. Maybe it's time to change source of 'time'?
