### PR TITLE
Used eventfd-backed awakener on linux.

### DIFF
--- a/src/sys/unix/awakener.rs
+++ b/src/sys/unix/awakener.rs
@@ -1,6 +1,11 @@
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub use self::pipe::Awakener;
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub use self::eventfd::Awakener;
+
 /// Default awakener backed by a pipe
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 mod pipe {
     use sys::unix;
     use {io, Ready, Poll, PollOpt, Token};
@@ -55,6 +60,69 @@ mod pipe {
 
         fn reader(&self) -> &unix::Io {
             &self.reader
+        }
+    }
+
+    impl Evented for Awakener {
+        fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+            self.reader().register(poll, token, interest, opts)
+        }
+
+        fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+            self.reader().reregister(poll, token, interest, opts)
+        }
+
+        fn deregister(&self, poll: &Poll) -> io::Result<()> {
+            self.reader().deregister(poll)
+        }
+    }
+}
+
+/// Awakener backed by an eventfd on Linux
+#[cfg(any(target_os = "linux", target_os = "android"))]
+mod eventfd {
+    use sys::unix;
+    use {io, Ready, Poll, PollOpt, Token};
+    use event::Evented;
+    use std::io::{Read, Write};
+    use std::mem::transmute;
+
+    /*
+     *
+     * ===== Awakener =====
+     *
+     */
+
+    pub struct Awakener {
+        fd: unix::Io,
+    }
+
+    impl Awakener {
+        pub fn new() -> io::Result<Awakener> {
+            Ok(Awakener { fd: unix::eventfd()? })
+        }
+
+        pub fn wakeup(&self) -> io::Result<()> {
+            let data: [u8; 8] = unsafe { transmute(1u64) };
+            match (&self.fd).write(&data) {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::WouldBlock {
+                        Ok(())
+                    } else {
+                        Err(e)
+                    }
+                }
+            }
+        }
+
+        pub fn cleanup(&self) {
+            let mut buf = [0; 8];
+            let _ = (&self.fd).read(&mut buf);
+        }
+
+        fn reader(&self) -> &unix::Io {
+            &self.fd
         }
     }
 

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -68,6 +68,14 @@ pub fn pipe() -> ::io::Result<(Io, Io)> {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn eventfd() -> ::io::Result<Io> {
+    unsafe {
+        let raw_fd = cvt(libc::eventfd(0, libc::EFD_CLOEXEC | libc::EFD_NONBLOCK))?;
+        Ok(Io::from_raw_fd(raw_fd))
+    }
+}
+
 trait IsMinusOne {
     fn is_minus_one(&self) -> bool;
 }


### PR DESCRIPTION
On Linux, instead of a pipe, we can use an eventfd, which uses less resources (a single fd and does not require buffers).