### PR TITLE
Add dependency on log crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 
 [dependencies]
 time = "*"
+log = "*"
 
 [dependencies.nix]
 


### PR DESCRIPTION
The log crate seems to live in its own package now, so this additional dependency is needed.
