### PR TITLE
Raw socket traits for Windows

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -733,3 +733,60 @@ impl FromRawFd for TcpListener {
         }
     }
 }
+
+/*
+ *
+ * ===== Windows ext =====
+ *
+ */
+
+#[cfg(windows)]
+use std::os::windows::io::{IntoRawSocket, AsRawSocket, FromRawSocket, RawSocket};
+
+#[cfg(windows)]
+impl IntoRawSocket for TcpStream {
+    fn into_raw_socket(self) -> RawSocket {
+        self.sys.into_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl AsRawSocket for TcpStream {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.sys.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl FromRawSocket for TcpStream {
+    unsafe fn from_raw_socket(socket: RawSocket) -> TcpStream {
+        TcpStream {
+            sys: FromRawSocket::from_raw_socket(socket),
+            selector_id: SelectorId::new(),
+        }
+    }
+}
+
+#[cfg(windows)]
+impl IntoRawSocket for TcpListener {
+    fn into_raw_socket(self) -> RawSocket {
+        self.sys.into_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl AsRawSocket for TcpListener {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.sys.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl FromRawSocket for TcpListener {
+    unsafe fn from_raw_socket(socket: RawSocket) -> TcpListener {
+        TcpListener {
+            sys: FromRawSocket::from_raw_socket(socket),
+            selector_id: SelectorId::new(),
+        }
+    }
+}

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -598,3 +598,35 @@ impl FromRawFd for UdpSocket {
     }
 }
 
+/*
+ *
+ * ===== Windows ext =====
+ *
+ */
+
+#[cfg(windows)]
+use std::os::windows::io::{IntoRawSocket, AsRawSocket, FromRawSocket, RawSocket};
+
+#[cfg(windows)]
+impl IntoRawSocket for UdpSocket {
+    fn into_raw_socket(self) -> RawSocket {
+        self.sys.into_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl AsRawSocket for UdpSocket {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.sys.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl FromRawSocket for UdpSocket {
+    unsafe fn from_raw_socket(socket: RawSocket) -> UdpSocket {
+        UdpSocket {
+            sys: FromRawSocket::from_raw_socket(socket),
+            selector_id: SelectorId::new(),
+        }
+    }
+}

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -623,6 +623,25 @@ impl fmt::Debug for TcpStream {
     }
 }
 
+impl FromRawSocket for TcpStream {
+    unsafe fn from_raw_socket(socket: RawSocket) -> TcpStream {
+        let stream = net::TcpStream::from_raw_socket(socket);
+        TcpStream::from_stream(stream)
+    }
+}
+
+impl IntoRawSocket for TcpStream {
+    fn into_raw_socket(self) -> RawSocket {
+        self.as_raw_socket()
+    }
+}
+
+impl AsRawSocket for TcpStream {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.imp.inner.socket.as_raw_socket()
+    }
+}
+
 impl Drop for TcpStream {
     fn drop(&mut self) {
         // If we're still internally reading, we're no longer interested. Note
@@ -829,6 +848,26 @@ impl fmt::Debug for TcpListener {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("TcpListener")
             .finish()
+    }
+}
+
+impl FromRawSocket for TcpListener {
+    unsafe fn from_raw_socket(socket: RawSocket) -> TcpListener {
+        let stream = net::TcpListener::from_raw_socket(socket);
+        TcpListener::new(stream)
+            .expect("tried to get local address of invalid/unbound socket")
+    }
+}
+
+impl IntoRawSocket for TcpListener {
+    fn into_raw_socket(self) -> RawSocket {
+        self.imp.inner.socket.as_raw_socket()
+    }
+}
+
+impl AsRawSocket for TcpListener {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.imp.inner.socket.as_raw_socket()
     }
 }
 

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -855,7 +855,7 @@ impl FromRawSocket for TcpListener {
     unsafe fn from_raw_socket(socket: RawSocket) -> TcpListener {
         let stream = net::TcpListener::from_raw_socket(socket);
         TcpListener::new(stream)
-            .expect("tried to get local address of invalid/unbound socket")
+            .expect("failed to create mio::sys::windows::TcpListener from std::net::TcpListener")
     }
 }
 

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -8,6 +8,7 @@ use std::io::prelude::*;
 use std::io;
 use std::mem;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::os::windows::io::{IntoRawSocket, AsRawSocket, FromRawSocket, RawSocket};
 use std::sync::{Mutex, MutexGuard};
 
 #[allow(unused_imports)]
@@ -380,6 +381,26 @@ impl Drop for UdpSocket {
                 State::Error(_) => {}
             }
         }
+    }
+}
+
+impl FromRawSocket for UdpSocket {
+    unsafe fn from_raw_socket(socket: RawSocket) -> UdpSocket {
+        let stream = net::UdpSocket::from_raw_socket(socket);
+        // Note that this cannot fail right now
+        UdpSocket::new(stream).unwrap()
+    }
+}
+
+impl IntoRawSocket for UdpSocket {
+    fn into_raw_socket(self) -> RawSocket {
+        self.imp.inner.socket.as_raw_socket()
+    }
+}
+
+impl AsRawSocket for UdpSocket {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.imp.inner.socket.as_raw_socket()
     }
 }
 

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -387,8 +387,8 @@ impl Drop for UdpSocket {
 impl FromRawSocket for UdpSocket {
     unsafe fn from_raw_socket(socket: RawSocket) -> UdpSocket {
         let stream = net::UdpSocket::from_raw_socket(socket);
-        // Note that this cannot fail right now
-        UdpSocket::new(stream).unwrap()
+        UdpSocket::new(stream)
+            .expect("failed to create mio::sys::windows::UdpSocket from std::net::UdpSocket")
     }
 }
 


### PR DESCRIPTION
This PR implements the `{As,From,Into}RawSocket` traits on TcpListener, TcpStream and UdpSocket for Windows.

This will allow for lower-level socket manipulation from outside of Mio on Windows (e.g. for TCP OOB streams). The step after this PR is to also implement those traits in Tokio.