### PR TITLE
Actually export EventLoopError.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ pub use io::{
     IoReader,
     IoWriter,
     IoAcceptor,
+    IoHandle,
     PipeReader,
     PipeWriter,
 };


### PR DESCRIPTION
This doesn't get caught by rustc since it is `pub` but it is not
re-exported, so can't be used.
