### PR TITLE
Add UdpSocket::{peek, peek_from}

### DIFF
--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -542,6 +542,33 @@ impl UdpSocket {
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         self.sys.take_error()
     }
+
+    /// Receives a single datagram on the socket from the remote address to which it is
+    /// connected, without removing the message from input queue. On success, returns
+    /// the number of bytes peeked.
+    ///
+    /// The function must be called with valid byte array `buf` of sufficient size to
+    /// hold the message bytes. If a message is too long to fit in the supplied buffer,
+    /// excess bytes may be discarded.
+    ///
+    /// Successive calls return the same data. This is accomplished by passing
+    /// `MSG_PEEK` as a flag to the underlying `recv` system call.
+    pub fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.sys.peek(buf)
+    }
+
+    /// Receives a single datagram message on the socket, without removing it from the
+    /// queue. On success, returns the number of bytes read and the origin.
+    ///
+    /// The function must be called with valid byte array `buf` of sufficient size to
+    /// hold the message bytes. If a message is too long to fit in the supplied buffer,
+    /// excess bytes may be discarded.
+    ///
+    /// Successive calls return the same data. This is accomplished by passing
+    /// `MSG_PEEK` as a flag to the underlying `recvfrom` system call.
+    pub fn peek_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+        self.sys.peek_from(buf)
+    }
 }
 
 impl Evented for UdpSocket {

--- a/src/sys/fuchsia/net.rs
+++ b/src/sys/fuchsia/net.rs
@@ -413,9 +413,16 @@ impl UdpSocket {
         self.io.only_v6()
     }
 
-
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         self.io.take_error()
+    }
+
+    pub fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.io.peek(buf)
+    }
+
+    pub fn peek_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+        self.io.peek_from(buf)
     }
 }
 

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -128,6 +128,14 @@ impl UdpSocket {
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         self.io.take_error()
     }
+
+    pub fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.io.peek(buf)
+    }
+
+    pub fn peek_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+        self.io.peek_from(buf)
+    }
 }
 
 impl Evented for UdpSocket {


### PR DESCRIPTION
Closes #749.

This branch adds `peek` and `peek_from` methods to `UdpSocket`, similar
to the methods of the same name on `std::net::UdpSocket`, and adds new
tests for these functions.

Because the Windows implementation of `UdpSocket` buffers data in the
`Ready` state, I couldn't get an implementation which called the
`peek_from` method on the socket's `std::net::UdpSocket` to work
correctly. Instead, the Windows `UdpSocket` implements `peek_from` by
providing access to the currently buffered data without draining it.
This means that it never actually calls `recvfrom` with the `MSG_PEEK`
flag. Hopefully, this implementation is acceptable; otherwise, I'd
appreciate some pointers on a better way to do it, as I'm not too
familiar with the Windows platform code.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>