### PR TITLE
Fix inconsistency of README vs. source code documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! * Zero allocations
 //! * A scalable readiness-based API, similar to epoll on Linux
 //! * Design to allow for stack allocated buffers when possible (avoid double buffering).
-//! * Provide utilities such as a timers, a notification channel, buffer abstractions, and a slab.
+//! * Provide utilities such as a notification channel, buffer abstractions, and a slab.
 //!
 //! # Platforms
 //!
@@ -21,6 +21,7 @@
 //! * NetBSD
 //! * Android
 //! * iOS
+//! * Fuchsia (experimental)
 //!
 //! mio can handle interfacing with each of the event notification systems of the aforementioned platforms. The details of
 //! their implementation are further discussed in [`Poll`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 //! * Zero allocations
 //! * A scalable readiness-based API, similar to epoll on Linux
 //! * Design to allow for stack allocated buffers when possible (avoid double buffering).
-//! * Provide utilities such as a notification channel, buffer abstractions, and a slab.
 //!
 //! # Platforms
 //!


### PR DESCRIPTION
While reading the [readme](https://github.com/carllerche/mio) and then the [source code documentation](https://carllerche.github.io/mio/mio/index.html) I discovered this inconsistency. According to the source code timers are deprecated, so I removed it from the goals.

While at it, it seemed that the list of supported platform was also not in sync, so I updated it as well.