### PR TITLE
Split Poll into Poll and Register

### DIFF
--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -1,13 +1,13 @@
 use std::{fmt, io, ops};
-use {Poll, Token};
+use {Register, Token};
 
-/// A value that may be registered with `Poll`
+/// A value that may be registered with `Register`
 ///
-/// Values that implement `Evented` can be registered with `Poll`. Users of Mio
-/// should not use the `Evented` trait functions directly. Instead, the
-/// equivalent functions on `Poll` should be used.
+/// Values that implement `Evented` can be registered with `Register`. Users of
+/// Mio should not use the `Evented` trait functions directly. Instead, the
+/// equivalent functions on `Register` should be used.
 ///
-/// See [`Poll`] for more details.
+/// See [`Register`] for more details.
 ///
 /// # Implementing `Evented`
 ///
@@ -21,7 +21,7 @@ use {Poll, Token};
 /// [`Registration`] and [`SetReadiness`]. In this case, the implementer takes
 /// responsibility for driving the readiness state changes.
 ///
-/// [`Poll`]: ../struct.Poll.html
+/// [`Register`]: ../struct.Register.html
 /// [`Registration`]: ../struct.Registration.html
 /// [`SetReadiness`]: ../struct.SetReadiness.html
 ///
@@ -30,7 +30,7 @@ use {Poll, Token};
 /// Implementing `Evented` on a struct containing a socket:
 ///
 /// ```
-/// use mio::{Ready, Poll, PollOpt, Token};
+/// use mio::{Ready, Register, PollOpt, Token};
 /// use mio::event::Evented;
 /// use mio::net::TcpStream;
 ///
@@ -41,23 +41,23 @@ use {Poll, Token};
 /// }
 ///
 /// impl Evented for MyEvented {
-///     fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
+///     fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
 ///         // Delegate the `register` call to `socket`
-///         self.socket.register(poll, token, interest, opts)
+///         self.socket.register(register, token, interest, opts)
 ///     }
 ///
-///     fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
+///     fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
 ///         // Delegate the `reregister` call to `socket`
-///         self.socket.reregister(poll, token, interest, opts)
+///         self.socket.reregister(register, token, interest, opts)
 ///     }
 ///
-///     fn deregister(&self, poll: &Poll) -> io::Result<()> {
+///     fn deregister(&self, register: &Register) -> io::Result<()> {
 ///         // Delegate the `deregister` call to `socket`
-///         self.socket.deregister(poll)
+///         self.socket.deregister(register)
 ///     }
 /// }
 /// ```
@@ -65,7 +65,7 @@ use {Poll, Token};
 /// Implement `Evented` using [`Registration`] and [`SetReadiness`].
 ///
 /// ```
-/// use mio::{Ready, Registration, Poll, PollOpt, Token};
+/// use mio::{Ready, Registration, Register, PollOpt, Token};
 /// use mio::event::Evented;
 ///
 /// use std::io;
@@ -79,7 +79,7 @@ use {Poll, Token};
 ///
 /// impl Deadline {
 ///     pub fn new(when: Instant) -> Deadline {
-///         let (registration, set_readiness) = Registration::new2();
+///         let (registration, set_readiness) = Registration::new();
 ///
 ///         thread::spawn(move || {
 ///             let now = Instant::now();
@@ -103,139 +103,144 @@ use {Poll, Token};
 /// }
 ///
 /// impl Evented for Deadline {
-///     fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
+///     fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         self.registration.register(poll, token, interest, opts)
+///         self.registration.register(register, token, interest, opts)
 ///     }
 ///
-///     fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
+///     fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         self.registration.reregister(poll, token, interest, opts)
+///         self.registration.reregister(register, token, interest, opts)
 ///     }
 ///
-///     fn deregister(&self, poll: &Poll) -> io::Result<()> {
-///         self.registration.deregister(poll)
+///     fn deregister(&self, register: &Register) -> io::Result<()> {
+///         self.registration.deregister(register)
 ///     }
 /// }
 /// ```
 pub trait Evented {
-    /// Register `self` with the given `Poll` instance.
+    /// Register `self` with the given `Register` instance.
     ///
-    /// This function should not be called directly. Use [`Poll::register`]
+    /// This function should not be called directly. Use [`Register::register`]
     /// instead. Implementors should handle registration by either delegating
     /// the call to another `Evented` type or creating a [`Registration`].
     ///
-    /// [`Poll::register`]: ../struct.Poll.html#method.register
+    /// [`Register::register`]: ../struct.Register.html#method.register
     /// [`Registration`]: ../struct.Registration.html
-    fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
-        -> io::Result<()>;
-
-    /// Re-register `self` with the given `Poll` instance.
-    ///
-    /// This function should not be called directly. Use [`Poll::reregister`]
-    /// instead. Implementors should handle re-registration by either delegating
-    /// the call to another `Evented` type or calling
-    /// [`SetReadiness::set_readiness`].
-    ///
-    /// [`Poll::reregister`]: ../struct.Poll.html#method.reregister
-    /// [`SetReadiness::set_readiness`]: ../struct.SetReadiness.html#method.set_readiness
-    fn reregister(
+    fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()>;
 
-    /// Deregister `self` from the given `Poll` instance
+    /// Re-register `self` with the given `Register` instance.
     ///
-    /// This function should not be called directly. Use [`Poll::deregister`]
+    /// This function should not be called directly. Use [`Register::reregister`]
+    /// instead. Implementors should handle re-registration by either delegating
+    /// the call to another `Evented` type or calling
+    /// [`SetReadiness::set_readiness`].
+    ///
+    /// [`Register::reregister`]: ../struct.Register.html#method.reregister
+    /// [`SetReadiness::set_readiness`]: ../struct.SetReadiness.html#method.set_readiness
+    fn reregister(
+        &self,
+        register: &Register,
+        token: Token,
+        interest: Ready,
+        opts: PollOpt,
+    ) -> io::Result<()>;
+
+    /// Deregister `self` from the given `Register` instance
+    ///
+    /// This function should not be called directly. Use [`Register::deregister`]
     /// instead. Implementors should handle deregistration by either delegating
     /// the call to another `Evented` type or by dropping the [`Registration`]
     /// associated with `self`.
     ///
-    /// [`Poll::deregister`]: ../struct.Poll.html#method.deregister
+    /// [`Register::deregister`]: ../struct.Register.html#method.deregister
     /// [`Registration`]: ../struct.Registration.html
-    fn deregister(&self, poll: &Poll) -> io::Result<()>;
+    fn deregister(&self, register: &Register) -> io::Result<()>;
 }
 
 impl Evented for Box<Evented> {
     fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.as_ref().register(poll, token, interest, opts)
+        self.as_ref().register(register, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.as_ref().reregister(poll, token, interest, opts)
+        self.as_ref().reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        self.as_ref().deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        self.as_ref().deregister(register)
     }
 }
 
 impl<T: Evented> Evented for Box<T> {
     fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.as_ref().register(poll, token, interest, opts)
+        self.as_ref().register(register, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.as_ref().reregister(poll, token, interest, opts)
+        self.as_ref().reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        self.as_ref().deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        self.as_ref().deregister(register)
     }
 }
 
 impl<T: Evented> Evented for ::std::sync::Arc<T> {
     fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.as_ref().register(poll, token, interest, opts)
+        self.as_ref().register(register, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.as_ref().reregister(poll, token, interest, opts)
+        self.as_ref().reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        self.as_ref().deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        self.as_ref().deregister(register)
     }
 }
 

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -1,13 +1,13 @@
 use std::{fmt, io, ops};
-use {Register, Token};
+use {Registry, Token};
 
-/// A value that may be registered with `Register`
+/// A value that may be registered with `Registry`
 ///
-/// Values that implement `Evented` can be registered with `Register`. Users of
+/// Values that implement `Evented` can be registered with `Registry`. Users of
 /// Mio should not use the `Evented` trait functions directly. Instead, the
-/// equivalent functions on `Register` should be used.
+/// equivalent functions on `Registry` should be used.
 ///
-/// See [`Register`] for more details.
+/// See [`Registry`] for more details.
 ///
 /// # Implementing `Evented`
 ///
@@ -21,7 +21,7 @@ use {Register, Token};
 /// [`Registration`] and [`SetReadiness`]. In this case, the implementer takes
 /// responsibility for driving the readiness state changes.
 ///
-/// [`Register`]: ../struct.Register.html
+/// [`Registry`]: ../struct.Registry.html
 /// [`Registration`]: ../struct.Registration.html
 /// [`SetReadiness`]: ../struct.SetReadiness.html
 ///
@@ -30,7 +30,7 @@ use {Register, Token};
 /// Implementing `Evented` on a struct containing a socket:
 ///
 /// ```
-/// use mio::{Ready, Register, PollOpt, Token};
+/// use mio::{Ready, Registry, PollOpt, Token};
 /// use mio::event::Evented;
 /// use mio::net::TcpStream;
 ///
@@ -41,23 +41,23 @@ use {Register, Token};
 /// }
 ///
 /// impl Evented for MyEvented {
-///     fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
+///     fn register(&self, registry: &Registry, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
 ///         // Delegate the `register` call to `socket`
-///         self.socket.register(register, token, interest, opts)
+///         self.socket.register(registry, token, interest, opts)
 ///     }
 ///
-///     fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
+///     fn reregister(&self, registry: &Registry, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
 ///         // Delegate the `reregister` call to `socket`
-///         self.socket.reregister(register, token, interest, opts)
+///         self.socket.reregister(registry, token, interest, opts)
 ///     }
 ///
-///     fn deregister(&self, register: &Register) -> io::Result<()> {
+///     fn deregister(&self, registry: &Registry) -> io::Result<()> {
 ///         // Delegate the `deregister` call to `socket`
-///         self.socket.deregister(register)
+///         self.socket.deregister(registry)
 ///     }
 /// }
 /// ```
@@ -65,7 +65,7 @@ use {Register, Token};
 /// Implement `Evented` using [`Registration`] and [`SetReadiness`].
 ///
 /// ```
-/// use mio::{Ready, Registration, Register, PollOpt, Token};
+/// use mio::{Ready, Registration, Registry, PollOpt, Token};
 /// use mio::event::Evented;
 ///
 /// use std::io;
@@ -103,144 +103,144 @@ use {Register, Token};
 /// }
 ///
 /// impl Evented for Deadline {
-///     fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
+///     fn register(&self, registry: &Registry, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         self.registration.register(register, token, interest, opts)
+///         self.registration.register(registry, token, interest, opts)
 ///     }
 ///
-///     fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
+///     fn reregister(&self, registry: &Registry, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         self.registration.reregister(register, token, interest, opts)
+///         self.registration.reregister(registry, token, interest, opts)
 ///     }
 ///
-///     fn deregister(&self, register: &Register) -> io::Result<()> {
-///         self.registration.deregister(register)
+///     fn deregister(&self, registry: &Registry) -> io::Result<()> {
+///         self.registration.deregister(registry)
 ///     }
 /// }
 /// ```
 pub trait Evented {
-    /// Register `self` with the given `Register` instance.
+    /// Register `self` with the given `Registry` instance.
     ///
-    /// This function should not be called directly. Use [`Register::register`]
+    /// This function should not be called directly. Use [`Registry::register`]
     /// instead. Implementors should handle registration by either delegating
     /// the call to another `Evented` type or creating a [`Registration`].
     ///
-    /// [`Register::register`]: ../struct.Register.html#method.register
+    /// [`Registry::register`]: ../struct.Registry.html#method.register
     /// [`Registration`]: ../struct.Registration.html
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()>;
 
-    /// Re-register `self` with the given `Register` instance.
+    /// Re-register `self` with the given `Registry` instance.
     ///
-    /// This function should not be called directly. Use [`Register::reregister`]
+    /// This function should not be called directly. Use [`Registry::reregister`]
     /// instead. Implementors should handle re-registration by either delegating
     /// the call to another `Evented` type or calling
     /// [`SetReadiness::set_readiness`].
     ///
-    /// [`Register::reregister`]: ../struct.Register.html#method.reregister
+    /// [`Registry::reregister`]: ../struct.Registry.html#method.reregister
     /// [`SetReadiness::set_readiness`]: ../struct.SetReadiness.html#method.set_readiness
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()>;
 
-    /// Deregister `self` from the given `Register` instance
+    /// Deregister `self` from the given `Registry` instance
     ///
-    /// This function should not be called directly. Use [`Register::deregister`]
+    /// This function should not be called directly. Use [`Registry::deregister`]
     /// instead. Implementors should handle deregistration by either delegating
     /// the call to another `Evented` type or by dropping the [`Registration`]
     /// associated with `self`.
     ///
-    /// [`Register::deregister`]: ../struct.Register.html#method.deregister
+    /// [`Registry::deregister`]: ../struct.Registry.html#method.deregister
     /// [`Registration`]: ../struct.Registration.html
-    fn deregister(&self, register: &Register) -> io::Result<()>;
+    fn deregister(&self, registry: &Registry) -> io::Result<()>;
 }
 
 impl Evented for Box<Evented> {
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.as_ref().register(register, token, interest, opts)
+        self.as_ref().register(registry, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.as_ref().reregister(register, token, interest, opts)
+        self.as_ref().reregister(registry, token, interest, opts)
     }
 
-    fn deregister(&self, register: &Register) -> io::Result<()> {
-        self.as_ref().deregister(register)
+    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+        self.as_ref().deregister(registry)
     }
 }
 
 impl<T: Evented> Evented for Box<T> {
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.as_ref().register(register, token, interest, opts)
+        self.as_ref().register(registry, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.as_ref().reregister(register, token, interest, opts)
+        self.as_ref().reregister(registry, token, interest, opts)
     }
 
-    fn deregister(&self, register: &Register) -> io::Result<()> {
-        self.as_ref().deregister(register)
+    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+        self.as_ref().deregister(registry)
     }
 }
 
 impl<T: Evented> Evented for ::std::sync::Arc<T> {
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.as_ref().register(register, token, interest, opts)
+        self.as_ref().register(registry, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.as_ref().reregister(register, token, interest, opts)
+        self.as_ref().reregister(registry, token, interest, opts)
     }
 
-    fn deregister(&self, register: &Register) -> io::Result<()> {
-        self.as_ref().deregister(register)
+    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+        self.as_ref().deregister(registry)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ mod token;
 pub mod net;
 
 pub use event_imp::{Interests, PollOpt, Ready};
-pub use poll::{Poll, Registry, Registration, SetReadiness};
+pub use poll::{Poll, Registration, Registry, SetReadiness};
 pub use token::Token;
 
 pub mod event {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,10 +67,10 @@
 //!
 //! // Create a poll instance
 //! let mut poll = Poll::new().unwrap();
-//! let register = poll.register().clone();
+//! let registry = poll.registry().clone();
 //!
 //! // Start listening for incoming connections
-//! register.register(
+//! registry.register(
 //!     &server,
 //!     SERVER,
 //!     Ready::readable(),
@@ -80,7 +80,7 @@
 //! let sock = TcpStream::connect(&addr).unwrap();
 //!
 //! // Register the socket
-//! register.register(
+//! registry.register(
 //!     &sock,
 //!     CLIENT,
 //!     Ready::readable(),
@@ -140,7 +140,7 @@ mod token;
 pub mod net;
 
 pub use event_imp::{PollOpt, Ready};
-pub use poll::{Poll, Register, Registration, SetReadiness};
+pub use poll::{Poll, Registry, Registration, SetReadiness};
 pub use token::Token;
 
 pub mod event {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,18 +66,25 @@
 //! let server = TcpListener::bind(&addr).unwrap();
 //!
 //! // Create a poll instance
-//! let poll = Poll::new().unwrap();
+//! let mut poll = Poll::new().unwrap();
+//! let register = poll.register().clone();
 //!
 //! // Start listening for incoming connections
-//! poll.register(&server, SERVER, Ready::readable(),
-//!               PollOpt::edge()).unwrap();
+//! register.register(
+//!     &server,
+//!     SERVER,
+//!     Ready::readable(),
+//!     PollOpt::edge()).unwrap();
 //!
 //! // Setup the client socket
 //! let sock = TcpStream::connect(&addr).unwrap();
 //!
 //! // Register the socket
-//! poll.register(&sock, CLIENT, Ready::readable(),
-//!               PollOpt::edge()).unwrap();
+//! register.register(
+//!     &sock,
+//!     CLIENT,
+//!     Ready::readable(),
+//!     PollOpt::edge()).unwrap();
 //!
 //! // Create storage for events
 //! let mut events = Events::with_capacity(1024);
@@ -133,7 +140,7 @@ mod token;
 pub mod net;
 
 pub use event_imp::{PollOpt, Ready};
-pub use poll::{Poll, Registration, SetReadiness};
+pub use poll::{Poll, Register, Registration, SetReadiness};
 pub use token::Token;
 
 pub mod event {

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -16,7 +16,7 @@ use net2::TcpBuilder;
 
 use event::Evented;
 use poll::SelectorId;
-use {io, sys, Poll, PollOpt, Ready, Token};
+use {io, sys, PollOpt, Ready, Register, Token};
 
 /*
  *
@@ -42,12 +42,13 @@ use {io, sys, Poll, PollOpt, Ready, Token};
 ///
 /// let stream = TcpStream::connect(&"127.0.0.1:34254".parse()?)?;
 ///
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
+/// let register = poll.register().clone();
 /// let mut events = Events::with_capacity(128);
 ///
 /// // Register the socket with `Poll`
-/// poll.register(&stream, Token(0), Ready::writable(),
-///               PollOpt::edge())?;
+/// register.register(&stream, Token(0), Ready::writable(),
+///                   PollOpt::edge())?;
 ///
 /// poll.poll(&mut events, Some(Duration::from_millis(100)))?;
 ///
@@ -394,27 +395,27 @@ impl<'a> Write for &'a TcpStream {
 impl Evented for TcpStream {
     fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.selector_id.associate_selector(poll)?;
-        self.sys.register(poll, token, interest, opts)
+        self.selector_id.associate_selector(register)?;
+        self.sys.register(register, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.sys.reregister(poll, token, interest, opts)
+        self.sys.reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        self.sys.deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        self.sys.deregister(register)
     }
 }
 
@@ -443,12 +444,13 @@ impl fmt::Debug for TcpStream {
 ///
 /// let listener = TcpListener::bind(&"127.0.0.1:34255".parse()?)?;
 ///
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
+/// let register = poll.register().clone();
 /// let mut events = Events::with_capacity(128);
 ///
 /// // Register the socket with `Poll`
-/// poll.register(&listener, Token(0), Ready::readable(),
-///               PollOpt::edge())?;
+/// register.register(&listener, Token(0), Ready::readable(),
+///                   PollOpt::edge())?;
 ///
 /// poll.poll(&mut events, Some(Duration::from_millis(100)))?;
 ///
@@ -589,27 +591,27 @@ impl TcpListener {
 impl Evented for TcpListener {
     fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.selector_id.associate_selector(poll)?;
-        self.sys.register(poll, token, interest, opts)
+        self.selector_id.associate_selector(register)?;
+        self.sys.register(register, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.sys.reregister(poll, token, interest, opts)
+        self.sys.reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        self.sys.deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        self.sys.deregister(register)
     }
 }
 

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -16,7 +16,7 @@ use net2::TcpBuilder;
 
 use event::Evented;
 use poll::SelectorId;
-use {io, sys, PollOpt, Ready, Register, Token};
+use {io, sys, PollOpt, Ready, Registry, Token};
 
 /*
  *
@@ -43,12 +43,12 @@ use {io, sys, PollOpt, Ready, Register, Token};
 /// let stream = TcpStream::connect(&"127.0.0.1:34254".parse()?)?;
 ///
 /// let mut poll = Poll::new()?;
-/// let register = poll.register().clone();
+/// let registry = poll.registry().clone();
 /// let mut events = Events::with_capacity(128);
 ///
 /// // Register the socket with `Poll`
-/// register.register(&stream, Token(0), Ready::writable(),
-///                   PollOpt::edge())?;
+/// registry.register(&stream, Token(0), Ready::writable(),
+///                    PollOpt::edge())?;
 ///
 /// poll.poll(&mut events, Some(Duration::from_millis(100)))?;
 ///
@@ -395,27 +395,27 @@ impl<'a> Write for &'a TcpStream {
 impl Evented for TcpStream {
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.selector_id.associate_selector(register)?;
-        self.sys.register(register, token, interest, opts)
+        self.selector_id.associate_selector(registry)?;
+        self.sys.register(registry, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.sys.reregister(register, token, interest, opts)
+        self.sys.reregister(registry, token, interest, opts)
     }
 
-    fn deregister(&self, register: &Register) -> io::Result<()> {
-        self.sys.deregister(register)
+    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+        self.sys.deregister(registry)
     }
 }
 
@@ -445,11 +445,11 @@ impl fmt::Debug for TcpStream {
 /// let listener = TcpListener::bind(&"127.0.0.1:34255".parse()?)?;
 ///
 /// let mut poll = Poll::new()?;
-/// let register = poll.register().clone();
+/// let registry = poll.registry().clone();
 /// let mut events = Events::with_capacity(128);
 ///
 /// // Register the socket with `Poll`
-/// register.register(&listener, Token(0), Ready::readable(),
+/// registry.register(&listener, Token(0), Ready::readable(),
 ///                   PollOpt::edge())?;
 ///
 /// poll.poll(&mut events, Some(Duration::from_millis(100)))?;
@@ -591,27 +591,27 @@ impl TcpListener {
 impl Evented for TcpListener {
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.selector_id.associate_selector(register)?;
-        self.sys.register(register, token, interest, opts)
+        self.selector_id.associate_selector(registry)?;
+        self.sys.register(registry, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.sys.reregister(register, token, interest, opts)
+        self.sys.reregister(registry, token, interest, opts)
     }
 
-    fn deregister(&self, register: &Register) -> io::Result<()> {
-        self.sys.deregister(register)
+    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+        self.sys.deregister(registry)
     }
 }
 

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -16,7 +16,7 @@ use net2::TcpBuilder;
 
 use event::Evented;
 use poll::SelectorId;
-use {io, sys, PollOpt, Interests, Registry, Token};
+use {io, sys, Interests, PollOpt, Registry, Token};
 
 /*
  *

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -10,7 +10,7 @@ use poll::SelectorId;
 use std::fmt;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 /// [portability guidelines]: ../struct.Poll.html#portability
-use {io, sys, PollOpt, Ready, Register, Token};
+use {io, sys, PollOpt, Ready, Registry, Token};
 
 #[cfg(all(unix, not(target_os = "fuchsia")))]
 use iovec::IoVec;
@@ -50,11 +50,11 @@ use iovec::IoVec;
 /// // We need a Poll to check if SENDER is ready to be written into, and if ECHOER is ready to be
 /// // read from.
 /// let mut poll = Poll::new()?;
-/// let register = poll.register().clone();
+/// let registry = poll.registry().clone();
 ///
 /// // We register our sockets here so that we can check if they are ready to be written/read.
-/// register.register(&sender_socket, SENDER, Ready::writable(), PollOpt::edge())?;
-/// register.register(&echoer_socket, ECHOER, Ready::readable(), PollOpt::edge())?;
+/// registry.register(&sender_socket, SENDER, Ready::writable(), PollOpt::edge())?;
+/// registry.register(&echoer_socket, ECHOER, Ready::readable(), PollOpt::edge())?;
 ///
 /// let msg_to_send = [9; 9];
 /// let mut buffer = [0; 9];
@@ -581,27 +581,27 @@ impl UdpSocket {
 impl Evented for UdpSocket {
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.selector_id.associate_selector(register)?;
-        self.sys.register(register, token, interest, opts)
+        self.selector_id.associate_selector(registry)?;
+        self.sys.register(registry, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.sys.reregister(register, token, interest, opts)
+        self.sys.reregister(registry, token, interest, opts)
     }
 
-    fn deregister(&self, register: &Register) -> io::Result<()> {
-        self.sys.deregister(register)
+    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+        self.sys.deregister(registry)
     }
 }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -10,7 +10,7 @@ use poll::SelectorId;
 use std::fmt;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 /// [portability guidelines]: ../struct.Poll.html#portability
-use {io, sys, PollOpt, Interests, Registry, Token};
+use {io, sys, Interests, PollOpt, Registry, Token};
 
 #[cfg(all(unix, not(target_os = "fuchsia")))]
 use iovec::IoVec;

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -10,7 +10,7 @@ use poll::SelectorId;
 use std::fmt;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 /// [portability guidelines]: ../struct.Poll.html#portability
-use {io, sys, Poll, PollOpt, Ready, Token};
+use {io, sys, PollOpt, Ready, Register, Token};
 
 #[cfg(all(unix, not(target_os = "fuchsia")))]
 use iovec::IoVec;
@@ -49,11 +49,12 @@ use iovec::IoVec;
 ///
 /// // We need a Poll to check if SENDER is ready to be written into, and if ECHOER is ready to be
 /// // read from.
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
+/// let register = poll.register().clone();
 ///
 /// // We register our sockets here so that we can check if they are ready to be written/read.
-/// poll.register(&sender_socket, SENDER, Ready::writable(), PollOpt::edge())?;
-/// poll.register(&echoer_socket, ECHOER, Ready::readable(), PollOpt::edge())?;
+/// register.register(&sender_socket, SENDER, Ready::writable(), PollOpt::edge())?;
+/// register.register(&echoer_socket, ECHOER, Ready::readable(), PollOpt::edge())?;
 ///
 /// let msg_to_send = [9; 9];
 /// let mut buffer = [0; 9];
@@ -580,27 +581,27 @@ impl UdpSocket {
 impl Evented for UdpSocket {
     fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.selector_id.associate_selector(poll)?;
-        self.sys.register(poll, token, interest, opts)
+        self.selector_id.associate_selector(register)?;
+        self.sys.register(register, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.sys.reregister(poll, token, interest, opts)
+        self.sys.reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        self.sys.deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        self.sys.deregister(register)
     }
 }
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -5,9 +5,9 @@ use std::os::unix::io::AsRawFd;
 #[cfg(all(unix, not(target_os = "fuchsia")))]
 use std::os::unix::io::RawFd;
 use std::process;
-use std::sync::atomic::Ordering::{self, AcqRel, Acquire, Relaxed, Release, SeqCst};
+use std::sync::atomic::Ordering::{self, AcqRel, Acquire, Relaxed, Release};
 use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{fmt, io, ptr, usize};
 use std::{isize, mem, ops};
@@ -71,12 +71,12 @@ use {sys, Token};
 /// [`write`].
 ///
 /// To use `Poll`, an `Evented` type must first be registered with the `Poll`
-/// instance using the [`register`] method, supplying readiness interest. The
-/// readiness interest tells `Poll` which specific operations on the handle to
-/// monitor for readiness. A `Token` is also passed to the [`register`]
-/// function. When `Poll` returns a readiness event, it will include this token.
-/// This associates the event with the `Evented` handle that generated the
-/// event.
+/// instance using the [`register`] method on its associated `Register`,
+/// supplying readiness interest. The readiness interest tells `Poll` which
+/// specific operations on the handle to monitor for readiness. A `Token` is
+/// also passed to the [`register`] function. When `Poll` returns a readiness
+/// event, it will include this token.  This associates the event with the
+/// `Evented` handle that generated the event.
 ///
 /// [`read`]: tcp/struct.TcpStream.html#method.read
 /// [`write`]: tcp/struct.TcpStream.html#method.write
@@ -99,14 +99,15 @@ use {sys, Token};
 /// let server = TcpListener::bind(&addr)?;
 ///
 /// // Construct a new `Poll` handle as well as the `Events` we'll store into
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
+/// let register = poll.register().clone();
 /// let mut events = Events::with_capacity(1024);
 ///
 /// // Connect the stream
 /// let stream = TcpStream::connect(&server.local_addr()?)?;
 ///
 /// // Register the stream with `Poll`
-/// poll.register(&stream, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
+/// register.register(&stream, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
 ///
 /// // Wait for the socket to become ready. This has to happens in a loop to
 /// // handle spurious wakeups.
@@ -145,13 +146,13 @@ use {sys, Token};
 /// 4. 1kb is read from the socket.
 /// 5. Another call to [`Poll::poll`] is made.
 ///
-/// If when the socket was registered with `Poll`, edge triggered events were
-/// requested, then the call to [`Poll::poll`] done in step **5** will
-/// (probably) hang despite there being another 1kb still present in the socket
-/// read buffer. The reason for this is that edge-triggered mode delivers events
-/// only when changes occur on the monitored [`Evented`]. So, in step *5* the
-/// caller might end up waiting for some data that is already present inside the
-/// socket buffer.
+/// If when the socket was registered, edge triggered events were requested,
+/// then the call to [`Poll::poll`] done in step **5** will (probably) hang
+/// despite there being another 1kb still present in the socket read buffer. The
+/// reason for this is that edge-triggered mode delivers events only when
+/// changes occur on the monitored [`Evented`]. So, in step *5* the caller might
+/// end up waiting for some data that is already present inside the socket
+/// buffer.
 ///
 /// With edge-triggered events, operations **must** be performed on the
 /// `Evented` type until [`WouldBlock`] is returned. In other words, after
@@ -186,9 +187,9 @@ use {sys, Token};
 /// 6. The socket receives another 2kb of data.
 /// 7. Another call to [`Poll::poll`] is made.
 ///
-/// Assuming the socket was registered with `Poll` with the [`edge`] and
-/// [`oneshot`] options, then the call to [`Poll::poll`] in step 7 would block. This
-/// is because, [`oneshot`] tells `Poll` to disable events for the socket after
+/// Assuming the socket was registered with the [`edge`] and [`oneshot`]
+/// options, then the call to [`Poll::poll`] in step 7 would block. This is
+/// because, [`oneshot`] tells `Poll` to disable events for the socket after
 /// returning an event.
 ///
 /// In order to receive the event for the data received in step 6, the socket
@@ -275,11 +276,12 @@ use {sys, Token};
 ///
 /// thread::sleep(Duration::from_secs(1));
 ///
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
+/// let register = poll.register().clone();
 ///
 /// // The connect is not guaranteed to have started until it is registered at
 /// // this point
-/// poll.register(&sock, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
+/// register.register(&sock, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
 /// #     Ok(())
 /// # }
 /// #
@@ -326,21 +328,21 @@ use {sys, Token};
 /// [`SetReadiness`]: struct.SetReadiness.html
 /// [`Poll::poll`]: struct.Poll.html#method.poll
 pub struct Poll {
+    register: Register,
+}
+
+/// Registers I/O resources.
+#[derive(Clone)]
+pub struct Register {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
     // Platform specific IO selector
     selector: sys::Selector,
 
     // Custom readiness queue
     readiness_queue: ReadinessQueue,
-
-    // Use an atomic to first check if a full lock will be required. This is a
-    // fast-path check for single threaded cases avoiding the extra syscall
-    lock_state: AtomicUsize,
-
-    // Sequences concurrent calls to `Poll::poll`
-    lock: Mutex<()>,
-
-    // Wakeup the next waiter
-    condvar: Condvar,
 }
 
 /// Handle to a user space `Poll` registration.
@@ -353,7 +355,7 @@ pub struct Poll {
 /// by [`poll`].
 ///
 /// A `Registration` / `SetReadiness` pair is created by calling
-/// [`Registration::new2`]. At this point, the registration is not being
+/// [`Registration::new`]. At this point, the registration is not being
 /// monitored by a [`Poll`] instance, so calls to `set_readiness` will not
 /// result in any readiness notifications.
 ///
@@ -372,7 +374,7 @@ pub struct Poll {
 /// # Examples
 ///
 /// ```
-/// use mio::{Ready, Registration, Poll, PollOpt, Token};
+/// use mio::{Ready, Registration, Register, Poll, PollOpt, Token};
 /// use mio::event::Evented;
 ///
 /// use std::io;
@@ -386,7 +388,7 @@ pub struct Poll {
 ///
 /// impl Deadline {
 ///     pub fn new(when: Instant) -> Deadline {
-///         let (registration, set_readiness) = Registration::new2();
+///         let (registration, set_readiness) = Registration::new();
 ///
 ///         thread::spawn(move || {
 ///             let now = Instant::now();
@@ -410,27 +412,27 @@ pub struct Poll {
 /// }
 ///
 /// impl Evented for Deadline {
-///     fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
+///     fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         self.registration.register(poll, token, interest, opts)
+///         self.registration.register(register, token, interest, opts)
 ///     }
 ///
-///     fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
+///     fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         self.registration.reregister(poll, token, interest, opts)
+///         self.registration.reregister(register, token, interest, opts)
 ///     }
 ///
-///     fn deregister(&self, poll: &Poll) -> io::Result<()> {
-///         poll.deregister(&self.registration)
+///     fn deregister(&self, register: &Register) -> io::Result<()> {
+///         register.deregister(&self.registration)
 ///     }
 /// }
 /// ```
 ///
 /// [system selector]: struct.Poll.html#implementation-notes
 /// [`Poll`]: struct.Poll.html
-/// [`Registration::new2`]: struct.Registration.html#method.new2
+/// [`Registration::new`]: struct.Registration.html#method.new
 /// [`Evented`]: event/trait.Evented.html
 /// [`set_readiness`]: struct.SetReadiness.html#method.set_readiness
 /// [`register`]: struct.Poll.html#method.register
@@ -629,7 +631,7 @@ impl Poll {
     /// use mio::{Poll, Events};
     /// use std::time::Duration;
     ///
-    /// let poll = match Poll::new() {
+    /// let mut poll = match Poll::new() {
     ///     Ok(poll) => poll,
     ///     Err(e) => panic!("failed to create Poll instance; err={:?}", e),
     /// };
@@ -652,25 +654,233 @@ impl Poll {
         is_send::<Poll>();
         is_sync::<Poll>();
 
-        let poll = Poll {
+        let inner = Arc::new(Inner {
             selector: sys::Selector::new()?,
             readiness_queue: ReadinessQueue::new()?,
-            lock_state: AtomicUsize::new(0),
-            lock: Mutex::new(()),
-            condvar: Condvar::new(),
-        };
+        });
+
+        let register = Register { inner };
 
         // Register the notification wakeup FD with the IO poller
-        poll.readiness_queue.inner.awakener.register(
-            &poll,
+        register.inner.readiness_queue.inner.awakener.register(
+            &register,
             AWAKEN,
             Ready::readable(),
             PollOpt::edge(),
         )?;
 
-        Ok(poll)
+        Ok(Poll { register })
     }
 
+    /// Return a reference to the associated `Register`.
+    pub fn register(&self) -> &Register {
+        &self.register
+    }
+
+    /// Wait for readiness events
+    ///
+    /// Blocks the current thread and waits for readiness events for any of the
+    /// `Evented` handles that have been registered with this `Poll` instance.
+    /// The function will block until either at least one readiness event has
+    /// been received or `timeout` has elapsed. A `timeout` of `None` means that
+    /// `poll` will block until a readiness event has been received.
+    ///
+    /// The supplied `events` will be cleared and newly received readiness events
+    /// will be pushed onto the end. At most `events.capacity()` events will be
+    /// returned. If there are further pending readiness events, they will be
+    /// returned on the next call to `poll`.
+    ///
+    /// A single call to `poll` may result in multiple readiness events being
+    /// returned for a single `Evented` handle. For example, if a TCP socket
+    /// becomes both readable and writable, it may be possible for a single
+    /// readiness event to be returned with both [`readable`] and [`writable`]
+    /// readiness **OR** two separate events may be returned, one with
+    /// [`readable`] set and one with [`writable`] set.
+    ///
+    /// Note that the `timeout` will be rounded up to the system clock
+    /// granularity (usually 1ms), and kernel scheduling delays mean that
+    /// the blocking interval may be overrun by a small amount.
+    ///
+    /// `poll` returns the number of readiness events that have been pushed into
+    /// `events` or `Err` when an error has been encountered with the system
+    /// selector.  The value returned is deprecated and will be removed in 0.7.0.
+    /// Accessing the events by index is also deprecated.  Events can be
+    /// inserted by other events triggering, thus making sequential access
+    /// problematic.  Use the iterator API instead.  See [`iter`].
+    ///
+    /// See the [struct] level documentation for a higher level discussion of
+    /// polling.
+    ///
+    /// [`readable`]: struct.Ready.html#method.readable
+    /// [`writable`]: struct.Ready.html#method.writable
+    /// [struct]: #
+    /// [`iter`]: struct.Events.html#method.iter
+    ///
+    /// # Examples
+    ///
+    /// A basic example -- establishing a `TcpStream` connection.
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # fn try_main() -> Result<(), Box<Error>> {
+    /// use mio::{Events, Poll, Ready, PollOpt, Token};
+    /// use mio::net::TcpStream;
+    ///
+    /// use std::net::{TcpListener, SocketAddr};
+    /// use std::thread;
+    ///
+    /// // Bind a server socket to connect to.
+    /// let addr: SocketAddr = "127.0.0.1:0".parse()?;
+    /// let server = TcpListener::bind(&addr)?;
+    /// let addr = server.local_addr()?.clone();
+    ///
+    /// // Spawn a thread to accept the socket
+    /// thread::spawn(move || {
+    ///     let _ = server.accept();
+    /// });
+    ///
+    /// // Construct a new `Poll` handle as well as the `Events` we'll store into
+    /// let mut poll = Poll::new()?;
+    /// let register = poll.register().clone();
+    /// let mut events = Events::with_capacity(1024);
+    ///
+    /// // Connect the stream
+    /// let stream = TcpStream::connect(&addr)?;
+    ///
+    /// // Register the stream with `Poll`
+    /// register.register(
+    ///     &stream,
+    ///     Token(0),
+    ///     Ready::readable() | Ready::writable(),
+    ///     PollOpt::edge())?;
+    ///
+    /// // Wait for the socket to become ready. This has to happens in a loop to
+    /// // handle spurious wakeups.
+    /// loop {
+    ///     poll.poll(&mut events, None)?;
+    ///
+    ///     for event in &events {
+    ///         if event.token() == Token(0) && event.readiness().is_writable() {
+    ///             // The socket connected (probably, it could still be a spurious
+    ///             // wakeup)
+    ///             return Ok(());
+    ///         }
+    ///     }
+    /// }
+    /// #     Ok(())
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     try_main().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// [struct]: #
+    pub fn poll(&mut self, events: &mut Events, timeout: Option<Duration>) -> io::Result<usize> {
+        self.poll2(events, timeout, false)
+    }
+
+    /// Like `poll`, but may be interrupted by a signal
+    ///
+    /// If `poll` is inturrupted while blocking, it will transparently retry the syscall.  If you
+    /// want to handle signals yourself, however, use `poll_interruptible`.
+    pub fn poll_interruptible(
+        &mut self,
+        events: &mut Events,
+        timeout: Option<Duration>,
+    ) -> io::Result<usize> {
+        self.poll2(events, timeout, true)
+    }
+
+    fn poll2(
+        &mut self,
+        events: &mut Events,
+        mut timeout: Option<Duration>,
+        interruptible: bool,
+    ) -> io::Result<usize> {
+        let inner = &*self.register.inner;
+
+        // Compute the timeout value passed to the system selector. If the
+        // readiness queue has pending nodes, we still want to poll the system
+        // selector for new events, but we don't want to block the thread to
+        // wait for new events.
+        if timeout == Some(Duration::from_millis(0)) {
+            // If blocking is not requested, then there is no need to prepare
+            // the queue for sleep
+            //
+            // The sleep_marker should be removed by readiness_queue.poll().
+        } else if inner.readiness_queue.prepare_for_sleep() {
+            // The readiness queue is empty. The call to `prepare_for_sleep`
+            // inserts `sleep_marker` into the queue. This signals to any
+            // threads setting readiness that the `Poll::poll` is going to
+            // sleep, so the awakener should be used.
+        } else {
+            // The readiness queue is not empty, so do not block the thread.
+            timeout = Some(Duration::from_millis(0));
+        }
+
+        loop {
+            let now = Instant::now();
+            // First get selector events
+            let res = inner.selector.select(&mut events.inner, AWAKEN, timeout);
+            match res {
+                Ok(true) => {
+                    // Some awakeners require reading from a FD.
+                    inner.readiness_queue.inner.awakener.cleanup();
+                    break;
+                }
+                Ok(false) => break,
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted && !interruptible => {
+                    // Interrupted by a signal; update timeout if necessary and retry
+                    if let Some(to) = timeout {
+                        let elapsed = now.elapsed();
+                        if elapsed >= to {
+                            break;
+                        } else {
+                            timeout = Some(to - elapsed);
+                        }
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        // Poll custom event queue
+        inner.readiness_queue.poll(&mut events.inner);
+
+        // Return number of polled events
+        Ok(events.inner.len())
+    }
+}
+
+fn validate_args(token: Token) -> io::Result<()> {
+    if token == AWAKEN {
+        return Err(io::Error::new(io::ErrorKind::Other, "invalid token"));
+    }
+
+    Ok(())
+}
+
+impl fmt::Debug for Poll {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Poll").finish()
+    }
+}
+
+impl fmt::Debug for Register {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Poll").finish()
+    }
+}
+
+#[cfg(all(unix, not(target_os = "fuchsia")))]
+impl AsRawFd for Poll {
+    fn as_raw_fd(&self) -> RawFd {
+        self.register.inner.selector.as_raw_fd()
+    }
+}
+
+impl Register {
     /// Register an `Evented` handle with the `Poll` instance.
     ///
     /// Once registered, the `Poll` instance will monitor the `Evented` handle
@@ -743,11 +953,16 @@ impl Poll {
     /// use mio::net::TcpStream;
     /// use std::time::{Duration, Instant};
     ///
-    /// let poll = Poll::new()?;
+    /// let mut poll = Poll::new()?;
+    /// let register = poll.register().clone();
     /// let socket = TcpStream::connect(&"216.58.193.100:80".parse()?)?;
     ///
     /// // Register the socket with `poll`
-    /// poll.register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
+    /// register.register(
+    ///     &socket,
+    ///     Token(0),
+    ///     Ready::readable() | Ready::writable(),
+    ///     PollOpt::edge())?;
     ///
     /// let mut events = Events::with_capacity(1024);
     /// let start = Instant::now();
@@ -834,16 +1049,25 @@ impl Poll {
     /// use mio::{Poll, Ready, PollOpt, Token};
     /// use mio::net::TcpStream;
     ///
-    /// let poll = Poll::new()?;
+    /// let mut poll = Poll::new()?;
+    /// let register = poll.register().clone();
     /// let socket = TcpStream::connect(&"216.58.193.100:80".parse()?)?;
     ///
     /// // Register the socket with `poll`, requesting readable
-    /// poll.register(&socket, Token(0), Ready::readable(), PollOpt::edge())?;
+    /// register.register(
+    ///     &socket,
+    ///     Token(0),
+    ///     Ready::readable(),
+    ///     PollOpt::edge())?;
     ///
     /// // Reregister the socket specifying a different token and write interest
     /// // instead. `PollOpt::edge()` must be specified even though that value
     /// // is not being changed.
-    /// poll.reregister(&socket, Token(2), Ready::writable(), PollOpt::edge())?;
+    /// register.reregister(
+    ///     &socket,
+    ///     Token(2),
+    ///     Ready::writable(),
+    ///     PollOpt::edge())?;
     /// #     Ok(())
     /// # }
     /// #
@@ -899,13 +1123,18 @@ impl Poll {
     /// use mio::net::TcpStream;
     /// use std::time::Duration;
     ///
-    /// let poll = Poll::new()?;
+    /// let mut poll = Poll::new()?;
+    /// let register = poll.register().clone();
     /// let socket = TcpStream::connect(&"216.58.193.100:80".parse()?)?;
     ///
     /// // Register the socket with `poll`
-    /// poll.register(&socket, Token(0), Ready::readable(), PollOpt::edge())?;
+    /// register.register(
+    ///     &socket,
+    ///     Token(0),
+    ///     Ready::readable(),
+    ///     PollOpt::edge())?;
     ///
-    /// poll.deregister(&socket)?;
+    /// register.deregister(&socket)?;
     ///
     /// let mut events = Events::with_capacity(1024);
     ///
@@ -930,332 +1159,6 @@ impl Poll {
 
         Ok(())
     }
-
-    /// Wait for readiness events
-    ///
-    /// Blocks the current thread and waits for readiness events for any of the
-    /// `Evented` handles that have been registered with this `Poll` instance.
-    /// The function will block until either at least one readiness event has
-    /// been received or `timeout` has elapsed. A `timeout` of `None` means that
-    /// `poll` will block until a readiness event has been received.
-    ///
-    /// The supplied `events` will be cleared and newly received readiness events
-    /// will be pushed onto the end. At most `events.capacity()` events will be
-    /// returned. If there are further pending readiness events, they will be
-    /// returned on the next call to `poll`.
-    ///
-    /// A single call to `poll` may result in multiple readiness events being
-    /// returned for a single `Evented` handle. For example, if a TCP socket
-    /// becomes both readable and writable, it may be possible for a single
-    /// readiness event to be returned with both [`readable`] and [`writable`]
-    /// readiness **OR** two separate events may be returned, one with
-    /// [`readable`] set and one with [`writable`] set.
-    ///
-    /// Note that the `timeout` will be rounded up to the system clock
-    /// granularity (usually 1ms), and kernel scheduling delays mean that
-    /// the blocking interval may be overrun by a small amount.
-    ///
-    /// `poll` returns the number of readiness events that have been pushed into
-    /// `events` or `Err` when an error has been encountered with the system
-    /// selector.  The value returned is deprecated and will be removed in 0.7.0.
-    /// Accessing the events by index is also deprecated.  Events can be
-    /// inserted by other events triggering, thus making sequential access
-    /// problematic.  Use the iterator API instead.  See [`iter`].
-    ///
-    /// See the [struct] level documentation for a higher level discussion of
-    /// polling.
-    ///
-    /// [`readable`]: struct.Ready.html#method.readable
-    /// [`writable`]: struct.Ready.html#method.writable
-    /// [struct]: #
-    /// [`iter`]: struct.Events.html#method.iter
-    ///
-    /// # Examples
-    ///
-    /// A basic example -- establishing a `TcpStream` connection.
-    ///
-    /// ```
-    /// # use std::error::Error;
-    /// # fn try_main() -> Result<(), Box<Error>> {
-    /// use mio::{Events, Poll, Ready, PollOpt, Token};
-    /// use mio::net::TcpStream;
-    ///
-    /// use std::net::{TcpListener, SocketAddr};
-    /// use std::thread;
-    ///
-    /// // Bind a server socket to connect to.
-    /// let addr: SocketAddr = "127.0.0.1:0".parse()?;
-    /// let server = TcpListener::bind(&addr)?;
-    /// let addr = server.local_addr()?.clone();
-    ///
-    /// // Spawn a thread to accept the socket
-    /// thread::spawn(move || {
-    ///     let _ = server.accept();
-    /// });
-    ///
-    /// // Construct a new `Poll` handle as well as the `Events` we'll store into
-    /// let poll = Poll::new()?;
-    /// let mut events = Events::with_capacity(1024);
-    ///
-    /// // Connect the stream
-    /// let stream = TcpStream::connect(&addr)?;
-    ///
-    /// // Register the stream with `Poll`
-    /// poll.register(&stream, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
-    ///
-    /// // Wait for the socket to become ready. This has to happens in a loop to
-    /// // handle spurious wakeups.
-    /// loop {
-    ///     poll.poll(&mut events, None)?;
-    ///
-    ///     for event in &events {
-    ///         if event.token() == Token(0) && event.readiness().is_writable() {
-    ///             // The socket connected (probably, it could still be a spurious
-    ///             // wakeup)
-    ///             return Ok(());
-    ///         }
-    ///     }
-    /// }
-    /// #     Ok(())
-    /// # }
-    /// #
-    /// # fn main() {
-    /// #     try_main().unwrap();
-    /// # }
-    /// ```
-    ///
-    /// [struct]: #
-    pub fn poll(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<usize> {
-        self.poll1(events, timeout, false)
-    }
-
-    /// Like `poll`, but may be interrupted by a signal
-    ///
-    /// If `poll` is inturrupted while blocking, it will transparently retry the syscall.  If you
-    /// want to handle signals yourself, however, use `poll_interruptible`.
-    pub fn poll_interruptible(
-        &self,
-        events: &mut Events,
-        timeout: Option<Duration>,
-    ) -> io::Result<usize> {
-        self.poll1(events, timeout, true)
-    }
-
-    fn poll1(
-        &self,
-        events: &mut Events,
-        mut timeout: Option<Duration>,
-        interruptible: bool,
-    ) -> io::Result<usize> {
-        let zero = Some(Duration::from_millis(0));
-
-        // At a high level, the synchronization strategy is to acquire access to
-        // the critical section by transitioning the atomic from unlocked ->
-        // locked. If the attempt fails, the thread will wait on the condition
-        // variable.
-        //
-        // # Some more detail
-        //
-        // The `lock_state` atomic usize combines:
-        //
-        // - locked flag, stored in the least significant bit
-        // - number of waiting threads, stored in the rest of the bits.
-        //
-        // When a thread transitions the locked flag from 0 -> 1, it has
-        // obtained access to the critical section.
-        //
-        // When entering `poll`, a compare-and-swap from 0 -> 1 is attempted.
-        // This is a fast path for the case when there are no concurrent calls
-        // to poll, which is very common.
-        //
-        // On failure, the mutex is locked, and the thread attempts to increment
-        // the number of waiting threads component of `lock_state`. If this is
-        // successfully done while the locked flag is set, then the thread can
-        // wait on the condition variable.
-        //
-        // When a thread exits the critical section, it unsets the locked flag.
-        // If there are any waiters, which is atomically determined while
-        // unsetting the locked flag, then the condvar is notified.
-
-        let mut curr = self.lock_state.compare_and_swap(0, 1, SeqCst);
-
-        if 0 != curr {
-            // Enter slower path
-            let mut lock = self.lock.lock().unwrap();
-            let mut inc = false;
-
-            loop {
-                if curr & 1 == 0 {
-                    // The lock is currently free, attempt to grab it
-                    let mut next = curr | 1;
-
-                    if inc {
-                        // The waiter count has previously been incremented, so
-                        // decrement it here
-                        next -= 2;
-                    }
-
-                    let actual = self.lock_state.compare_and_swap(curr, next, SeqCst);
-
-                    if actual != curr {
-                        curr = actual;
-                        continue;
-                    }
-
-                    // Lock acquired, break from the loop
-                    break;
-                }
-
-                if timeout == zero {
-                    if inc {
-                        self.lock_state.fetch_sub(2, SeqCst);
-                    }
-
-                    return Ok(0);
-                }
-
-                // The lock is currently held, so wait for it to become
-                // free. If the waiter count hasn't been incremented yet, do
-                // so now
-                if !inc {
-                    let next = curr.checked_add(2).expect("overflow");
-                    let actual = self.lock_state.compare_and_swap(curr, next, SeqCst);
-
-                    if actual != curr {
-                        curr = actual;
-                        continue;
-                    }
-
-                    // Track that the waiter count has been incremented for
-                    // this thread and fall through to the condvar waiting
-                    inc = true;
-                }
-
-                lock = match timeout {
-                    Some(to) => {
-                        let now = Instant::now();
-
-                        // Wait to be notified
-                        let (l, _) = self.condvar.wait_timeout(lock, to).unwrap();
-
-                        // See how much time was elapsed in the wait
-                        let elapsed = now.elapsed();
-
-                        // Update `timeout` to reflect how much time is left to
-                        // wait.
-                        if elapsed >= to {
-                            timeout = zero;
-                        } else {
-                            // Update the timeout
-                            timeout = Some(to - elapsed);
-                        }
-
-                        l
-                    }
-                    None => self.condvar.wait(lock).unwrap(),
-                };
-
-                // Reload the state
-                curr = self.lock_state.load(SeqCst);
-
-                // Try to lock again...
-            }
-        }
-
-        let ret = self.poll2(events, timeout, interruptible);
-
-        // Release the lock
-        if 1 != self.lock_state.fetch_and(!1, Release) {
-            // Acquire the mutex
-            let _lock = self.lock.lock().unwrap();
-
-            // There is at least one waiting thread, so notify one
-            self.condvar.notify_one();
-        }
-
-        ret
-    }
-
-    #[inline]
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::if_same_then_else))]
-    fn poll2(
-        &self,
-        events: &mut Events,
-        mut timeout: Option<Duration>,
-        interruptible: bool,
-    ) -> io::Result<usize> {
-        // Compute the timeout value passed to the system selector. If the
-        // readiness queue has pending nodes, we still want to poll the system
-        // selector for new events, but we don't want to block the thread to
-        // wait for new events.
-        if timeout == Some(Duration::from_millis(0)) {
-            // If blocking is not requested, then there is no need to prepare
-            // the queue for sleep
-            //
-            // The sleep_marker should be removed by readiness_queue.poll().
-        } else if self.readiness_queue.prepare_for_sleep() {
-            // The readiness queue is empty. The call to `prepare_for_sleep`
-            // inserts `sleep_marker` into the queue. This signals to any
-            // threads setting readiness that the `Poll::poll` is going to
-            // sleep, so the awakener should be used.
-        } else {
-            // The readiness queue is not empty, so do not block the thread.
-            timeout = Some(Duration::from_millis(0));
-        }
-
-        loop {
-            let now = Instant::now();
-            // First get selector events
-            let res = self.selector.select(&mut events.inner, AWAKEN, timeout);
-            match res {
-                Ok(true) => {
-                    // Some awakeners require reading from a FD.
-                    self.readiness_queue.inner.awakener.cleanup();
-                    break;
-                }
-                Ok(false) => break,
-                Err(ref e) if e.kind() == io::ErrorKind::Interrupted && !interruptible => {
-                    // Interrupted by a signal; update timeout if necessary and retry
-                    if let Some(to) = timeout {
-                        let elapsed = now.elapsed();
-                        if elapsed >= to {
-                            break;
-                        } else {
-                            timeout = Some(to - elapsed);
-                        }
-                    }
-                }
-                Err(e) => return Err(e),
-            }
-        }
-
-        // Poll custom event queue
-        self.readiness_queue.poll(&mut events.inner);
-
-        // Return number of polled events
-        Ok(events.inner.len())
-    }
-}
-
-fn validate_args(token: Token) -> io::Result<()> {
-    if token == AWAKEN {
-        return Err(io::Error::new(io::ErrorKind::Other, "invalid token"));
-    }
-
-    Ok(())
-}
-
-impl fmt::Debug for Poll {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("Poll").finish()
-    }
-}
-
-#[cfg(all(unix, not(target_os = "fuchsia")))]
-impl AsRawFd for Poll {
-    fn as_raw_fd(&self) -> RawFd {
-        self.selector.as_raw_fd()
-    }
 }
 
 /// A collection of readiness events.
@@ -1276,7 +1179,7 @@ impl AsRawFd for Poll {
 /// use std::time::Duration;
 ///
 /// let mut events = Events::with_capacity(1024);
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
 ///
 /// assert_eq!(0, events.iter().count());
 ///
@@ -1314,7 +1217,7 @@ pub struct Events {
 /// use std::time::Duration;
 ///
 /// let mut events = Events::with_capacity(1024);
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
 ///
 /// // Register handles with `poll`
 ///
@@ -1352,7 +1255,7 @@ pub struct Iter<'a> {
 /// use std::time::Duration;
 ///
 /// let mut events = Events::with_capacity(1024);
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
 ///
 /// // Register handles with `poll`
 ///
@@ -1432,7 +1335,7 @@ impl Events {
     /// use std::time::Duration;
     ///
     /// let mut events = Events::with_capacity(1024);
-    /// let poll = Poll::new()?;
+    /// let mut poll = Poll::new()?;
     ///
     /// // Register handles with `poll`
     ///
@@ -1466,7 +1369,7 @@ impl Events {
     /// use std::time::Duration;
     ///
     /// let mut events = Events::with_capacity(1024);
-    /// let poll = Poll::new()?;
+    /// let mut poll = Poll::new()?;
     ///
     /// // Register handles with `poll`
     /// for _ in 0..2 {
@@ -1540,8 +1443,8 @@ impl fmt::Debug for Events {
 
 // ===== Accessors for internal usage =====
 
-pub fn selector(poll: &Poll) -> &sys::Selector {
-    &poll.selector
+pub fn selector(register: &Register) -> &sys::Selector {
+    &register.inner.selector
 }
 
 /*
@@ -1553,12 +1456,12 @@ pub fn selector(poll: &Poll) -> &sys::Selector {
 // TODO: get rid of this, windows depends on it for now
 #[allow(dead_code)]
 pub fn new_registration(
-    poll: &Poll,
+    register: &Register,
     token: Token,
     ready: Ready,
     opt: PollOpt,
 ) -> (Registration, SetReadiness) {
-    Registration::new_priv(poll, token, ready, opt)
+    Registration::new_priv(register, token, ready, opt)
 }
 
 impl Registration {
@@ -1576,7 +1479,7 @@ impl Registration {
     /// use mio::{Events, Ready, Registration, Poll, PollOpt, Token};
     /// use std::thread;
     ///
-    /// let (registration, set_readiness) = Registration::new2();
+    /// let (registration, set_readiness) = Registration::new();
     ///
     /// thread::spawn(move || {
     ///     use std::time::Duration;
@@ -1585,8 +1488,14 @@ impl Registration {
     ///     set_readiness.set_readiness(Ready::readable());
     /// });
     ///
-    /// let poll = Poll::new()?;
-    /// poll.register(&registration, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
+    /// let mut poll = Poll::new()?;
+    /// let register = poll.register().clone();
+    ///
+    /// register.register(
+    ///     &registration,
+    ///     Token(0),
+    ///     Ready::readable() | Ready::writable(),
+    ///     PollOpt::edge())?;
     ///
     /// let mut events = Events::with_capacity(256);
     ///
@@ -1608,7 +1517,7 @@ impl Registration {
     /// ```
     /// [struct]: #
     /// [`Poll`]: struct.Poll.html
-    pub fn new2() -> (Registration, SetReadiness) {
+    pub fn new() -> (Registration, SetReadiness) {
         // Allocate the registration node. The new node will have `ref_count`
         // set to 2: one SetReadiness, one Registration.
         let node = Box::into_raw(Box::new(ReadinessNode::new(
@@ -1632,7 +1541,7 @@ impl Registration {
 
     // TODO: Get rid of this (windows depends on it for now)
     fn new_priv(
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opt: PollOpt,
@@ -1643,7 +1552,7 @@ impl Registration {
         is_sync::<SetReadiness>();
 
         // Clone handle to the readiness queue, this bumps the ref count
-        let queue = poll.readiness_queue.inner.clone();
+        let queue = register.inner.readiness_queue.inner.clone();
 
         // Convert to a *mut () pointer
         let queue: *mut () = unsafe { mem::transmute(queue) };
@@ -1667,27 +1576,27 @@ impl Registration {
 impl Evented for Registration {
     fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.inner.update(poll, token, interest, opts)
+        self.inner.update(register, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.inner.update(poll, token, interest, opts)
+        self.inner.update(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
+    fn deregister(&self, register: &Register) -> io::Result<()> {
         self.inner
-            .update(poll, Token(0), Ready::empty(), PollOpt::empty())
+            .update(register, Token(0), Ready::empty(), PollOpt::empty())
     }
 }
 
@@ -1725,7 +1634,7 @@ impl SetReadiness {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// use mio::{Registration, Ready};
     ///
-    /// let (registration, set_readiness) = Registration::new2();
+    /// let (registration, set_readiness) = Registration::new();
     ///
     /// assert!(set_readiness.readiness().is_empty());
     ///
@@ -1765,13 +1674,14 @@ impl SetReadiness {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// use mio::{Events, Registration, Ready, Poll, PollOpt, Token};
     ///
-    /// let poll = Poll::new()?;
-    /// let (registration, set_readiness) = Registration::new2();
+    /// let mut poll = Poll::new()?;
+    /// let register = poll.register().clone();
+    /// let (registration, set_readiness) = Registration::new();
     ///
-    /// poll.register(&registration,
-    ///               Token(0),
-    ///               Ready::readable(),
-    ///               PollOpt::edge())?;
+    /// register.register(&registration,
+    ///                   Token(0),
+    ///                   Ready::readable(),
+    ///                   PollOpt::edge())?;
     ///
     /// // Set the readiness, then immediately poll to try to get the readiness
     /// // event
@@ -1803,7 +1713,7 @@ impl SetReadiness {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// use mio::{Registration, Ready};
     ///
-    /// let (registration, set_readiness) = Registration::new2();
+    /// let (registration, set_readiness) = Registration::new();
     ///
     /// assert!(set_readiness.readiness().is_empty());
     ///
@@ -1883,15 +1793,22 @@ impl RegistrationInner {
     }
 
     /// Update the registration details associated with the node
-    fn update(&self, poll: &Poll, token: Token, interest: Ready, opt: PollOpt) -> io::Result<()> {
-        // First, ensure poll instances match
+    fn update(
+        &self,
+        register: &Register,
+        token: Token,
+        interest: Ready,
+        opt: PollOpt,
+    ) -> io::Result<()> {
+        // First, ensure register instances match
         //
         // Load the queue pointer, `Relaxed` is sufficient here as only the
         // pointer is being operated on. The actual memory is guaranteed to be
-        // visible the `poll: &Poll` ref passed as an argument to the function.
+        // visible the `register: &Register` ref passed as an argument to the
+        // function.
         let mut queue = self.readiness_queue.load(Relaxed);
         let other: &*mut () =
-            unsafe { &*(&poll.readiness_queue.inner as *const _ as *const *mut ()) };
+            unsafe { &*(&register.inner.readiness_queue.inner as *const _ as *const *mut ()) };
         let other = *other;
 
         debug_assert!(mem::size_of::<Arc<ReadinessQueueInner>>() == mem::size_of::<*mut ()>());
@@ -1903,7 +1820,7 @@ impl RegistrationInner {
 
             if actual.is_null() {
                 // The CAS succeeded, this means that the node's ref count
-                // should be incremented to reflect that the `poll` function
+                // should be incremented to reflect that the `register` function
                 // effectively owns the node as well.
                 //
                 // `Relaxed` ordering used for the same reason as in
@@ -1918,7 +1835,7 @@ impl RegistrationInner {
                 // Down below in `release_node` when we deallocate this
                 // `RegistrationInner` is where we'll transmute this back to an
                 // arc and decrement the reference count.
-                mem::forget(poll.readiness_queue.clone());
+                mem::forget(register.inner.readiness_queue.clone());
             } else {
                 // The CAS failed, another thread set the queue pointer, so ensure
                 // that the pointer and `other` match
@@ -1939,7 +1856,7 @@ impl RegistrationInner {
         }
 
         unsafe {
-            let actual = &poll.readiness_queue.inner as *const _ as *const usize;
+            let actual = &register.inner.readiness_queue.inner as *const _ as *const usize;
             debug_assert_eq!(queue as usize, *actual);
         }
 
@@ -2779,16 +2696,17 @@ impl SelectorId {
         }
     }
 
-    pub fn associate_selector(&self, poll: &Poll) -> io::Result<()> {
+    pub fn associate_selector(&self, register: &Register) -> io::Result<()> {
         let selector_id = self.id.load(Ordering::SeqCst);
 
-        if selector_id != 0 && selector_id != poll.selector.id() {
+        if selector_id != 0 && selector_id != register.inner.selector.id() {
             Err(io::Error::new(
                 io::ErrorKind::Other,
                 "socket already registered",
             ))
         } else {
-            self.id.store(poll.selector.id(), Ordering::SeqCst);
+            self.id
+                .store(register.inner.selector.id(), Ordering::SeqCst);
             Ok(())
         }
     }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -869,7 +869,7 @@ impl fmt::Debug for Poll {
 
 impl fmt::Debug for Register {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("Poll").finish()
+        fmt.debug_struct("Register").finish()
     }
 }
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1587,7 +1587,8 @@ impl Evented for Registration {
         interests: Interests,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.inner.update(registry, token, interests.to_ready(), opts)
+        self.inner
+            .update(registry, token, interests.to_ready(), opts)
     }
 
     fn reregister(
@@ -1597,7 +1598,8 @@ impl Evented for Registration {
         interests: Interests,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.inner.update(registry, token, interests.to_ready(), opts)
+        self.inner
+            .update(registry, token, interests.to_ready(), opts)
     }
 
     fn deregister(&self, registry: &Registry) -> io::Result<()> {

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -100,14 +100,14 @@ use {sys, Token};
 ///
 /// // Construct a new `Poll` handle as well as the `Events` we'll store into
 /// let mut poll = Poll::new()?;
-/// let register = poll.register().clone();
+/// let registry = poll.registry().clone();
 /// let mut events = Events::with_capacity(1024);
 ///
 /// // Connect the stream
 /// let stream = TcpStream::connect(&server.local_addr()?)?;
 ///
 /// // Register the stream with `Poll`
-/// register.register(&stream, Token(0), Interests::readable() | Interests::writable(), PollOpt::edge())?;
+/// registry.register(&stream, Token(0), Interests::readable() | Interests::writable(), PollOpt::edge())?;
 ///
 /// // Wait for the socket to become ready. This has to happens in a loop to
 /// // handle spurious wakeups.
@@ -277,11 +277,11 @@ use {sys, Token};
 /// thread::sleep(Duration::from_secs(1));
 ///
 /// let mut poll = Poll::new()?;
-/// let register = poll.register().clone();
+/// let registry = poll.registry().clone();
 ///
 /// // The connect is not guaranteed to have started until it is registered at
 /// // this point
-/// register.register(&sock, Token(0), Interests::readable() | Interests::writable(), PollOpt::edge())?;
+/// registry.register(&sock, Token(0), Interests::readable() | Interests::writable(), PollOpt::edge())?;
 /// #     Ok(())
 /// # }
 /// #
@@ -374,7 +374,7 @@ struct Inner {
 /// # Examples
 ///
 /// ```
-/// use mio::{Ready, Interests, Registration, Register, Poll, PollOpt, Token};
+/// use mio::{Ready, Interests, Registration, Registry, Poll, PollOpt, Token};
 /// use mio::event::Evented;
 ///
 /// use std::io;
@@ -412,20 +412,20 @@ struct Inner {
 /// }
 ///
 /// impl Evented for Deadline {
-///     fn register(&self, register: &Register, token: Token, interests: Interests, opts: PollOpt)
+///     fn register(&self, registry: &Registry, token: Token, interests: Interests, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         self.registration.register(register, token, interests, opts)
+///         self.registration.register(registry, token, interests, opts)
 ///     }
 ///
-///     fn reregister(&self, register: &Register, token: Token, interests: Interests, opts: PollOpt)
+///     fn reregister(&self, registry: &Registry, token: Token, interests: Interests, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         self.registration.reregister(register, token, interests, opts)
+///         self.registration.reregister(registry, token, interests, opts)
 ///     }
 ///
-///     fn deregister(&self, register: &Register) -> io::Result<()> {
-///         register.deregister(&self.registration)
+///     fn deregister(&self, registry: &Registry) -> io::Result<()> {
+///         registry.deregister(&self.registration)
 ///     }
 /// }
 /// ```
@@ -435,9 +435,9 @@ struct Inner {
 /// [`Registration::new`]: struct.Registration.html#method.new
 /// [`Evented`]: event/trait.Evented.html
 /// [`set_readiness`]: struct.SetReadiness.html#method.set_readiness
-/// [`register`]: struct.Poll.html#method.register
-/// [`reregister`]: struct.Poll.html#method.reregister
-/// [`deregister`]: struct.Poll.html#method.deregister
+/// [`register`]: struct.Registry.html#method.register
+/// [`reregister`]: struct.Registry.html#method.reregister
+/// [`deregister`]: struct.Registry.html#method.deregister
 /// [portability]: struct.Poll.html#portability
 pub struct Registration {
     inner: RegistrationInner,
@@ -1489,7 +1489,7 @@ impl Registration {
     /// });
     ///
     /// let mut poll = Poll::new()?;
-    /// let registry = poll.register().clone();
+    /// let registry = poll.registry().clone();
     ///
     /// registry.register(
     ///     &registration,

--- a/src/sys/unix/awakener.rs
+++ b/src/sys/unix/awakener.rs
@@ -5,7 +5,7 @@ mod pipe {
     use event::Evented;
     use std::io::{Read, Write};
     use sys::unix;
-    use {io, PollOpt, Interests, Registry, Token};
+    use {io, Interests, PollOpt, Registry, Token};
 
     /*
      *

--- a/src/sys/unix/awakener.rs
+++ b/src/sys/unix/awakener.rs
@@ -5,7 +5,7 @@ mod pipe {
     use event::Evented;
     use std::io::{Read, Write};
     use sys::unix;
-    use {io, PollOpt, Ready, Register, Token};
+    use {io, PollOpt, Ready, Registry, Token};
 
     /*
      *
@@ -61,26 +61,26 @@ mod pipe {
     impl Evented for Awakener {
         fn register(
             &self,
-            register: &Register,
+            registry: &Registry,
             token: Token,
             interest: Ready,
             opts: PollOpt,
         ) -> io::Result<()> {
-            self.reader().register(register, token, interest, opts)
+            self.reader().register(registry, token, interest, opts)
         }
 
         fn reregister(
             &self,
-            register: &Register,
+            registry: &Registry,
             token: Token,
             interest: Ready,
             opts: PollOpt,
         ) -> io::Result<()> {
-            self.reader().reregister(register, token, interest, opts)
+            self.reader().reregister(registry, token, interest, opts)
         }
 
-        fn deregister(&self, register: &Register) -> io::Result<()> {
-            self.reader().deregister(register)
+        fn deregister(&self, registry: &Registry) -> io::Result<()> {
+            self.reader().deregister(registry)
         }
     }
 }

--- a/src/sys/unix/awakener.rs
+++ b/src/sys/unix/awakener.rs
@@ -5,7 +5,7 @@ mod pipe {
     use event::Evented;
     use std::io::{Read, Write};
     use sys::unix;
-    use {io, Poll, PollOpt, Ready, Token};
+    use {io, PollOpt, Ready, Register, Token};
 
     /*
      *
@@ -61,26 +61,26 @@ mod pipe {
     impl Evented for Awakener {
         fn register(
             &self,
-            poll: &Poll,
+            register: &Register,
             token: Token,
             interest: Ready,
             opts: PollOpt,
         ) -> io::Result<()> {
-            self.reader().register(poll, token, interest, opts)
+            self.reader().register(register, token, interest, opts)
         }
 
         fn reregister(
             &self,
-            poll: &Poll,
+            register: &Register,
             token: Token,
             interest: Ready,
             opts: PollOpt,
         ) -> io::Result<()> {
-            self.reader().reregister(poll, token, interest, opts)
+            self.reader().reregister(register, token, interest, opts)
         }
 
-        fn deregister(&self, poll: &Poll) -> io::Result<()> {
-            self.reader().deregister(poll)
+        fn deregister(&self, register: &Register) -> io::Result<()> {
+            self.reader().deregister(register)
         }
     }
 }

--- a/src/sys/unix/eventedfd.rs
+++ b/src/sys/unix/eventedfd.rs
@@ -1,6 +1,6 @@
 use event::Evented;
 use std::os::unix::io::RawFd;
-use {io, poll, PollOpt, Interests, Registry, Token};
+use {io, poll, Interests, PollOpt, Registry, Token};
 
 /*
  *

--- a/src/sys/unix/eventedfd.rs
+++ b/src/sys/unix/eventedfd.rs
@@ -1,6 +1,6 @@
 use event::Evented;
 use std::os::unix::io::RawFd;
-use {io, poll, PollOpt, Ready, Register, Token};
+use {io, poll, PollOpt, Ready, Registry, Token};
 
 /*
  *
@@ -41,10 +41,10 @@ use {io, poll, PollOpt, Ready, Register, Token};
 /// let listener = TcpListener::bind("127.0.0.1:0")?;
 ///
 /// let mut poll = Poll::new()?;
-/// let register = poll.register().clone();
+/// let registry = poll.registry().clone();
 ///
 /// // Register the listener
-/// register.register(
+/// registry.register(
 ///     &EventedFd(&listener.as_raw_fd()),
 ///     Token(0),
 ///     Ready::readable(),
@@ -60,7 +60,7 @@ use {io, poll, PollOpt, Ready, Register, Token};
 /// Implementing [`Evented`] for a custom type backed by a [`RawFd`].
 ///
 /// ```
-/// use mio::{Ready, Register, PollOpt, Token};
+/// use mio::{Ready, Registry, PollOpt, Token};
 /// use mio::event::Evented;
 /// use mio::unix::EventedFd;
 ///
@@ -72,20 +72,20 @@ use {io, poll, PollOpt, Ready, Register, Token};
 /// }
 ///
 /// impl Evented for MyIo {
-///     fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
+///     fn register(&self, registry: &Registry, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         EventedFd(&self.fd).register(register, token, interest, opts)
+///         EventedFd(&self.fd).register(registry, token, interest, opts)
 ///     }
 ///
-///     fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
+///     fn reregister(&self, registry: &Registry, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         EventedFd(&self.fd).reregister(register, token, interest, opts)
+///         EventedFd(&self.fd).reregister(registry, token, interest, opts)
 ///     }
 ///
-///     fn deregister(&self, register: &Register) -> io::Result<()> {
-///         EventedFd(&self.fd).deregister(register)
+///     fn deregister(&self, registry: &Registry) -> io::Result<()> {
+///         EventedFd(&self.fd).deregister(registry)
 ///     }
 /// }
 /// ```
@@ -99,25 +99,25 @@ pub struct EventedFd<'a>(pub &'a RawFd);
 impl<'a> Evented for EventedFd<'a> {
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        poll::selector(register).register(*self.0, token, interest, opts)
+        poll::selector(registry).register(*self.0, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        poll::selector(register).reregister(*self.0, token, interest, opts)
+        poll::selector(registry).reregister(*self.0, token, interest, opts)
     }
 
-    fn deregister(&self, register: &Register) -> io::Result<()> {
-        poll::selector(register).deregister(*self.0)
+    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+        poll::selector(registry).deregister(*self.0)
     }
 }

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -7,7 +7,7 @@ use libc;
 use event::Evented;
 use sys::unix::cvt;
 use unix::EventedFd;
-use {io, PollOpt, Ready, Register, Token};
+use {io, PollOpt, Ready, Registry, Token};
 
 pub fn set_nonblock(fd: libc::c_int) -> io::Result<()> {
     unsafe {
@@ -67,26 +67,26 @@ impl AsRawFd for Io {
 impl Evented for Io {
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).register(register, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).register(registry, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).reregister(register, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).reregister(registry, token, interest, opts)
     }
 
-    fn deregister(&self, register: &Register) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).deregister(register)
+    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).deregister(registry)
     }
 }
 

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -7,7 +7,7 @@ use libc;
 use event::Evented;
 use sys::unix::cvt;
 use unix::EventedFd;
-use {io, PollOpt, Interests, Registry, Token};
+use {io, Interests, PollOpt, Registry, Token};
 
 pub fn set_nonblock(fd: libc::c_int) -> io::Result<()> {
     unsafe {

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -7,7 +7,7 @@ use libc;
 use event::Evented;
 use sys::unix::cvt;
 use unix::EventedFd;
-use {io, Poll, PollOpt, Ready, Token};
+use {io, PollOpt, Ready, Register, Token};
 
 pub fn set_nonblock(fd: libc::c_int) -> io::Result<()> {
     unsafe {
@@ -67,26 +67,26 @@ impl AsRawFd for Io {
 impl Evented for Io {
     fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).register(poll, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).register(register, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).reregister(poll, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).deregister(register)
     }
 }
 

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -393,7 +393,7 @@ fn does_not_register_rw() {
 
     // registering kqueue fd will fail if write is requested (On anything but some versions of OS
     // X)
-    poll.register()
+    poll.registry()
         .register(
             &kqf,
             Token(1234),

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -393,13 +393,14 @@ fn does_not_register_rw() {
 
     // registering kqueue fd will fail if write is requested (On anything but some versions of OS
     // X)
-    poll.register(
-        &kqf,
-        Token(1234),
-        Ready::readable(),
-        PollOpt::edge() | PollOpt::oneshot(),
-    )
-    .unwrap();
+    poll.register()
+        .register(
+            &kqf,
+            Token(1234),
+            Ready::readable(),
+            PollOpt::edge() | PollOpt::oneshot(),
+        )
+        .unwrap();
 }
 
 #[cfg(any(

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -73,12 +73,13 @@ use std::ops;
 /// let addr = "216.58.193.68:80".parse()?;
 /// let socket = TcpStream::connect(&addr)?;
 ///
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
+/// let register = poll.register().clone();
 ///
-/// poll.register(&socket,
-///               Token(0),
-///               Ready::readable() | UnixReady::error(),
-///               PollOpt::edge())?;
+/// register.register(&socket,
+///                   Token(0),
+///                   Ready::readable() | UnixReady::error(),
+///                   PollOpt::edge())?;
 /// #     Ok(())
 /// # }
 /// #

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -73,9 +73,9 @@ use std::ops;
 /// let socket = TcpStream::connect(&addr)?;
 ///
 /// let mut poll = Poll::new()?;
-/// let register = poll.register().clone();
+/// let registry = poll.registry().clone();
 ///
-/// register.register(&socket,
+/// registry.register(&socket,
 ///                   Token(0),
 ///                   Interests::readable(),
 ///                   PollOpt::edge())?;

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -9,7 +9,7 @@ use libc;
 use net2::TcpStreamExt;
 
 use event::Evented;
-use {io, PollOpt, Ready, Register, Token};
+use {io, PollOpt, Ready, Registry, Token};
 
 use sys::unix::eventedfd::EventedFd;
 use sys::unix::io::set_nonblock;
@@ -148,26 +148,26 @@ impl<'a> Write for &'a TcpStream {
 impl Evented for TcpStream {
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).register(register, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).register(registry, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).reregister(register, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).reregister(registry, token, interest, opts)
     }
 
-    fn deregister(&self, register: &Register) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).deregister(register)
+    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).deregister(registry)
     }
 }
 
@@ -231,26 +231,26 @@ impl TcpListener {
 impl Evented for TcpListener {
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).register(register, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).register(registry, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).reregister(register, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).reregister(registry, token, interest, opts)
     }
 
-    fn deregister(&self, register: &Register) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).deregister(register)
+    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).deregister(registry)
     }
 }
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -9,7 +9,7 @@ use libc;
 use net2::TcpStreamExt;
 
 use event::Evented;
-use {io, Poll, PollOpt, Ready, Token};
+use {io, PollOpt, Ready, Register, Token};
 
 use sys::unix::eventedfd::EventedFd;
 use sys::unix::io::set_nonblock;
@@ -148,26 +148,26 @@ impl<'a> Write for &'a TcpStream {
 impl Evented for TcpStream {
     fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).register(poll, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).register(register, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).reregister(poll, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).deregister(register)
     }
 }
 
@@ -231,26 +231,26 @@ impl TcpListener {
 impl Evented for TcpListener {
     fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).register(poll, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).register(register, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).reregister(poll, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).deregister(register)
     }
 }
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -9,7 +9,7 @@ use libc;
 use net2::TcpStreamExt;
 
 use event::Evented;
-use {io, PollOpt, Interests, Registry, Token};
+use {io, Interests, PollOpt, Registry, Token};
 
 use sys::unix::eventedfd::EventedFd;
 use sys::unix::io::set_nonblock;

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -4,7 +4,7 @@ use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use sys::unix::uio::VecIo;
 use unix::EventedFd;
-use {io, Poll, PollOpt, Ready, Token};
+use {io, PollOpt, Ready, Register, Token};
 
 use iovec::IoVec;
 #[allow(unused_imports)] // only here for Rust 1.8
@@ -128,26 +128,26 @@ impl UdpSocket {
 impl Evented for UdpSocket {
     fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).register(poll, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).register(register, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).reregister(poll, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).deregister(register)
     }
 }
 

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -5,7 +5,7 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use sys::unix::uio::VecIo;
 use unix::EventedFd;
-use {io, PollOpt, Interests, Registry, Token};
+use {io, Interests, PollOpt, Registry, Token};
 
 use iovec::IoVec;
 #[allow(unused_imports)] // only here for Rust 1.8

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -4,7 +4,7 @@ use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use sys::unix::uio::VecIo;
 use unix::EventedFd;
-use {io, PollOpt, Ready, Register, Token};
+use {io, PollOpt, Ready, Registry, Token};
 
 use iovec::IoVec;
 #[allow(unused_imports)] // only here for Rust 1.8
@@ -128,26 +128,26 @@ impl UdpSocket {
 impl Evented for UdpSocket {
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).register(register, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).register(registry, token, interest, opts)
     }
 
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).reregister(register, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).reregister(registry, token, interest, opts)
     }
 
-    fn deregister(&self, register: &Register) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).deregister(register)
+    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).deregister(registry)
     }
 }
 

--- a/src/sys/windows/awakener.rs
+++ b/src/sys/windows/awakener.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 use event::Evented;
 use miow::iocp::CompletionStatus;
 use sys::windows::Selector;
-use {io, poll, PollOpt, Interests, Registry, Token};
+use {io, poll, Interests, PollOpt, Registry, Token};
 
 pub struct Awakener {
     inner: Mutex<Option<AwakenerInner>>,

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -16,7 +16,7 @@ use event::Evented;
 use sys::windows::from_raw_arc::FromRawArc;
 use sys::windows::selector::{Overlapped, ReadyBinding};
 use sys::windows::Family;
-use {poll, Poll, PollOpt, Ready, Token};
+use {poll, PollOpt, Ready, Register, Token};
 
 pub struct TcpStream {
     /// Separately stored implementation to ensure that the `Drop`
@@ -578,7 +578,7 @@ fn write_done(status: &OVERLAPPED_ENTRY) {
 impl Evented for TcpStream {
     fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
@@ -586,7 +586,7 @@ impl Evented for TcpStream {
         let mut me = self.inner();
         me.iocp.register_socket(
             &self.imp.inner.socket,
-            poll,
+            register,
             token,
             interest,
             opts,
@@ -611,7 +611,7 @@ impl Evented for TcpStream {
 
     fn reregister(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
@@ -619,7 +619,7 @@ impl Evented for TcpStream {
         let mut me = self.inner();
         me.iocp.reregister_socket(
             &self.imp.inner.socket,
-            poll,
+            register,
             token,
             interest,
             opts,
@@ -629,10 +629,10 @@ impl Evented for TcpStream {
         Ok(())
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
+    fn deregister(&self, register: &Register) -> io::Result<()> {
         self.inner()
             .iocp
-            .deregister(&self.imp.inner.socket, poll, &self.registration)
+            .deregister(&self.imp.inner.socket, register, &self.registration)
     }
 }
 
@@ -816,7 +816,7 @@ fn accept_done(status: &OVERLAPPED_ENTRY) {
 impl Evented for TcpListener {
     fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
@@ -824,7 +824,7 @@ impl Evented for TcpListener {
         let mut me = self.inner();
         me.iocp.register_socket(
             &self.imp.inner.socket,
-            poll,
+            register,
             token,
             interest,
             opts,
@@ -842,7 +842,7 @@ impl Evented for TcpListener {
 
     fn reregister(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
@@ -850,7 +850,7 @@ impl Evented for TcpListener {
         let mut me = self.inner();
         me.iocp.reregister_socket(
             &self.imp.inner.socket,
-            poll,
+            register,
             token,
             interest,
             opts,
@@ -860,10 +860,10 @@ impl Evented for TcpListener {
         Ok(())
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
+    fn deregister(&self, register: &Register) -> io::Result<()> {
         self.inner()
             .iocp
-            .deregister(&self.imp.inner.socket, poll, &self.registration)
+            .deregister(&self.imp.inner.socket, register, &self.registration)
     }
 }
 

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -16,7 +16,7 @@ use event::Evented;
 use sys::windows::from_raw_arc::FromRawArc;
 use sys::windows::selector::{Overlapped, ReadyBinding};
 use sys::windows::Family;
-use {poll, PollOpt, Ready, Register, Token};
+use {poll, PollOpt, Ready, Registry, Token};
 
 pub struct TcpStream {
     /// Separately stored implementation to ensure that the `Drop`
@@ -578,7 +578,7 @@ fn write_done(status: &OVERLAPPED_ENTRY) {
 impl Evented for TcpStream {
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
@@ -586,7 +586,7 @@ impl Evented for TcpStream {
         let mut me = self.inner();
         me.iocp.register_socket(
             &self.imp.inner.socket,
-            register,
+            registry,
             token,
             interest,
             opts,
@@ -611,7 +611,7 @@ impl Evented for TcpStream {
 
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
@@ -619,7 +619,7 @@ impl Evented for TcpStream {
         let mut me = self.inner();
         me.iocp.reregister_socket(
             &self.imp.inner.socket,
-            register,
+            registry,
             token,
             interest,
             opts,
@@ -629,10 +629,10 @@ impl Evented for TcpStream {
         Ok(())
     }
 
-    fn deregister(&self, register: &Register) -> io::Result<()> {
+    fn deregister(&self, registry: &Registry) -> io::Result<()> {
         self.inner()
             .iocp
-            .deregister(&self.imp.inner.socket, register, &self.registration)
+            .deregister(&self.imp.inner.socket, registry, &self.registration)
     }
 }
 
@@ -816,7 +816,7 @@ fn accept_done(status: &OVERLAPPED_ENTRY) {
 impl Evented for TcpListener {
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
@@ -824,7 +824,7 @@ impl Evented for TcpListener {
         let mut me = self.inner();
         me.iocp.register_socket(
             &self.imp.inner.socket,
-            register,
+            registry,
             token,
             interest,
             opts,
@@ -842,7 +842,7 @@ impl Evented for TcpListener {
 
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
@@ -850,7 +850,7 @@ impl Evented for TcpListener {
         let mut me = self.inner();
         me.iocp.reregister_socket(
             &self.imp.inner.socket,
-            register,
+            registry,
             token,
             interest,
             opts,
@@ -860,10 +860,10 @@ impl Evented for TcpListener {
         Ok(())
     }
 
-    fn deregister(&self, register: &Register) -> io::Result<()> {
+    fn deregister(&self, registry: &Registry) -> io::Result<()> {
         self.inner()
             .iocp
-            .deregister(&self.imp.inner.socket, register, &self.registration)
+            .deregister(&self.imp.inner.socket, registry, &self.registration)
     }
 }
 

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -20,7 +20,7 @@ use winapi::*;
 use event::Evented;
 use sys::windows::from_raw_arc::FromRawArc;
 use sys::windows::selector::{Overlapped, ReadyBinding};
-use {poll, PollOpt, Ready, Register, Token};
+use {poll, PollOpt, Ready, Registry, Token};
 
 pub struct UdpSocket {
     imp: Imp,
@@ -346,7 +346,7 @@ impl Imp {
 impl Evented for UdpSocket {
     fn register(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
@@ -354,7 +354,7 @@ impl Evented for UdpSocket {
         let mut me = self.inner();
         me.iocp.register_socket(
             &self.imp.inner.socket,
-            register,
+            registry,
             token,
             interest,
             opts,
@@ -366,7 +366,7 @@ impl Evented for UdpSocket {
 
     fn reregister(
         &self,
-        register: &Register,
+        registry: &Registry,
         token: Token,
         interest: Ready,
         opts: PollOpt,
@@ -374,7 +374,7 @@ impl Evented for UdpSocket {
         let mut me = self.inner();
         me.iocp.reregister_socket(
             &self.imp.inner.socket,
-            register,
+            registry,
             token,
             interest,
             opts,
@@ -384,10 +384,10 @@ impl Evented for UdpSocket {
         Ok(())
     }
 
-    fn deregister(&self, register: &Register) -> io::Result<()> {
+    fn deregister(&self, registry: &Registry) -> io::Result<()> {
         self.inner()
             .iocp
-            .deregister(&self.imp.inner.socket, register, &self.registration)
+            .deregister(&self.imp.inner.socket, registry, &self.registration)
     }
 }
 

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -20,7 +20,7 @@ use winapi::*;
 use event::Evented;
 use sys::windows::from_raw_arc::FromRawArc;
 use sys::windows::selector::{Overlapped, ReadyBinding};
-use {poll, Poll, PollOpt, Ready, Token};
+use {poll, PollOpt, Ready, Register, Token};
 
 pub struct UdpSocket {
     imp: Imp,
@@ -346,7 +346,7 @@ impl Imp {
 impl Evented for UdpSocket {
     fn register(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
@@ -354,7 +354,7 @@ impl Evented for UdpSocket {
         let mut me = self.inner();
         me.iocp.register_socket(
             &self.imp.inner.socket,
-            poll,
+            register,
             token,
             interest,
             opts,
@@ -366,7 +366,7 @@ impl Evented for UdpSocket {
 
     fn reregister(
         &self,
-        poll: &Poll,
+        register: &Register,
         token: Token,
         interest: Ready,
         opts: PollOpt,
@@ -374,7 +374,7 @@ impl Evented for UdpSocket {
         let mut me = self.inner();
         me.iocp.reregister_socket(
             &self.imp.inner.socket,
-            poll,
+            register,
             token,
             interest,
             opts,
@@ -384,10 +384,10 @@ impl Evented for UdpSocket {
         Ok(())
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
+    fn deregister(&self, register: &Register) -> io::Result<()> {
         self.inner()
             .iocp
-            .deregister(&self.imp.inner.socket, poll, &self.registration)
+            .deregister(&self.imp.inner.socket, register, &self.registration)
     }
 }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -34,16 +34,17 @@
 /// let mut next_socket_index = 0;
 ///
 /// // The `Poll` instance
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
+/// let register = poll.register().clone();
 ///
 /// // Tcp listener
 /// let listener = TcpListener::bind(&"127.0.0.1:0".parse()?)?;
 ///
 /// // Register the listener
-/// poll.register(&listener,
-///               LISTENER,
-///               Ready::readable(),
-///               PollOpt::edge())?;
+/// register.register(&listener,
+///                   LISTENER,
+///                   Ready::readable(),
+///                   PollOpt::edge())?;
 ///
 /// // Spawn a thread that will connect a bunch of sockets then close them
 /// let addr = listener.local_addr()?;
@@ -86,10 +87,10 @@
 ///                             next_socket_index += 1;
 ///
 ///                             // Register the new socket w/ poll
-///                             poll.register(&socket,
-///                                          token,
-///                                          Ready::readable(),
-///                                          PollOpt::edge())?;
+///                             register.register(&socket,
+///                                               token,
+///                                               Ready::readable(),
+///                                               PollOpt::edge())?;
 ///
 ///                             // Store the socket
 ///                             sockets.insert(token, socket);

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,7 +1,7 @@
 /// Associates readiness notifications with [`Evented`] handles.
 ///
 /// `Token` is a wrapper around `usize` and is used as an argument to
-/// [`Poll::register`] and [`Poll::reregister`].
+/// [`Registry::register`] and [`Registry::reregister`].
 ///
 /// See [`Poll`] for more documentation on polling.
 ///
@@ -35,13 +35,13 @@
 ///
 /// // The `Poll` instance
 /// let mut poll = Poll::new()?;
-/// let register = poll.register().clone();
+/// let registry = poll.registry().clone();
 ///
 /// // Tcp listener
 /// let listener = TcpListener::bind(&"127.0.0.1:0".parse()?)?;
 ///
 /// // Register the listener
-/// register.register(&listener,
+/// registry.register(&listener,
 ///                   LISTENER,
 ///                   Interests::readable(),
 ///                   PollOpt::edge())?;
@@ -87,7 +87,7 @@
 ///                             next_socket_index += 1;
 ///
 ///                             // Register the new socket w/ poll
-///                             register.register(&socket,
+///                             registry.register(&socket,
 ///                                               token,
 ///                                               Interests::readable(),
 ///                                               PollOpt::edge())?;
@@ -135,8 +135,8 @@
 ///
 /// [`Evented`]: event/trait.Evented.html
 /// [`Poll`]: struct.Poll.html
-/// [`Poll::register`]: struct.Poll.html#method.register
-/// [`Poll::reregister`]: struct.Poll.html#method.reregister
+/// [`Registry::register`]: struct.Registry.html#method.register
+/// [`Registry::reregister`]: struct.Registry.html#method.reregister
 /// [`slab`]: https://crates.io/crates/slab
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Token(pub usize);

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -189,7 +189,7 @@ pub fn sleep_ms(ms: u64) {
 }
 
 pub fn expect_events(
-    poll: &Poll,
+    poll: &mut Poll,
     event_buffer: &mut Events,
     poll_try_count: usize,
     mut expected: Vec<Event>,

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -61,7 +61,8 @@ impl TestHandler {
             }
             _ => panic!("received unknown token {:?}", tok),
         }
-        poll.reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::edge())
+        poll.register()
+            .reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::edge())
             .unwrap();
     }
 
@@ -70,7 +71,8 @@ impl TestHandler {
             SERVER => panic!("received writable for token 0"),
             CLIENT => {
                 debug!("client connected");
-                poll.reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::edge())
+                poll.register()
+                    .reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::edge())
                     .unwrap();
             }
             _ => panic!("received unknown token {:?}", tok),
@@ -90,13 +92,15 @@ pub fn test_close_on_drop() {
     // == Create & setup server socket
     let srv = TcpListener::bind(&addr).unwrap();
 
-    poll.register(&srv, SERVER, Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&srv, SERVER, Ready::readable(), PollOpt::edge())
         .unwrap();
 
     // == Create & setup client socket
     let sock = TcpStream::connect(&addr).unwrap();
 
-    poll.register(&sock, CLIENT, Ready::writable(), PollOpt::edge())
+    poll.register()
+        .register(&sock, CLIENT, Ready::writable(), PollOpt::edge())
         .unwrap();
 
     // == Create storage for events

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -61,7 +61,7 @@ impl TestHandler {
             }
             _ => panic!("received unknown token {:?}", tok),
         }
-        poll.register()
+        poll.registry()
             .reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::edge())
             .unwrap();
     }
@@ -71,7 +71,7 @@ impl TestHandler {
             SERVER => panic!("received writable for token 0"),
             CLIENT => {
                 debug!("client connected");
-                poll.register()
+                poll.registry()
                     .reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::edge())
                     .unwrap();
             }
@@ -92,14 +92,14 @@ pub fn test_close_on_drop() {
     // == Create & setup server socket
     let srv = TcpListener::bind(&addr).unwrap();
 
-    poll.register()
+    poll.registry()
         .register(&srv, SERVER, Ready::readable(), PollOpt::edge())
         .unwrap();
 
     // == Create & setup client socket
     let sock = TcpStream::connect(&addr).unwrap();
 
-    poll.register()
+    poll.registry()
         .register(&sock, CLIENT, Ready::writable(), PollOpt::edge())
         .unwrap();
 

--- a/test/test_custom_evented.rs
+++ b/test/test_custom_evented.rs
@@ -4,12 +4,17 @@ use std::time::Duration;
 
 #[test]
 fn smoke() {
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(128);
 
-    let (r, set) = Registration::new2();
-    r.register(&poll, Token(0), Ready::readable(), PollOpt::edge())
-        .unwrap();
+    let (r, set) = Registration::new();
+    r.register(
+        poll.register(),
+        Token(0),
+        Ready::readable(),
+        PollOpt::edge(),
+    )
+    .unwrap();
 
     let n = poll
         .poll(&mut events, Some(Duration::from_millis(0)))
@@ -31,11 +36,11 @@ fn set_readiness_before_register() {
     use std::sync::{Arc, Barrier};
     use std::thread;
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(128);
 
     for _ in 0..5_000 {
-        let (r, set) = Registration::new2();
+        let (r, set) = Registration::new();
 
         let b1 = Arc::new(Barrier::new(2));
         let b2 = b1.clone();
@@ -52,7 +57,8 @@ fn set_readiness_before_register() {
         b1.wait();
 
         // now register
-        poll.register(&r, Token(123), Ready::readable(), PollOpt::edge())
+        poll.register()
+            .register(&r, Token(123), Ready::readable(), PollOpt::edge())
             .unwrap();
 
         loop {
@@ -90,14 +96,19 @@ mod stress {
         const NUM_REGISTRATIONS: usize = 128;
 
         for _ in 0..NUM_ATTEMPTS {
-            let poll = Poll::new().unwrap();
+            let mut poll = Poll::new().unwrap();
             let mut events = Events::with_capacity(NUM_REGISTRATIONS);
 
             let registrations: Vec<_> = (0..NUM_REGISTRATIONS)
                 .map(|i| {
-                    let (r, s) = Registration::new2();
-                    r.register(&poll, Token(i), Ready::readable(), PollOpt::edge())
-                        .unwrap();
+                    let (r, s) = Registration::new();
+                    r.register(
+                        poll.register(),
+                        Token(i),
+                        Ready::readable(),
+                        PollOpt::edge(),
+                    )
+                    .unwrap();
                     (r, s)
                 })
                 .collect();
@@ -136,8 +147,13 @@ mod stress {
             while remaining.load(Acquire) > 0 {
                 // Set interest
                 for (i, &(ref r, _)) in registrations.iter().enumerate() {
-                    r.reregister(&poll, Token(i), Ready::writable(), PollOpt::edge())
-                        .unwrap();
+                    r.reregister(
+                        poll.register(),
+                        Token(i),
+                        Ready::writable(),
+                        PollOpt::edge(),
+                    )
+                    .unwrap();
                 }
 
                 poll.poll(&mut events, Some(Duration::from_millis(0)))
@@ -150,8 +166,13 @@ mod stress {
                 // Update registration
                 // Set interest
                 for (i, &(ref r, _)) in registrations.iter().enumerate() {
-                    r.reregister(&poll, Token(i), Ready::readable(), PollOpt::edge())
-                        .unwrap();
+                    r.reregister(
+                        poll.register(),
+                        Token(i),
+                        Ready::readable(),
+                        PollOpt::edge(),
+                    )
+                    .unwrap();
                 }
             }
 
@@ -177,120 +198,6 @@ mod stress {
     }
 
     #[test]
-    fn multi_threaded_poll() {
-        use std::sync::atomic::AtomicUsize;
-        use std::sync::atomic::Ordering::{Relaxed, SeqCst};
-        use std::sync::{Arc, Barrier};
-        use std::thread;
-
-        const ENTRIES: usize = 10_000;
-        const PER_ENTRY: usize = 16;
-        const THREADS: usize = 4;
-        const NUM: usize = ENTRIES * PER_ENTRY;
-
-        struct Entry {
-            #[allow(dead_code)]
-            registration: Registration,
-            set_readiness: SetReadiness,
-            num: AtomicUsize,
-        }
-
-        impl Entry {
-            fn fire(&self) {
-                self.set_readiness.set_readiness(Ready::readable()).unwrap();
-            }
-        }
-
-        let poll = Arc::new(Poll::new().unwrap());
-        let mut entries = vec![];
-
-        // Create entries
-        for i in 0..ENTRIES {
-            let (registration, set_readiness) = Registration::new2();
-            registration
-                .register(&poll, Token(i), Ready::readable(), PollOpt::edge())
-                .unwrap();
-
-            entries.push(Entry {
-                registration,
-                set_readiness,
-                num: AtomicUsize::new(0),
-            });
-        }
-
-        let total = Arc::new(AtomicUsize::new(0));
-        let entries = Arc::new(entries);
-        let barrier = Arc::new(Barrier::new(THREADS));
-
-        let mut threads = vec![];
-
-        for th in 0..THREADS {
-            let poll = poll.clone();
-            let total = total.clone();
-            let entries = entries.clone();
-            let barrier = barrier.clone();
-
-            threads.push(thread::spawn(move || {
-                let mut events = Events::with_capacity(128);
-
-                barrier.wait();
-
-                // Prime all the registrations
-                let mut i = th;
-                while i < ENTRIES {
-                    entries[i].fire();
-                    i += THREADS;
-                }
-
-                let mut n = 0;
-
-                while total.load(SeqCst) < NUM {
-                    // A poll timeout is necessary here because there may be more
-                    // than one threads blocked in `poll` when the final wakeup
-                    // notification arrives (and only notifies one thread).
-                    n += poll
-                        .poll(&mut events, Some(Duration::from_millis(100)))
-                        .unwrap();
-
-                    let mut num_this_tick = 0;
-
-                    for event in &events {
-                        let e = &entries[event.token().0];
-
-                        let mut num = e.num.load(Relaxed);
-
-                        loop {
-                            if num < PER_ENTRY {
-                                let actual = e.num.compare_and_swap(num, num + 1, Relaxed);
-
-                                if actual == num {
-                                    num_this_tick += 1;
-                                    e.fire();
-                                    break;
-                                }
-
-                                num = actual;
-                            } else {
-                                break;
-                            }
-                        }
-                    }
-
-                    total.fetch_add(num_this_tick, SeqCst);
-                }
-
-                n
-            }));
-        }
-
-        let _: Vec<_> = threads.into_iter().map(|th| th.join().unwrap()).collect();
-
-        for entry in entries.iter() {
-            assert_eq!(PER_ENTRY, entry.num.load(Relaxed));
-        }
-    }
-
-    #[test]
     fn with_small_events_collection() {
         const N: usize = 8;
         const ITER: usize = 1_000;
@@ -300,15 +207,16 @@ mod stress {
         use std::sync::{Arc, Barrier};
         use std::thread;
 
-        let poll = Poll::new().unwrap();
+        let mut poll = Poll::new().unwrap();
         let mut registrations = vec![];
 
         let barrier = Arc::new(Barrier::new(N + 1));
         let done = Arc::new(AtomicBool::new(false));
 
         for i in 0..N {
-            let (registration, set_readiness) = Registration::new2();
-            poll.register(&registration, Token(i), Ready::readable(), PollOpt::edge())
+            let (registration, set_readiness) = Registration::new();
+            poll.register()
+                .register(&registration, Token(i), Ready::readable(), PollOpt::edge())
                 .unwrap();
 
             registrations.push(registration);
@@ -366,7 +274,7 @@ fn drop_registration_from_non_main_thread() {
     const THREADS: usize = 8;
     const ITERS: usize = 50_000;
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
     let mut senders = Vec::with_capacity(THREADS);
     let mut token_index = 0;
@@ -387,10 +295,10 @@ fn drop_registration_from_non_main_thread() {
 
     let mut index: usize = 0;
     for _ in 0..ITERS {
-        let (registration, set_readiness) = Registration::new2();
+        let (registration, set_readiness) = Registration::new();
         registration
             .register(
-                &poll,
+                poll.register(),
                 Token(token_index),
                 Ready::readable(),
                 PollOpt::edge(),
@@ -403,10 +311,10 @@ fn drop_registration_from_non_main_thread() {
         if index == THREADS {
             index = 0;
 
-            let (registration, set_readiness) = Registration::new2();
+            let (registration, set_readiness) = Registration::new();
             registration
                 .register(
-                    &poll,
+                    poll.register(),
                     Token(token_index),
                     Ready::readable(),
                     PollOpt::edge(),

--- a/test/test_custom_evented.rs
+++ b/test/test_custom_evented.rs
@@ -9,7 +9,7 @@ fn smoke() {
 
     let (r, set) = Registration::new();
     r.register(
-        poll.register(),
+        poll.registry(),
         Token(0),
         Ready::readable(),
         PollOpt::edge(),
@@ -57,7 +57,7 @@ fn set_readiness_before_register() {
         b1.wait();
 
         // now register
-        poll.register()
+        poll.registry()
             .register(&r, Token(123), Ready::readable(), PollOpt::edge())
             .unwrap();
 
@@ -103,7 +103,7 @@ mod stress {
                 .map(|i| {
                     let (r, s) = Registration::new();
                     r.register(
-                        poll.register(),
+                        poll.registry(),
                         Token(i),
                         Ready::readable(),
                         PollOpt::edge(),
@@ -148,7 +148,7 @@ mod stress {
                 // Set interest
                 for (i, &(ref r, _)) in registrations.iter().enumerate() {
                     r.reregister(
-                        poll.register(),
+                        poll.registry(),
                         Token(i),
                         Ready::writable(),
                         PollOpt::edge(),
@@ -167,7 +167,7 @@ mod stress {
                 // Set interest
                 for (i, &(ref r, _)) in registrations.iter().enumerate() {
                     r.reregister(
-                        poll.register(),
+                        poll.registry(),
                         Token(i),
                         Ready::readable(),
                         PollOpt::edge(),
@@ -215,7 +215,7 @@ mod stress {
 
         for i in 0..N {
             let (registration, set_readiness) = Registration::new();
-            poll.register()
+            poll.registry()
                 .register(&registration, Token(i), Ready::readable(), PollOpt::edge())
                 .unwrap();
 
@@ -298,7 +298,7 @@ fn drop_registration_from_non_main_thread() {
         let (registration, set_readiness) = Registration::new();
         registration
             .register(
-                poll.register(),
+                poll.registry(),
                 Token(token_index),
                 Ready::readable(),
                 PollOpt::edge(),
@@ -314,7 +314,7 @@ fn drop_registration_from_non_main_thread() {
             let (registration, set_readiness) = Registration::new();
             registration
                 .register(
-                    poll.register(),
+                    poll.registry(),
                     Token(token_index),
                     Ready::readable(),
                     PollOpt::edge(),

--- a/test/test_custom_evented.rs
+++ b/test/test_custom_evented.rs
@@ -216,7 +216,12 @@ mod stress {
         for i in 0..N {
             let (registration, set_readiness) = Registration::new();
             poll.registry()
-                .register(&registration, Token(i), Interests::readable(), PollOpt::edge())
+                .register(
+                    &registration,
+                    Token(i),
+                    Interests::readable(),
+                    PollOpt::edge(),
+                )
                 .unwrap();
 
             registrations.push(registration);

--- a/test/test_double_register.rs
+++ b/test/test_double_register.rs
@@ -12,9 +12,11 @@ pub fn test_double_register() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register(&l, Token(0), Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&l, Token(0), Ready::readable(), PollOpt::edge())
         .unwrap();
     assert!(poll
+        .register()
         .register(&l, Token(1), Ready::readable(), PollOpt::edge())
         .is_err());
 }

--- a/test/test_double_register.rs
+++ b/test/test_double_register.rs
@@ -12,11 +12,12 @@ pub fn test_double_register() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register()
+    poll.registry()
         .register(&l, Token(0), Interests::readable(), PollOpt::edge())
         .unwrap();
+
     assert!(poll
-        .register()
+        .registry()
         .register(&l, Token(1), Interests::readable(), PollOpt::edge())
         .is_err());
 }

--- a/test/test_local_addr_ready.rs
+++ b/test/test_local_addr_ready.rs
@@ -20,12 +20,12 @@ fn local_addr_ready() {
     let addr = server.local_addr().unwrap();
 
     let mut poll = Poll::new().unwrap();
-    poll.register()
+    poll.registry()
         .register(&server, LISTEN, Ready::readable(), PollOpt::edge())
         .unwrap();
 
     let sock = TcpStream::connect(&addr).unwrap();
-    poll.register()
+    poll.registry()
         .register(&sock, CLIENT, Ready::readable(), PollOpt::edge())
         .unwrap();
 
@@ -45,7 +45,7 @@ fn local_addr_ready() {
             match event.token() {
                 LISTEN => {
                     let sock = handler.listener.accept().unwrap().0;
-                    poll.register()
+                    poll.registry()
                         .register(&sock, SERVER, Ready::writable(), PollOpt::edge())
                         .unwrap();
                     handler.accepted = Some(sock);

--- a/test/test_local_addr_ready.rs
+++ b/test/test_local_addr_ready.rs
@@ -19,12 +19,14 @@ fn local_addr_ready() {
     let server = TcpListener::bind(&addr).unwrap();
     let addr = server.local_addr().unwrap();
 
-    let poll = Poll::new().unwrap();
-    poll.register(&server, LISTEN, Ready::readable(), PollOpt::edge())
+    let mut poll = Poll::new().unwrap();
+    poll.register()
+        .register(&server, LISTEN, Ready::readable(), PollOpt::edge())
         .unwrap();
 
     let sock = TcpStream::connect(&addr).unwrap();
-    poll.register(&sock, CLIENT, Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&sock, CLIENT, Ready::readable(), PollOpt::edge())
         .unwrap();
 
     let mut events = Events::with_capacity(1024);
@@ -43,7 +45,8 @@ fn local_addr_ready() {
             match event.token() {
                 LISTEN => {
                     let sock = handler.listener.accept().unwrap().0;
-                    poll.register(&sock, SERVER, Ready::writable(), PollOpt::edge())
+                    poll.register()
+                        .register(&sock, SERVER, Ready::writable(), PollOpt::edge())
                         .unwrap();
                     handler.accepted = Some(sock);
                 }

--- a/test/test_multicast.rs
+++ b/test/test_multicast.rs
@@ -5,7 +5,7 @@
 use bytes::{Buf, MutBuf, RingBuf, SliceBuf};
 use localhost;
 use mio::net::UdpSocket;
-use mio::{Events, Poll, PollOpt, Ready, Token};
+use mio::{Events, Poll, PollOpt, Ready, Register, Token};
 use std::net::IpAddr;
 use std::str;
 
@@ -36,7 +36,7 @@ impl UdpHandler {
         }
     }
 
-    fn handle_read(&mut self, _: &mut Poll, token: Token, _: Ready) {
+    fn handle_read(&mut self, _: &Register, token: Token, _: Ready) {
         if let LISTENER = token {
             debug!("We are receiving a datagram now...");
             match unsafe { self.rx.recv_from(self.rx_buf.mut_bytes()) } {
@@ -53,7 +53,7 @@ impl UdpHandler {
         }
     }
 
-    fn handle_write(&mut self, _: &mut Poll, token: Token, _: Ready) {
+    fn handle_write(&mut self, _: &Register, token: Token, _: Ready) {
         if let SENDER = token {
             let addr = self.rx.local_addr().unwrap();
             let cnt = self.tx.send_to(self.buf.bytes(), &addr).unwrap();
@@ -84,11 +84,13 @@ pub fn test_multicast() {
         .unwrap();
 
     info!("Registering SENDER");
-    poll.register(&tx, SENDER, Ready::writable(), PollOpt::edge())
+    poll.register()
+        .register(&tx, SENDER, Ready::writable(), PollOpt::edge())
         .unwrap();
 
     info!("Registering LISTENER");
-    poll.register(&rx, LISTENER, Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&rx, LISTENER, Ready::readable(), PollOpt::edge())
         .unwrap();
 
     let mut events = Events::with_capacity(1024);
@@ -102,11 +104,11 @@ pub fn test_multicast() {
 
         for event in &events {
             if event.readiness().is_readable() {
-                handler.handle_read(&mut poll, event.token(), event.readiness());
+                handler.handle_read(poll.register(), event.token(), event.readiness());
             }
 
             if event.readiness().is_writable() {
-                handler.handle_write(&mut poll, event.token(), event.readiness());
+                handler.handle_write(poll.register(), event.token(), event.readiness());
             }
         }
     }

--- a/test/test_oneshot.rs
+++ b/test/test_oneshot.rs
@@ -16,25 +16,28 @@ pub fn test_tcp_edge_oneshot() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register(&l, Token(0), Ready::readable(), PollOpt::level())
+    poll.register()
+        .register(&l, Token(0), Ready::readable(), PollOpt::level())
         .unwrap();
 
     // Connect a socket, we are going to write to it
     let mut s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register(&s1, Token(1), Ready::writable(), PollOpt::level())
+    poll.register()
+        .register(&s1, Token(1), Ready::writable(), PollOpt::level())
         .unwrap();
 
     wait_for(&mut poll, &mut events, Token(0));
 
     // Get pair
     let (mut s2, _) = l.accept().unwrap();
-    poll.register(
-        &s2,
-        Token(2),
-        Ready::readable(),
-        PollOpt::edge() | PollOpt::oneshot(),
-    )
-    .unwrap();
+    poll.register()
+        .register(
+            &s2,
+            Token(2),
+            Ready::readable(),
+            PollOpt::edge() | PollOpt::oneshot(),
+        )
+        .unwrap();
 
     wait_for(&mut poll, &mut events, Token(1));
 
@@ -49,22 +52,24 @@ pub fn test_tcp_edge_oneshot() {
         assert_eq!(1, s2.read(&mut buf).unwrap());
         assert_eq!(*byte, buf[0]);
 
-        poll.reregister(
-            &s2,
-            Token(2),
-            Ready::readable(),
-            PollOpt::edge() | PollOpt::oneshot(),
-        )
-        .unwrap();
-
-        if *byte == b'o' {
-            poll.reregister(
+        poll.register()
+            .reregister(
                 &s2,
                 Token(2),
                 Ready::readable(),
                 PollOpt::edge() | PollOpt::oneshot(),
             )
             .unwrap();
+
+        if *byte == b'o' {
+            poll.register()
+                .reregister(
+                    &s2,
+                    Token(2),
+                    Ready::readable(),
+                    PollOpt::edge() | PollOpt::oneshot(),
+                )
+                .unwrap();
         }
     }
 }

--- a/test/test_oneshot.rs
+++ b/test/test_oneshot.rs
@@ -16,13 +16,13 @@ pub fn test_tcp_edge_oneshot() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register()
+    poll.registry()
         .register(&l, Token(0), Ready::readable(), PollOpt::level())
         .unwrap();
 
     // Connect a socket, we are going to write to it
     let mut s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register()
+    poll.registry()
         .register(&s1, Token(1), Ready::writable(), PollOpt::level())
         .unwrap();
 
@@ -30,7 +30,7 @@ pub fn test_tcp_edge_oneshot() {
 
     // Get pair
     let (mut s2, _) = l.accept().unwrap();
-    poll.register()
+    poll.registry()
         .register(
             &s2,
             Token(2),
@@ -52,7 +52,7 @@ pub fn test_tcp_edge_oneshot() {
         assert_eq!(1, s2.read(&mut buf).unwrap());
         assert_eq!(*byte, buf[0]);
 
-        poll.register()
+        poll.registry()
             .reregister(
                 &s2,
                 Token(2),
@@ -62,7 +62,7 @@ pub fn test_tcp_edge_oneshot() {
             .unwrap();
 
         if *byte == b'o' {
-            poll.register()
+            poll.registry()
                 .reregister(
                     &s2,
                     Token(2),

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -8,7 +8,7 @@ fn test_poll_closes_fd() {
         let mut events = Events::with_capacity(4);
         let (registration, set_readiness) = Registration::new();
 
-        poll.register()
+        poll.registry()
             .register(&registration, Token(0), Ready::readable(), PollOpt::edge())
             .unwrap();
         poll.poll(&mut events, Some(Duration::from_millis(0)))

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -4,11 +4,12 @@ use std::time::Duration;
 #[test]
 fn test_poll_closes_fd() {
     for _ in 0..2000 {
-        let poll = Poll::new().unwrap();
+        let mut poll = Poll::new().unwrap();
         let mut events = Events::with_capacity(4);
-        let (registration, set_readiness) = Registration::new2();
+        let (registration, set_readiness) = Registration::new();
 
-        poll.register(&registration, Token(0), Ready::readable(), PollOpt::edge())
+        poll.register()
+            .register(&registration, Token(0), Ready::readable(), PollOpt::edge())
             .unwrap();
         poll.poll(&mut events, Some(Duration::from_millis(0)))
             .unwrap();

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -9,7 +9,12 @@ fn test_poll_closes_fd() {
         let (registration, set_readiness) = Registration::new();
 
         poll.registry()
-            .register(&registration, Token(0), Interests::readable(), PollOpt::edge())
+            .register(
+                &registration,
+                Token(0),
+                Interests::readable(),
+                PollOpt::edge(),
+            )
             .unwrap();
 
         poll.poll(&mut events, Some(Duration::from_millis(0)))

--- a/test/test_register_deregister.rs
+++ b/test/test_register_deregister.rs
@@ -34,7 +34,12 @@ impl TestHandler {
                 assert!(self.state == 0, "unexpected state {}", self.state);
                 self.state = 1;
                 registry
-                    .reregister(&self.client, CLIENT, Interests::writable(), PollOpt::level())
+                    .reregister(
+                        &self.client,
+                        CLIENT,
+                        Interests::writable(),
+                        PollOpt::level(),
+                    )
                     .unwrap();
             }
             _ => panic!("unexpected token"),

--- a/test/test_register_multiple_event_loops.rs
+++ b/test/test_register_multiple_event_loops.rs
@@ -10,7 +10,7 @@ fn test_tcp_register_multiple_event_loops() {
 
     let poll1 = Poll::new().unwrap();
     poll1
-        .register()
+        .registry()
         .register(
             &listener,
             Token(0),
@@ -22,7 +22,7 @@ fn test_tcp_register_multiple_event_loops() {
     let poll2 = Poll::new().unwrap();
 
     // Try registering the same socket with the initial one
-    let res = poll2.register().register(
+    let res = poll2.registry().register(
         &listener,
         Token(0),
         Ready::readable() | Ready::writable(),
@@ -33,7 +33,7 @@ fn test_tcp_register_multiple_event_loops() {
 
     // Try cloning the socket and registering it again
     let listener2 = listener.try_clone().unwrap();
-    let res = poll2.register().register(
+    let res = poll2.registry().register(
         &listener2,
         Token(0),
         Ready::readable() | Ready::writable(),
@@ -46,7 +46,7 @@ fn test_tcp_register_multiple_event_loops() {
     let stream = TcpStream::connect(&addr).unwrap();
 
     poll1
-        .register()
+        .registry()
         .register(
             &stream,
             Token(1),
@@ -55,7 +55,7 @@ fn test_tcp_register_multiple_event_loops() {
         )
         .unwrap();
 
-    let res = poll2.register().register(
+    let res = poll2.registry().register(
         &stream,
         Token(1),
         Ready::readable() | Ready::writable(),
@@ -66,7 +66,7 @@ fn test_tcp_register_multiple_event_loops() {
 
     // Try cloning the socket and registering it again
     let stream2 = stream.try_clone().unwrap();
-    let res = poll2.register().register(
+    let res = poll2.registry().register(
         &stream2,
         Token(1),
         Ready::readable() | Ready::writable(),
@@ -83,7 +83,7 @@ fn test_udp_register_multiple_event_loops() {
 
     let poll1 = Poll::new().unwrap();
     poll1
-        .register()
+        .registry()
         .register(
             &socket,
             Token(0),
@@ -95,7 +95,7 @@ fn test_udp_register_multiple_event_loops() {
     let poll2 = Poll::new().unwrap();
 
     // Try registering the same socket with the initial one
-    let res = poll2.register().register(
+    let res = poll2.registry().register(
         &socket,
         Token(0),
         Ready::readable() | Ready::writable(),
@@ -106,7 +106,7 @@ fn test_udp_register_multiple_event_loops() {
 
     // Try cloning the socket and registering it again
     let socket2 = socket.try_clone().unwrap();
-    let res = poll2.register().register(
+    let res = poll2.registry().register(
         &socket2,
         Token(0),
         Ready::readable() | Ready::writable(),

--- a/test/test_register_multiple_event_loops.rs
+++ b/test/test_register_multiple_event_loops.rs
@@ -10,6 +10,7 @@ fn test_tcp_register_multiple_event_loops() {
 
     let poll1 = Poll::new().unwrap();
     poll1
+        .register()
         .register(
             &listener,
             Token(0),
@@ -21,7 +22,7 @@ fn test_tcp_register_multiple_event_loops() {
     let poll2 = Poll::new().unwrap();
 
     // Try registering the same socket with the initial one
-    let res = poll2.register(
+    let res = poll2.register().register(
         &listener,
         Token(0),
         Ready::readable() | Ready::writable(),
@@ -32,7 +33,7 @@ fn test_tcp_register_multiple_event_loops() {
 
     // Try cloning the socket and registering it again
     let listener2 = listener.try_clone().unwrap();
-    let res = poll2.register(
+    let res = poll2.register().register(
         &listener2,
         Token(0),
         Ready::readable() | Ready::writable(),
@@ -45,6 +46,7 @@ fn test_tcp_register_multiple_event_loops() {
     let stream = TcpStream::connect(&addr).unwrap();
 
     poll1
+        .register()
         .register(
             &stream,
             Token(1),
@@ -53,7 +55,7 @@ fn test_tcp_register_multiple_event_loops() {
         )
         .unwrap();
 
-    let res = poll2.register(
+    let res = poll2.register().register(
         &stream,
         Token(1),
         Ready::readable() | Ready::writable(),
@@ -64,7 +66,7 @@ fn test_tcp_register_multiple_event_loops() {
 
     // Try cloning the socket and registering it again
     let stream2 = stream.try_clone().unwrap();
-    let res = poll2.register(
+    let res = poll2.register().register(
         &stream2,
         Token(1),
         Ready::readable() | Ready::writable(),
@@ -81,6 +83,7 @@ fn test_udp_register_multiple_event_loops() {
 
     let poll1 = Poll::new().unwrap();
     poll1
+        .register()
         .register(
             &socket,
             Token(0),
@@ -92,7 +95,7 @@ fn test_udp_register_multiple_event_loops() {
     let poll2 = Poll::new().unwrap();
 
     // Try registering the same socket with the initial one
-    let res = poll2.register(
+    let res = poll2.register().register(
         &socket,
         Token(0),
         Ready::readable() | Ready::writable(),
@@ -103,7 +106,7 @@ fn test_udp_register_multiple_event_loops() {
 
     // Try cloning the socket and registering it again
     let socket2 = socket.try_clone().unwrap();
-    let res = poll2.register(
+    let res = poll2.register().register(
         &socket2,
         Token(0),
         Ready::readable() | Ready::writable(),

--- a/test/test_reregister_without_poll.rs
+++ b/test/test_reregister_without_poll.rs
@@ -8,33 +8,36 @@ const MS: u64 = 1_000;
 #[test]
 pub fn test_reregister_different_without_poll() {
     let mut events = Events::with_capacity(1024);
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
 
     // Create the listener
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register(
-        &l,
-        Token(0),
-        Ready::readable(),
-        PollOpt::edge() | PollOpt::oneshot(),
-    )
-    .unwrap();
+    poll.register()
+        .register(
+            &l,
+            Token(0),
+            Ready::readable(),
+            PollOpt::edge() | PollOpt::oneshot(),
+        )
+        .unwrap();
 
     let s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register(&s1, Token(2), Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&s1, Token(2), Ready::readable(), PollOpt::edge())
         .unwrap();
 
     sleep_ms(MS);
 
-    poll.reregister(
-        &l,
-        Token(0),
-        Ready::writable(),
-        PollOpt::edge() | PollOpt::oneshot(),
-    )
-    .unwrap();
+    poll.register()
+        .reregister(
+            &l,
+            Token(0),
+            Ready::writable(),
+            PollOpt::edge() | PollOpt::oneshot(),
+        )
+        .unwrap();
 
     poll.poll(&mut events, Some(Duration::from_millis(MS)))
         .unwrap();

--- a/test/test_reregister_without_poll.rs
+++ b/test/test_reregister_without_poll.rs
@@ -14,7 +14,7 @@ pub fn test_reregister_different_without_poll() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register()
+    poll.registry()
         .register(
             &l,
             Token(0),
@@ -24,13 +24,13 @@ pub fn test_reregister_different_without_poll() {
         .unwrap();
 
     let s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register()
+    poll.registry()
         .register(&s1, Token(2), Ready::readable(), PollOpt::edge())
         .unwrap();
 
     sleep_ms(MS);
 
-    poll.register()
+    poll.registry()
         .reregister(
             &l,
             Token(0),

--- a/test/test_smoke.rs
+++ b/test/test_smoke.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 #[test]
 fn run_once_with_nothing() {
     let mut events = Events::with_capacity(1024);
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     poll.poll(&mut events, Some(Duration::from_millis(100)))
         .unwrap();
 }
@@ -16,14 +16,15 @@ fn run_once_with_nothing() {
 fn add_then_drop() {
     let mut events = Events::with_capacity(1024);
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
-    let poll = Poll::new().unwrap();
-    poll.register(
-        &l,
-        Token(1),
-        Ready::readable() | Ready::writable(),
-        PollOpt::edge(),
-    )
-    .unwrap();
+    let mut poll = Poll::new().unwrap();
+    poll.register()
+        .register(
+            &l,
+            Token(1),
+            Ready::readable() | Ready::writable(),
+            PollOpt::edge(),
+        )
+        .unwrap();
     drop(l);
     poll.poll(&mut events, Some(Duration::from_millis(100)))
         .unwrap();

--- a/test/test_smoke.rs
+++ b/test/test_smoke.rs
@@ -17,7 +17,7 @@ fn add_then_drop() {
     let mut events = Events::with_capacity(1024);
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let mut poll = Poll::new().unwrap();
-    poll.register()
+    poll.registry()
         .register(
             &l,
             Token(1),

--- a/test/test_tcp.rs
+++ b/test/test_tcp.rs
@@ -30,7 +30,7 @@ fn accept() {
 
     let mut poll = Poll::new().unwrap();
 
-    poll.register()
+    poll.registry()
         .register(&l, Token(1), Ready::readable(), PollOpt::edge())
         .unwrap();
 
@@ -79,7 +79,7 @@ fn connect() {
     let mut poll = Poll::new().unwrap();
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register()
+    poll.registry()
         .register(
             &s,
             Token(1),
@@ -154,7 +154,7 @@ fn read() {
     let mut poll = Poll::new().unwrap();
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register()
+    poll.registry()
         .register(&s, Token(1), Ready::readable(), PollOpt::edge())
         .unwrap();
 
@@ -211,7 +211,7 @@ fn peek() {
     let mut poll = Poll::new().unwrap();
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register()
+    poll.registry()
         .register(&s, Token(1), Ready::readable(), PollOpt::edge())
         .unwrap();
 
@@ -271,7 +271,7 @@ fn read_bufs() {
 
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register()
+    poll.registry()
         .register(&s, Token(1), Ready::readable(), PollOpt::level())
         .unwrap();
 
@@ -342,7 +342,7 @@ fn write() {
     let mut poll = Poll::new().unwrap();
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register()
+    poll.registry()
         .register(&s, Token(1), Ready::writable(), PollOpt::edge())
         .unwrap();
 
@@ -401,7 +401,7 @@ fn write_bufs() {
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(128);
     let s = TcpStream::connect(&addr).unwrap();
-    poll.register()
+    poll.registry()
         .register(&s, Token(1), Ready::writable(), PollOpt::level())
         .unwrap();
 
@@ -436,10 +436,10 @@ fn connect_then_close() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let s = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
 
-    poll.register()
+    poll.registry()
         .register(&l, Token(1), Ready::readable(), PollOpt::edge())
         .unwrap();
-    poll.register()
+    poll.registry()
         .register(&s, Token(2), Ready::readable(), PollOpt::edge())
         .unwrap();
 
@@ -455,7 +455,7 @@ fn connect_then_close() {
         for event in &events {
             if event.token() == Token(1) {
                 let s = h.listener.accept().unwrap().0;
-                poll.register()
+                poll.registry()
                     .register(
                         &s,
                         Token(3),
@@ -476,7 +476,7 @@ fn listen_then_close() {
     let mut poll = Poll::new().unwrap();
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
-    poll.register()
+    poll.registry()
         .register(&l, Token(1), Ready::readable(), PollOpt::edge())
         .unwrap();
     drop(l);
@@ -536,7 +536,7 @@ fn multiple_writes_immediate_success() {
 
     let mut poll = Poll::new().unwrap();
     let mut s = TcpStream::connect(&addr).unwrap();
-    poll.register()
+    poll.registry()
         .register(&s, Token(1), Ready::writable(), PollOpt::level())
         .unwrap();
     let mut events = Events::with_capacity(16);
@@ -578,12 +578,12 @@ fn connection_reset_by_peer() {
     let client = TcpStream::from_stream(client).unwrap();
 
     // Register server
-    poll.register()
+    poll.registry()
         .register(&l, Token(0), Ready::readable(), PollOpt::edge())
         .unwrap();
 
     // Register interest in the client
-    poll.register()
+    poll.registry()
         .register(
             &client,
             Token(1),
@@ -618,7 +618,7 @@ fn connection_reset_by_peer() {
     thread::sleep(Duration::from_millis(100));
 
     // Register interest in the server socket
-    poll.register()
+    poll.registry()
         .register(&server, Token(3), Ready::readable(), PollOpt::edge())
         .unwrap();
 
@@ -657,7 +657,7 @@ fn connect_error() {
         Err(e) => panic!("TcpStream::connect unexpected error {:?}", e),
     };
 
-    poll.register()
+    poll.registry()
         .register(&l, Token(0), Ready::writable(), PollOpt::edge())
         .unwrap();
 
@@ -690,7 +690,7 @@ fn write_error() {
     });
 
     let mut s = TcpStream::connect(&addr).unwrap();
-    poll.register()
+    poll.registry()
         .register(
             &s,
             Token(0),

--- a/test/test_tcp.rs
+++ b/test/test_tcp.rs
@@ -28,9 +28,10 @@ fn accept() {
         net::TcpStream::connect(&addr).unwrap();
     });
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
 
-    poll.register(&l, Token(1), Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&l, Token(1), Ready::readable(), PollOpt::edge())
         .unwrap();
 
     let mut events = Events::with_capacity(128);
@@ -75,16 +76,17 @@ fn connect() {
         tx2.send(()).unwrap();
     });
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register(
-        &s,
-        Token(1),
-        Ready::readable() | Ready::writable(),
-        PollOpt::edge(),
-    )
-    .unwrap();
+    poll.register()
+        .register(
+            &s,
+            Token(1),
+            Ready::readable() | Ready::writable(),
+            PollOpt::edge(),
+        )
+        .unwrap();
 
     let mut events = Events::with_capacity(128);
 
@@ -149,10 +151,11 @@ fn read() {
         }
     });
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register(&s, Token(1), Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&s, Token(1), Ready::readable(), PollOpt::edge())
         .unwrap();
 
     let mut events = Events::with_capacity(128);
@@ -205,10 +208,11 @@ fn peek() {
         }
     });
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register(&s, Token(1), Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&s, Token(1), Ready::readable(), PollOpt::edge())
         .unwrap();
 
     let mut events = Events::with_capacity(128);
@@ -262,12 +266,13 @@ fn read_bufs() {
         }
     });
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(128);
 
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register(&s, Token(1), Ready::readable(), PollOpt::level())
+    poll.register()
+        .register(&s, Token(1), Ready::readable(), PollOpt::level())
         .unwrap();
 
     let b1 = &mut [0; 10][..];
@@ -334,10 +339,11 @@ fn write() {
         }
     });
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register(&s, Token(1), Ready::writable(), PollOpt::edge())
+    poll.register()
+        .register(&s, Token(1), Ready::writable(), PollOpt::edge())
         .unwrap();
 
     let mut events = Events::with_capacity(128);
@@ -392,10 +398,11 @@ fn write_bufs() {
         }
     });
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(128);
     let s = TcpStream::connect(&addr).unwrap();
-    poll.register(&s, Token(1), Ready::writable(), PollOpt::level())
+    poll.register()
+        .register(&s, Token(1), Ready::writable(), PollOpt::level())
         .unwrap();
 
     let b1 = &[1; 10][..];
@@ -425,13 +432,15 @@ fn connect_then_close() {
         shutdown: bool,
     }
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let s = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
 
-    poll.register(&l, Token(1), Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&l, Token(1), Ready::readable(), PollOpt::edge())
         .unwrap();
-    poll.register(&s, Token(2), Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&s, Token(2), Ready::readable(), PollOpt::edge())
         .unwrap();
 
     let mut events = Events::with_capacity(128);
@@ -446,13 +455,14 @@ fn connect_then_close() {
         for event in &events {
             if event.token() == Token(1) {
                 let s = h.listener.accept().unwrap().0;
-                poll.register(
-                    &s,
-                    Token(3),
-                    Ready::readable() | Ready::writable(),
-                    PollOpt::edge(),
-                )
-                .unwrap();
+                poll.register()
+                    .register(
+                        &s,
+                        Token(3),
+                        Ready::readable() | Ready::writable(),
+                        PollOpt::edge(),
+                    )
+                    .unwrap();
                 drop(s);
             } else if event.token() == Token(2) {
                 h.shutdown = true;
@@ -463,10 +473,11 @@ fn connect_then_close() {
 
 #[test]
 fn listen_then_close() {
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
-    poll.register(&l, Token(1), Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&l, Token(1), Ready::readable(), PollOpt::edge())
         .unwrap();
     drop(l);
 
@@ -523,9 +534,10 @@ fn multiple_writes_immediate_success() {
         }
     });
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut s = TcpStream::connect(&addr).unwrap();
-    poll.register(&s, Token(1), Ready::writable(), PollOpt::level())
+    poll.register()
+        .register(&s, Token(1), Ready::writable(), PollOpt::level())
         .unwrap();
     let mut events = Events::with_capacity(16);
 
@@ -548,7 +560,7 @@ fn multiple_writes_immediate_success() {
 
 #[test]
 fn connection_reset_by_peer() {
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(16);
     let mut buf = [0u8; 16];
 
@@ -566,17 +578,19 @@ fn connection_reset_by_peer() {
     let client = TcpStream::from_stream(client).unwrap();
 
     // Register server
-    poll.register(&l, Token(0), Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&l, Token(0), Ready::readable(), PollOpt::edge())
         .unwrap();
 
     // Register interest in the client
-    poll.register(
-        &client,
-        Token(1),
-        Ready::readable() | Ready::writable(),
-        PollOpt::edge(),
-    )
-    .unwrap();
+    poll.register()
+        .register(
+            &client,
+            Token(1),
+            Ready::readable() | Ready::writable(),
+            PollOpt::edge(),
+        )
+        .unwrap();
 
     // Wait for listener to be ready
     let mut server;
@@ -604,7 +618,8 @@ fn connection_reset_by_peer() {
     thread::sleep(Duration::from_millis(100));
 
     // Register interest in the server socket
-    poll.register(&server, Token(3), Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&server, Token(3), Ready::readable(), PollOpt::edge())
         .unwrap();
 
     loop {
@@ -628,7 +643,7 @@ fn connection_reset_by_peer() {
 #[test]
 #[cfg_attr(target_os = "fuchsia", ignore)]
 fn connect_error() {
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(16);
 
     // Pick a "random" port that shouldn't be in use.
@@ -642,7 +657,8 @@ fn connect_error() {
         Err(e) => panic!("TcpStream::connect unexpected error {:?}", e),
     };
 
-    poll.register(&l, Token(0), Ready::writable(), PollOpt::edge())
+    poll.register()
+        .register(&l, Token(0), Ready::writable(), PollOpt::edge())
         .unwrap();
 
     'outer: loop {
@@ -661,7 +677,7 @@ fn connect_error() {
 
 #[test]
 fn write_error() {
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(16);
     let (tx, rx) = channel();
 
@@ -674,13 +690,14 @@ fn write_error() {
     });
 
     let mut s = TcpStream::connect(&addr).unwrap();
-    poll.register(
-        &s,
-        Token(0),
-        Ready::readable() | Ready::writable(),
-        PollOpt::edge(),
-    )
-    .unwrap();
+    poll.register()
+        .register(
+            &s,
+            Token(0),
+            Ready::readable() | Ready::writable(),
+            PollOpt::edge(),
+        )
+        .unwrap();
 
     let mut wait_writable = || 'outer: loop {
         poll.poll(&mut events, None).unwrap();

--- a/test/test_tcp_level.rs
+++ b/test/test_tcp_level.rs
@@ -16,12 +16,12 @@ pub fn test_tcp_listener_level_triggered() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register()
+    poll.registry()
         .register(&l, Token(0), Ready::readable(), PollOpt::level())
         .unwrap();
 
     let s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register()
+    poll.registry()
         .register(&s1, Token(1), Ready::readable(), PollOpt::edge())
         .unwrap();
 
@@ -49,7 +49,7 @@ pub fn test_tcp_listener_level_triggered() {
     assert!(events.is_empty(), "actual={:?}", events);
 
     let s3 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register()
+    poll.registry()
         .register(&s3, Token(2), Ready::readable(), PollOpt::edge())
         .unwrap();
 
@@ -80,12 +80,12 @@ pub fn test_tcp_stream_level_triggered() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register()
+    poll.registry()
         .register(&l, Token(0), Ready::readable(), PollOpt::edge())
         .unwrap();
 
     let mut s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register()
+    poll.registry()
         .register(
             &s1,
             Token(1),
@@ -121,7 +121,7 @@ pub fn test_tcp_stream_level_triggered() {
     );
 
     // Register the socket
-    poll.register()
+    poll.registry()
         .register(&s1_tx, Token(123), Ready::readable(), PollOpt::edge())
         .unwrap();
 

--- a/test/test_udp_level.rs
+++ b/test/test_udp_level.rs
@@ -14,7 +14,7 @@ pub fn test_udp_level_triggered() {
     let tx = UdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let rx = UdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
-    poll.register()
+    poll.registry()
         .register(
             &tx,
             Token(0),
@@ -23,7 +23,7 @@ pub fn test_udp_level_triggered() {
         )
         .unwrap();
 
-    poll.register()
+    poll.registry()
         .register(
             &rx,
             Token(1),

--- a/test/test_udp_level.rs
+++ b/test/test_udp_level.rs
@@ -5,8 +5,8 @@ use {expect_events, sleep_ms};
 
 #[test]
 pub fn test_udp_level_triggered() {
-    let poll = Poll::new().unwrap();
-    let poll = &poll;
+    let mut poll = Poll::new().unwrap();
+    let poll = &mut poll;
     let mut events = Events::with_capacity(1024);
     let events = &mut events;
 
@@ -14,20 +14,23 @@ pub fn test_udp_level_triggered() {
     let tx = UdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let rx = UdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
-    poll.register(
-        &tx,
-        Token(0),
-        Ready::readable() | Ready::writable(),
-        PollOpt::level(),
-    )
-    .unwrap();
-    poll.register(
-        &rx,
-        Token(1),
-        Ready::readable() | Ready::writable(),
-        PollOpt::level(),
-    )
-    .unwrap();
+    poll.register()
+        .register(
+            &tx,
+            Token(0),
+            Ready::readable() | Ready::writable(),
+            PollOpt::level(),
+        )
+        .unwrap();
+
+    poll.register()
+        .register(
+            &rx,
+            Token(1),
+            Ready::readable() | Ready::writable(),
+            PollOpt::level(),
+        )
+        .unwrap();
 
     for _ in 0..2 {
         expect_events(

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -41,7 +41,7 @@ fn assert_sync<T: Sync>() {}
 #[cfg(test)]
 fn test_send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
     debug!("Starting TEST_UDP_SOCKETS");
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
 
     assert_send::<UdpSocket>();
     assert_sync::<UdpSocket>();
@@ -54,11 +54,13 @@ fn test_send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
     );
 
     info!("Registering SENDER");
-    poll.register(&tx, SENDER, Ready::writable(), PollOpt::edge())
+    poll.register()
+        .register(&tx, SENDER, Ready::writable(), PollOpt::edge())
         .unwrap();
 
     info!("Registering LISTENER");
-    poll.register(&rx, LISTENER, Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&rx, LISTENER, Ready::readable(), PollOpt::edge())
         .unwrap();
 
     let mut events = Events::with_capacity(1024);
@@ -157,14 +159,16 @@ pub fn test_udp_socket_discard() {
     assert!(udp_outside.connect(rx_addr).is_ok());
     assert!(rx.connect(tx_addr).is_ok());
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
 
     let r = udp_outside.send(b"hello world");
     assert!(r.is_ok() || r.unwrap_err().kind() == ErrorKind::WouldBlock);
 
-    poll.register(&rx, LISTENER, Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&rx, LISTENER, Ready::readable(), PollOpt::edge())
         .unwrap();
-    poll.register(&tx, SENDER, Ready::writable(), PollOpt::edge())
+    poll.register()
+        .register(&tx, SENDER, Ready::writable(), PollOpt::edge())
         .unwrap();
 
     let mut events = Events::with_capacity(1024);
@@ -186,12 +190,14 @@ pub fn test_udp_socket_discard() {
 pub fn test_udp_socket_send_recv_bufs() {
     let (tx, rx) = connected_sockets();
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
 
-    poll.register(&tx, SENDER, Ready::writable(), PollOpt::edge())
+    poll.register()
+        .register(&tx, SENDER, Ready::writable(), PollOpt::edge())
         .unwrap();
 
-    poll.register(&rx, LISTENER, Ready::readable(), PollOpt::edge())
+    poll.register()
+        .register(&rx, LISTENER, Ready::readable(), PollOpt::edge())
         .unwrap();
 
     let mut events = Events::with_capacity(1024);

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -54,12 +54,12 @@ fn test_send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
     );
 
     info!("Registering SENDER");
-    poll.register()
+    poll.registry()
         .register(&tx, SENDER, Ready::writable(), PollOpt::edge())
         .unwrap();
 
     info!("Registering LISTENER");
-    poll.register()
+    poll.registry()
         .register(&rx, LISTENER, Ready::readable(), PollOpt::edge())
         .unwrap();
 
@@ -164,10 +164,10 @@ pub fn test_udp_socket_discard() {
     let r = udp_outside.send(b"hello world");
     assert!(r.is_ok() || r.unwrap_err().kind() == ErrorKind::WouldBlock);
 
-    poll.register()
+    poll.registry()
         .register(&rx, LISTENER, Ready::readable(), PollOpt::edge())
         .unwrap();
-    poll.register()
+    poll.registry()
         .register(&tx, SENDER, Ready::writable(), PollOpt::edge())
         .unwrap();
 
@@ -192,11 +192,11 @@ pub fn test_udp_socket_send_recv_bufs() {
 
     let mut poll = Poll::new().unwrap();
 
-    poll.register()
+    poll.registry()
         .register(&tx, SENDER, Ready::writable(), PollOpt::edge())
         .unwrap();
 
-    poll.register()
+    poll.registry()
         .register(&rx, LISTENER, Ready::readable(), PollOpt::edge())
         .unwrap();
 

--- a/test/test_write_then_drop.rs
+++ b/test/test_write_then_drop.rs
@@ -12,11 +12,16 @@ fn write_then_drop() {
     let addr = a.local_addr().unwrap();
     let mut s = TcpStream::connect(&addr).unwrap();
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
 
-    a.register(&poll, Token(1), Ready::readable(), PollOpt::edge())
-        .unwrap();
-    s.register(&poll, Token(3), Ready::empty(), PollOpt::edge())
+    a.register(
+        poll.register(),
+        Token(1),
+        Ready::readable(),
+        PollOpt::edge(),
+    )
+    .unwrap();
+    s.register(poll.register(), Token(3), Ready::empty(), PollOpt::edge())
         .unwrap();
 
     let mut events = Events::with_capacity(1024);
@@ -28,8 +33,13 @@ fn write_then_drop() {
 
     let mut s2 = a.accept().unwrap().0;
 
-    s2.register(&poll, Token(2), Ready::writable(), PollOpt::edge())
-        .unwrap();
+    s2.register(
+        poll.register(),
+        Token(2),
+        Ready::writable(),
+        PollOpt::edge(),
+    )
+    .unwrap();
 
     let mut events = Events::with_capacity(1024);
     while events.is_empty() {
@@ -41,8 +51,13 @@ fn write_then_drop() {
     s2.write_all(&[1, 2, 3, 4]).unwrap();
     drop(s2);
 
-    s.reregister(&poll, Token(3), Ready::readable(), PollOpt::edge())
-        .unwrap();
+    s.reregister(
+        poll.register(),
+        Token(3),
+        Ready::readable(),
+        PollOpt::edge(),
+    )
+    .unwrap();
     let mut events = Events::with_capacity(1024);
     while events.is_empty() {
         poll.poll(&mut events, None).unwrap();
@@ -63,11 +78,16 @@ fn write_then_deregister() {
     let addr = a.local_addr().unwrap();
     let mut s = TcpStream::connect(&addr).unwrap();
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
 
-    a.register(&poll, Token(1), Ready::readable(), PollOpt::edge())
-        .unwrap();
-    s.register(&poll, Token(3), Ready::empty(), PollOpt::edge())
+    a.register(
+        poll.register(),
+        Token(1),
+        Ready::readable(),
+        PollOpt::edge(),
+    )
+    .unwrap();
+    s.register(poll.register(), Token(3), Ready::empty(), PollOpt::edge())
         .unwrap();
 
     let mut events = Events::with_capacity(1024);
@@ -79,8 +99,13 @@ fn write_then_deregister() {
 
     let mut s2 = a.accept().unwrap().0;
 
-    s2.register(&poll, Token(2), Ready::writable(), PollOpt::edge())
-        .unwrap();
+    s2.register(
+        poll.register(),
+        Token(2),
+        Ready::writable(),
+        PollOpt::edge(),
+    )
+    .unwrap();
 
     let mut events = Events::with_capacity(1024);
     while events.is_empty() {
@@ -90,10 +115,15 @@ fn write_then_deregister() {
     assert_eq!(events.iter().next().unwrap().token(), Token(2));
 
     s2.write_all(&[1, 2, 3, 4]).unwrap();
-    s2.deregister(&poll).unwrap();
+    s2.deregister(poll.register()).unwrap();
 
-    s.reregister(&poll, Token(3), Ready::readable(), PollOpt::edge())
-        .unwrap();
+    s.reregister(
+        poll.register(),
+        Token(3),
+        Ready::readable(),
+        PollOpt::edge(),
+    )
+    .unwrap();
     let mut events = Events::with_capacity(1024);
     while events.is_empty() {
         poll.poll(&mut events, None).unwrap();

--- a/test/test_write_then_drop.rs
+++ b/test/test_write_then_drop.rs
@@ -22,8 +22,13 @@ fn write_then_drop() {
     )
     .unwrap();
 
-    s.register(poll.registry(), Token(3), Interests::readable(), PollOpt::edge())
-        .unwrap();
+    s.register(
+        poll.registry(),
+        Token(3),
+        Interests::readable(),
+        PollOpt::edge(),
+    )
+    .unwrap();
 
     let mut events = Events::with_capacity(1024);
     while events.is_empty() {
@@ -89,8 +94,13 @@ fn write_then_deregister() {
         PollOpt::edge(),
     )
     .unwrap();
-    s.register(poll.registry(), Token(3), Interests::readable(), PollOpt::edge())
-        .unwrap();
+    s.register(
+        poll.registry(),
+        Token(3),
+        Interests::readable(),
+        PollOpt::edge(),
+    )
+    .unwrap();
 
     let mut events = Events::with_capacity(1024);
     while events.is_empty() {

--- a/test/test_write_then_drop.rs
+++ b/test/test_write_then_drop.rs
@@ -15,13 +15,13 @@ fn write_then_drop() {
     let mut poll = Poll::new().unwrap();
 
     a.register(
-        poll.register(),
+        poll.registry(),
         Token(1),
         Ready::readable(),
         PollOpt::edge(),
     )
     .unwrap();
-    s.register(poll.register(), Token(3), Ready::empty(), PollOpt::edge())
+    s.register(poll.registry(), Token(3), Ready::empty(), PollOpt::edge())
         .unwrap();
 
     let mut events = Events::with_capacity(1024);
@@ -34,7 +34,7 @@ fn write_then_drop() {
     let mut s2 = a.accept().unwrap().0;
 
     s2.register(
-        poll.register(),
+        poll.registry(),
         Token(2),
         Ready::writable(),
         PollOpt::edge(),
@@ -52,7 +52,7 @@ fn write_then_drop() {
     drop(s2);
 
     s.reregister(
-        poll.register(),
+        poll.registry(),
         Token(3),
         Ready::readable(),
         PollOpt::edge(),
@@ -81,13 +81,13 @@ fn write_then_deregister() {
     let mut poll = Poll::new().unwrap();
 
     a.register(
-        poll.register(),
+        poll.registry(),
         Token(1),
         Ready::readable(),
         PollOpt::edge(),
     )
     .unwrap();
-    s.register(poll.register(), Token(3), Ready::empty(), PollOpt::edge())
+    s.register(poll.registry(), Token(3), Ready::empty(), PollOpt::edge())
         .unwrap();
 
     let mut events = Events::with_capacity(1024);
@@ -100,7 +100,7 @@ fn write_then_deregister() {
     let mut s2 = a.accept().unwrap().0;
 
     s2.register(
-        poll.register(),
+        poll.registry(),
         Token(2),
         Ready::writable(),
         PollOpt::edge(),
@@ -115,10 +115,10 @@ fn write_then_deregister() {
     assert_eq!(events.iter().next().unwrap().token(), Token(2));
 
     s2.write_all(&[1, 2, 3, 4]).unwrap();
-    s2.deregister(poll.register()).unwrap();
+    s2.deregister(poll.registry()).unwrap();
 
     s.reregister(
-        poll.register(),
+        poll.registry(),
         Token(3),
         Ready::readable(),
         PollOpt::edge(),


### PR DESCRIPTION
This also makes `Poll::poll` require `&mut self` since `Poll` is no
longer expected to be stored in a `Sync` context.

Resolves #757

This is a very large change and I would not look for perfection, just that nothing in the change is terribly broken. This will be but one of many PRs to transition Mio to 0.7 and I am attempting to make it as incremental as possible.

cc @Thomasdezeeuw @stjepang 