### PR TITLE
Fix incidences of syntax error.

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -188,7 +188,7 @@ pub mod tcp {
         }
 
         pub fn bind(self, addr: &SockAddr) -> MioResult<TcpListener> {
-            try!(os::bind(&self.desc, addr))
+            try!(os::bind(&self.desc, addr));
             Ok(TcpListener { desc: self.desc })
         }
     }
@@ -305,7 +305,7 @@ pub mod udp {
         }
 
         pub fn bind(&self, addr: &SockAddr) -> MioResult<()> {
-            try!(os::bind(&self.desc, addr))
+            try!(os::bind(&self.desc, addr));
             Ok(())
         }
 
@@ -429,7 +429,7 @@ pub mod pipe {
         }
 
         pub fn bind(self, addr: &SockAddr) -> MioResult<UnixListener> {
-            try!(os::bind(&self.desc, addr))
+            try!(os::bind(&self.desc, addr));
             Ok(UnixListener { desc: self.desc })
         }
     }

--- a/src/os/event.rs
+++ b/src/os/event.rs
@@ -101,7 +101,7 @@ bitflags!(
         const HINTED   = 0x010,
         const ALL      = 0x001 | 0x002 | 0x008  //epoll checks for ERROR no matter what
     }
-)
+);
 
 
 impl fmt::Show for Interest {
@@ -133,7 +133,7 @@ bitflags!(
         const HUPHINT     = 0x002,
         const ERRORHINT   = 0x004
     }
-)
+);
 
 impl fmt::Show for ReadHint {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
src/net.rs:192:13: 192:15 error: expected one of `.`, `;`, or `}`, found `Ok`

---

Same caveat as previous pull ;)
