### PR TITLE
Pass Ipv4Addr arguments by value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased (Unreleased)
 
+* The `join_multicast_v4` and `leave_multicast_v4` methods now take their
+  `Ipv4Addr` arguments by value rather than by reference.
 * Fix lazycell related compilation issues.
 
 # 0.6.16 (September 5, 2018)

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -471,7 +471,7 @@ impl UdpSocket {
     /// address of the local interface with which the system should join the
     /// multicast group. If it's equal to `INADDR_ANY` then an appropriate
     /// interface is chosen by the system.
-    pub fn join_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
+    pub fn join_multicast_v4(&self, multiaddr: Ipv4Addr, interface: Ipv4Addr) -> io::Result<()> {
         self.sys.join_multicast_v4(multiaddr, interface)
     }
 
@@ -490,7 +490,7 @@ impl UdpSocket {
     /// [`join_multicast_v4`][link].
     ///
     /// [link]: #method.join_multicast_v4
-    pub fn leave_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
+    pub fn leave_multicast_v4(&self, multiaddr: Ipv4Addr, interface: Ipv4Addr) -> io::Result<()> {
         self.sys.leave_multicast_v4(multiaddr, interface)
     }
 

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,6 +1,6 @@
 use event::Evented;
-use std::fmt;
 use std;
+use std::fmt;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use sys::unix::uio::VecIo;

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,6 +1,7 @@
 use event::Evented;
 use std::fmt;
-use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use sys::unix::uio::VecIo;
 use unix::EventedFd;
@@ -11,11 +12,11 @@ use iovec::IoVec;
 use net2::UdpSocketExt;
 
 pub struct UdpSocket {
-    io: net::UdpSocket,
+    io: std::net::UdpSocket,
 }
 
 impl UdpSocket {
-    pub fn new(socket: net::UdpSocket) -> io::Result<UdpSocket> {
+    pub fn new(socket: std::net::UdpSocket) -> io::Result<UdpSocket> {
         socket.set_nonblocking(true)?;
         Ok(UdpSocket { io: socket })
     }
@@ -88,16 +89,16 @@ impl UdpSocket {
         self.io.set_ttl(ttl)
     }
 
-    pub fn join_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
-        self.io.join_multicast_v4(multiaddr, interface)
+    pub fn join_multicast_v4(&self, multiaddr: Ipv4Addr, interface: Ipv4Addr) -> io::Result<()> {
+        self.io.join_multicast_v4(&multiaddr, &interface)
     }
 
     pub fn join_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         self.io.join_multicast_v6(multiaddr, interface)
     }
 
-    pub fn leave_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
-        self.io.leave_multicast_v4(multiaddr, interface)
+    pub fn leave_multicast_v4(&self, multiaddr: Ipv4Addr, interface: Ipv4Addr) -> io::Result<()> {
+        self.io.leave_multicast_v4(&multiaddr, &interface)
     }
 
     pub fn leave_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
@@ -160,7 +161,7 @@ impl fmt::Debug for UdpSocket {
 impl FromRawFd for UdpSocket {
     unsafe fn from_raw_fd(fd: RawFd) -> UdpSocket {
         UdpSocket {
-            io: net::UdpSocket::from_raw_fd(fd),
+            io: std::net::UdpSocket::from_raw_fd(fd),
         }
     }
 }

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -239,11 +239,11 @@ impl UdpSocket {
         self.imp.inner.socket.set_ttl(ttl)
     }
 
-    pub fn join_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
+    pub fn join_multicast_v4(&self, multiaddr: Ipv4Addr, interface: Ipv4Addr) -> io::Result<()> {
         self.imp
             .inner
             .socket
-            .join_multicast_v4(multiaddr, interface)
+            .join_multicast_v4(&multiaddr, &interface)
     }
 
     pub fn join_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
@@ -253,11 +253,11 @@ impl UdpSocket {
             .join_multicast_v6(multiaddr, interface)
     }
 
-    pub fn leave_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
+    pub fn leave_multicast_v4(&self, multiaddr: Ipv4Addr, interface: Ipv4Addr) -> io::Result<()> {
         self.imp
             .inner
             .socket
-            .leave_multicast_v4(multiaddr, interface)
+            .leave_multicast_v4(&multiaddr, &interface)
     }
 
     pub fn leave_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {

--- a/test/test_multicast.rs
+++ b/test/test_multicast.rs
@@ -76,11 +76,11 @@ pub fn test_multicast() {
 
     info!("Joining group 227.1.1.100");
     let any = "0.0.0.0".parse().unwrap();
-    rx.join_multicast_v4(&"227.1.1.100".parse().unwrap(), &any)
+    rx.join_multicast_v4("227.1.1.100".parse().unwrap(), any)
         .unwrap();
 
     info!("Joining group 227.1.1.101");
-    rx.join_multicast_v4(&"227.1.1.101".parse().unwrap(), &any)
+    rx.join_multicast_v4("227.1.1.101".parse().unwrap(), any)
         .unwrap();
 
     info!("Registering SENDER");

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -175,7 +175,7 @@ pub fn test_udp_socket_discard() {
     for event in &events {
         if event.readiness().is_readable() {
             if let LISTENER = event.token() {
-                assert!(false, "Expected to no receive a packet but got something")
+                panic!("Expected to no receive a packet but got something")
             }
         }
     }


### PR DESCRIPTION
This is faster than passing them by reference, since they're Copy and
only 4 bytes big.  But it's a breaking change.