### PR TITLE
Only emit UnixReady::hup() from kqueue when EVFILT_READ is set

### DIFF
--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -307,7 +307,9 @@ impl Events {
             }
 
             if e.flags & libc::EV_EOF != 0 {
-                event::kind_mut(&mut self.events[idx]).insert(UnixReady::hup());
+                if e.filter == libc::EVFILT_READ as Filter {
+                    event::kind_mut(&mut self.events[idx]).insert(UnixReady::hup());
+                }
 
                 // When the read end of the socket is closed, EV_EOF is set on
                 // flags, and fflags contains the error if there is one.


### PR DESCRIPTION
This branch changes the `kqueue` selector to only set the HUP bit for events whose filter type is `EVFILT_READ`. This is somewhat cargo-culted from how FreeBSD's Linux compatibility code [translates `kqueue` events to `epoll` events](https://github.com/freebsd/freebsd/blob/f9a484901c4f26d2def4274a997c98777d73a435/sys/compat/linux/linux_event.c#L364-L367). This appears to resolve tokio-rs/tokio#449.

I'll admit that I don't _entirely_ trust this change. However, all of `mio`'s tests pass with this change, as do all of `tokio`'s when it depends on a version of `mio` with this patch. I haven't been able to come up with any other solutions to tokio-rs/tokio#449, so this is the best I've got so far. 🤷‍♀️  

Signed-off-by: Eliza Weisman <eliza@buoyant.io>