### PR TITLE
Make `Option<Interests>` the same size as `Interests`

### DIFF
--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -980,13 +980,13 @@ const LIO: usize = 0b10_0000;
 /// they indicate what readiness should be monitored for. For example if a
 /// socket is registered with readable interests and the socket becomes
 /// writable, no event will be returned from [`poll`].
-/// 
+///
 /// The size of `Option<Interests>` should be identical to itself.
 ///
 /// ```
 /// use std::mem::size_of;
 /// use mio::Interests;
-/// 
+///
 /// assert_eq!(size_of::<Option<Interests>>(), size_of::<usize>());
 /// ```
 ///

--- a/test/test_echo_server.rs
+++ b/test/test_echo_server.rs
@@ -87,7 +87,9 @@ impl EchoConn {
             }
             Err(e) => {
                 debug!("not implemented; client err={:?}", e);
-                if let Some(x) = self.interests.as_mut() {
+                if self.interests == Some(Interests::readable()) {
+                    self.interests = None;
+                } else if let Some(x) = self.interests.as_mut() {
                     *x -= Interests::readable();
                 }
             }
@@ -202,7 +204,9 @@ impl EchoClient {
 
                 self.mut_buf = Some(buf.flip());
 
-                if let Some(x) = self.interests.as_mut() {
+                if self.interests == Some(Interests::readable()) {
+                    self.interests = None;
+                } else if let Some(x) = self.interests.as_mut() {
                     *x -= Interests::readable();
                 }
 

--- a/test/test_uds_shutdown.rs
+++ b/test/test_uds_shutdown.rs
@@ -90,7 +90,9 @@ impl EchoConn {
             }
             Err(e) => {
                 debug!("not implemented; client err={:?}", e);
-                if let Some(x) = self.interests.as_mut() {
+                if self.interests == Some(Interests::readable()) {
+                    self.interests = None;
+                } else if let Some(x) = self.interests.as_mut() {
                     *x -= Interests::readable();
                 }
             }
@@ -185,7 +187,9 @@ impl EchoClient {
             }
             Ok(Some(r)) => {
                 if r == 0 {
-                    if let Some(x) = self.interests.as_mut() {
+                    if self.interests == Some(Interests::readable()) {
+                        self.interests = None;
+                    } else if let Some(x) = self.interests.as_mut() {
                         *x -= Interests::readable();
                     }
                     event_loop.shutdown();

--- a/test/test_unix_echo_server.rs
+++ b/test/test_unix_echo_server.rs
@@ -89,7 +89,9 @@ impl EchoConn {
             }
             Err(e) => {
                 debug!("not implemented; client err={:?}", e);
-                if let Some(x) = self.interests.as_mut() {
+                if self.interests == Some(Interests::readable()) {
+                    self.interests = None;
+                } else if let Some(x) = self.interests.as_mut() {
                     *x -= Interests::readable();
                 }
             }
@@ -207,7 +209,9 @@ impl EchoClient {
 
                 self.mut_buf = Some(buf.flip());
 
-                if let Some(x) = self.interests.as_mut() {
+                if self.interests == Some(Interests::readable()) {
+                    self.interests = None;
+                } else if let Some(x) = self.interests.as_mut() {
                     *x -= Interests::readable();
                 }
 

--- a/test/test_unix_pass_fd.rs
+++ b/test/test_unix_pass_fd.rs
@@ -82,10 +82,9 @@ impl EchoConn {
             }
             Err(e) => {
                 debug!("not implemented; client err={:?}", e);
-                if self.interests == Some(Interests::readable()) {
-                    self.interests = None;
-                } else if let Some(x) = self.interests.as_mut() {
-                    *x -= Interests::readable();
+                self.interests = match self.interests {
+                    Interests::readable() | None => None,
+                    _ => self.interests - Interests::readable(),
                 }
             }
         };

--- a/test/test_unix_pass_fd.rs
+++ b/test/test_unix_pass_fd.rs
@@ -82,7 +82,9 @@ impl EchoConn {
             }
             Err(e) => {
                 debug!("not implemented; client err={:?}", e);
-                if let Some(x) = self.interests.as_mut() {
+                if self.interests == Some(Interests::readable()) {
+                    self.interests = None;
+                } else if let Some(x) = self.interests.as_mut() {
                     *x -= Interests::readable();
                 }
             }


### PR DESCRIPTION
Issue #934

The problem in test case is still waiting. https://github.com/tokio-rs/mio/issues/934#issuecomment-492096665