### PR TITLE
Prefer pass-by-value over pass-by-reference for public methods

### DIFF
--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -112,9 +112,9 @@ impl Event {
     /// Create a reference to an `Event` from a platform specific event.
     pub(crate) fn from_sys_event_ref(sys_event: &sys::Event) -> &Event {
         unsafe {
-            // This is safe because only because the memory layout of `Event` is
+            // This is safe because the memory layout of `Event` is
             // the same as `sys::Event` due to the `repr(transparent)` attribute.
-            std::mem::transmute(sys_event)
+            &*(sys_event as *const sys::Event as *const Event)
         }
     }
 }

--- a/src/interests.rs
+++ b/src/interests.rs
@@ -64,22 +64,22 @@ impl Interests {
     pub const LIO: Interests = Interests(unsafe { NonZeroU8::new_unchecked(LIO) });
 
     /// Returns true if the value includes readable readiness.
-    pub fn is_readable(&self) -> bool {
+    pub fn is_readable(self) -> bool {
         (self.0.get() & READABLE) != 0
     }
 
     /// Returns true if the value includes writable readiness.
-    pub fn is_writable(&self) -> bool {
+    pub fn is_writable(self) -> bool {
         (self.0.get() & WRITABLE) != 0
     }
 
     /// Returns true if `Interests` contains AIO readiness
-    pub fn is_aio(&self) -> bool {
+    pub fn is_aio(self) -> bool {
         (self.0.get() & AIO) != 0
     }
 
     /// Returns true if `Interests` contains LIO readiness
-    pub fn is_lio(&self) -> bool {
+    pub fn is_lio(self) -> bool {
         (self.0.get() & LIO) != 0
     }
 

--- a/src/interests.rs
+++ b/src/interests.rs
@@ -112,14 +112,14 @@ impl fmt::Debug for Interests {
             if one {
                 write!(fmt, " | ")?
             }
-            write!(fmt, "{}", "READABLE")?;
+            write!(fmt, "READABLE")?;
             one = true
         }
         if self.is_writable() {
             if one {
                 write!(fmt, " | ")?
             }
-            write!(fmt, "{}", "WRITABLE")?;
+            write!(fmt, "WRITABLE")?;
             one = true
         }
         #[cfg(any(
@@ -133,7 +133,7 @@ impl fmt::Debug for Interests {
                 if one {
                     write!(fmt, " | ")?
                 }
-                write!(fmt, "{}", "AIO")?;
+                write!(fmt, "AIO")?;
                 one = true
             }
         }
@@ -143,7 +143,7 @@ impl fmt::Debug for Interests {
                 if one {
                     write!(fmt, " | ")?
                 }
-                write!(fmt, "{}", "LIO")?;
+                write!(fmt, "LIO")?;
                 one = true
             }
         }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -382,6 +382,7 @@ impl Poll {
         self.poll2(events, timeout, true)
     }
 
+    #[allow(clippy::if_same_then_else)]
     fn poll2(
         &mut self,
         events: &mut Events,


### PR DESCRIPTION
pass-by-value is faster than pass-by-reference for types that are small
and Copy.  This is technically a breaking change since these methods are
public.  However, most crates should compile fine because the only
method argument that's changing is `&self`, which is provided
implicitly.  The only way to get into trouble would be something like
this:

```rust
let ready = Ready::new;
Ready::is_hup(&ready)
```