### PR TITLE
Add more HUP tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,7 @@ task:
     - cargo build --no-default-features
   test_script:
     - . $HOME/.cargo/env
-    - cargo test
+    - RUST_BACKTRACE=1 cargo test
     - cargo test --no-default-features
   before_cache_script:
     - rm -rf $HOME/.cargo/registry/index

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-trigger: ["master", "v0.6.x"]
+trigger: ["master", "v0.6.x", "wtf-shutdown"]
 pr: ["master", "v0.6.x"]
 
 jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-trigger: ["master", "v0.6.x", "wtf-shutdown"]
+trigger: ["master", "v0.6.x"]
 pr: ["master", "v0.6.x"]
 
 jobs:

--- a/test/test_tcp_shutdown.rs
+++ b/test/test_tcp_shutdown.rs
@@ -209,7 +209,7 @@ fn test_graceful_shutdown() {
 
 #[test]
 fn test_abrupt_shutdown() {
-    // use net2::TcpStreamExt;
+    use net2::TcpStreamExt;
     use std::io::{self, Read, Write};
 
     let mut poll = TestPoll::new();

--- a/test/test_tcp_shutdown.rs
+++ b/test/test_tcp_shutdown.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 use std::net::Shutdown;
-use std::ops::Deref;
 use std::time::{Duration, Instant};
 
-use mio::{Token, Ready, PollOpt, Poll, Evented, Events};
+use mio::{Token, Ready, PollOpt, Poll, Events};
+use mio::event::Evented;
 use mio::net::TcpStream;
 
 struct TestPoll {
@@ -158,7 +158,7 @@ fn test_graceful_shutdown() {
 #[test]
 fn test_abrupt_shutdown() {
     use net2::TcpStreamExt;
-    use std::io::{self, Read, Write};
+    use std::io::{Read, Write};
 
     let mut poll = TestPoll::new();
     let mut buf = [0; 1024];
@@ -173,7 +173,7 @@ fn test_abrupt_shutdown() {
                   PollOpt::edge());
 
     let (mut socket, _) = listener.accept().unwrap();
-    socket.set_linger(None);
+    socket.set_linger(None).unwrap();
 
     // Wait to be connected
     poll.wait_for(Token(0), Ready::writable());

--- a/test/test_tcp_shutdown.rs
+++ b/test/test_tcp_shutdown.rs
@@ -225,23 +225,31 @@ fn test_abrupt_shutdown() {
                   PollOpt::edge());
 
     let (mut socket, _) = assert_ok!(listener.accept());
-    assert_ok!(socket.set_linger(None));
+    assert_ok!(socket.set_linger(Some(Duration::from_millis(0))));
+    // assert_ok!(socket.set_linger(None));
 
     // Wait to be connected
     assert_ready!(poll, Token(0), Ready::writable());
 
     // Write some data
 
+    /*
     assert_ok!(client.write(b"junk"));
 
     assert_ok!(socket.write(b"junk"));
     assert_ok!(socket.read(&mut buf[..1]));
+    */
 
     drop(socket);
 
     assert_hup_ready!(poll);
     assert_ready!(poll, Token(0), Ready::writable());
+    assert_ready!(poll, Token(0), Ready::readable());
 
+    let res = client.read(&mut buf);
+    assert!(res.is_err(), "not err = {:?}", res);
+
+    /*
     let mut rem = 5; // Because we want to be able to trigger the err
 
     while rem > 0 {
@@ -258,4 +266,5 @@ fn test_abrupt_shutdown() {
     }
 
     panic!("reading too much");
+    */
 }

--- a/test/test_tcp_shutdown.rs
+++ b/test/test_tcp_shutdown.rs
@@ -231,15 +231,6 @@ fn test_abrupt_shutdown() {
     // Wait to be connected
     assert_ready!(poll, Token(0), Ready::writable());
 
-    // Write some data
-
-    /*
-    assert_ok!(client.write(b"junk"));
-
-    assert_ok!(socket.write(b"junk"));
-    assert_ok!(socket.read(&mut buf[..1]));
-    */
-
     drop(socket);
 
     assert_hup_ready!(poll);
@@ -248,23 +239,4 @@ fn test_abrupt_shutdown() {
 
     let res = client.read(&mut buf);
     assert!(res.is_err(), "not err = {:?}", res);
-
-    /*
-    let mut rem = 5; // Because we want to be able to trigger the err
-
-    while rem > 0 {
-        assert_ready!(poll, Token(0), Ready::readable());
-
-        loop {
-            match client.read(&mut buf) {
-                Ok(n) if n > 0 => rem -= n,
-                Ok(_) => panic!("read(buf) -> Ok(0)"),
-                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(_) => return,
-            }
-        }
-    }
-
-    panic!("reading too much");
-    */
 }

--- a/test/test_tcp_shutdown.rs
+++ b/test/test_tcp_shutdown.rs
@@ -239,6 +239,7 @@ fn test_abrupt_shutdown() {
 
     drop(socket);
 
+    assert_hup_ready!(poll);
     assert_ready!(poll, Token(0), Ready::writable());
 
     let mut rem = 5; // Because we want to be able to trigger the err

--- a/test/test_tcp_shutdown.rs
+++ b/test/test_tcp_shutdown.rs
@@ -197,7 +197,7 @@ fn test_abrupt_shutdown() {
     socket.set_linger(None).unwrap();
 
     // Wait to be connected
-    poll.wait_for(Token(0), Ready::writable());
+    wait_for!(poll, Token(0), Ready::writable());
 
     // Write some data
 

--- a/test/test_tcp_shutdown.rs
+++ b/test/test_tcp_shutdown.rs
@@ -1,109 +1,195 @@
+use std::collections::HashMap;
 use std::net::Shutdown;
-use std::time::Duration;
+use std::ops::Deref;
+use std::time::{Duration, Instant};
 
-use mio::{Token, Ready, PollOpt, Poll, Events};
+use mio::{Token, Ready, PollOpt, Poll, Evented, Events};
 use mio::net::TcpStream;
 
-macro_rules! wait {
-    ($poll:ident, $ready:ident) => {{
-        use std::time::Instant;
+struct TestPoll {
+    poll: Poll,
+    events: Events,
+    buf: HashMap<Token, Ready>,
+}
 
+impl TestPoll {
+    fn new() -> TestPoll {
+        TestPoll {
+            poll: Poll::new().unwrap(),
+            events: Events::with_capacity(1024),
+            buf: HashMap::new(),
+        }
+    }
+
+    fn register<E: ?Sized>(&self, handle: &E, token: Token, interest: Ready, opts: PollOpt)
+        where E: Evented
+    {
+        self.poll.register(handle, token, interest, opts).unwrap();
+    }
+
+    fn wait_for(&mut self, token: Token, ready: Ready) {
         let now = Instant::now();
-        let mut events = Events::with_capacity(16);
-        let mut found = false;
 
-        while !found {
+        loop {
             if now.elapsed() > Duration::from_secs(5) {
                 panic!("not ready");
             }
 
-            $poll.poll(&mut events, Some(Duration::from_secs(1))).unwrap();
-
-            for event in &events {
-                #[cfg(unix)]
-                {
-                    use mio::unix::UnixReady;
-                    assert!(!UnixReady::from(event.readiness()).is_hup());
-                }
-
-                if event.token() == Token(0) && event.readiness().$ready() {
-                    found = true;
+            if let Some(curr) = self.buf.get(&token) {
+                if curr.contains(ready) {
                     break;
                 }
             }
+
+            self.poll.poll(&mut self.events, Some(Duration::from_secs(1))).unwrap();
+
+            for event in &self.events {
+                let curr = self.buf.entry(event.token())
+                    .or_insert(Ready::empty());
+
+                *curr |= event.readiness();
+            }
         }
-    }};
+
+        *self.buf.get_mut(&token).unwrap() -= ready;
+    }
+
+    fn assert_idle(&mut self) {
+        self.poll.poll(&mut self.events, Some(Duration::from_millis(100))).unwrap();
+
+        if let Some(e) = self.events.iter().next() {
+            panic!("expected idle; got = {:?}", e);
+        }
+    }
+
+    fn readiness(&self, token: Token) -> Ready {
+        self.buf.get(&token).map(|r| *r).unwrap_or(Ready::empty())
+    }
+}
+
+macro_rules! wait_for_hup {
+    ($poll:expr) => {
+        #[cfg(unix)]
+        {
+            use mio::unix::UnixReady;
+            $poll.wait_for(Token(0), UnixReady::hup().into());
+        }
+    }
 }
 
 #[test]
 fn test_write_shutdown() {
-    let poll = Poll::new().unwrap();
+    use std::io::prelude::*;
+
+    let mut poll = TestPoll::new();
 
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
 
-    let mut ready = Ready::readable() | Ready::writable();
-
-    #[cfg(unix)]
-    {
-        ready |= mio::unix::UnixReady::hup();
-    }
-
-    let client = TcpStream::connect(&addr).unwrap();
+    let mut client = TcpStream::connect(&addr).unwrap();
     poll.register(&client,
                   Token(0),
-                  ready,
-                  PollOpt::edge()).unwrap();
+                  Ready::readable() | Ready::writable(),
+                  PollOpt::edge());
 
     let (socket, _) = listener.accept().unwrap();
 
-    wait!(poll, is_writable);
-
-    let mut events = Events::with_capacity(16);
+    poll.wait_for(Token(0), Ready::writable());
 
     // Polling should not have any events
-    poll.poll(&mut events, Some(Duration::from_millis(100))).unwrap();
-    assert!(events.iter().next().is_none());
+    poll.assert_idle();
 
-    println!("SHUTTING DOWN");
     // Now, shutdown the write half of the socket.
     socket.shutdown(Shutdown::Write).unwrap();
 
-    wait!(poll, is_readable);
+    poll.wait_for(Token(0), Ready::readable());
+
+    #[cfg(unix)]
+    {
+        use mio::unix::UnixReady;
+
+        let readiness = poll.readiness(Token(0));
+        assert!(!UnixReady::from(readiness).is_hup());
+    }
+
+    let mut buf = [0; 1024];
+    let n = client.read(&mut buf).unwrap();
+    assert_eq!(n, 0);
 }
 
 #[test]
-fn test_full_shutdown() {
-    let poll = Poll::new().unwrap();
+fn test_graceful_shutdown() {
+    use std::io::prelude::*;
+
+    let mut poll = TestPoll::new();
+    let mut buf = [0; 1024];
 
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
 
-    let mut ready = Ready::readable() | Ready::writable();
-
-    #[cfg(unix)]
-    {
-        ready |= mio::unix::UnixReady::hup();
-    }
-
-    let client = TcpStream::connect(&addr).unwrap();
+    let mut client = TcpStream::connect(&addr).unwrap();
     poll.register(&client,
                   Token(0),
-                  ready,
-                  PollOpt::edge()).unwrap();
+                  Ready::readable() | Ready::writable(),
+                  PollOpt::edge());
 
-    let (socket, _) = listener.accept().unwrap();
+    let (mut socket, _) = listener.accept().unwrap();
 
-    wait!(poll, is_writable);
-
-    let mut events = Events::with_capacity(16);
+    poll.wait_for(Token(0), Ready::writable());
 
     // Polling should not have any events
-    poll.poll(&mut events, Some(Duration::from_millis(100))).unwrap();
-    assert!(events.iter().next().is_none());
+    poll.assert_idle();
 
-    println!("SHUTTING DOWN");
+    // Now, shutdown the write half of the socket.
+    client.shutdown(Shutdown::Write).unwrap();
+
+    let n = socket.read(&mut buf).unwrap();
+    assert_eq!(0, n);
     drop(socket);
 
-    wait!(poll, is_readable);
+    poll.wait_for(Token(0), Ready::readable());
+    wait_for_hup!(poll);
+
+    let mut buf = [0; 1024];
+    let n = client.read(&mut buf).unwrap();
+    assert_eq!(n, 0);
+}
+
+#[test]
+fn test_abrupt_shutdown() {
+    use net2::TcpStreamExt;
+    use std::io::{self, Read, Write};
+
+    let mut poll = TestPoll::new();
+    let mut buf = [0; 1024];
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let mut client = TcpStream::connect(&addr).unwrap();
+    poll.register(&client,
+                  Token(0),
+                  Ready::readable() | Ready::writable(),
+                  PollOpt::edge());
+
+    let (mut socket, _) = listener.accept().unwrap();
+    socket.set_linger(None);
+
+    // Wait to be connected
+    poll.wait_for(Token(0), Ready::writable());
+
+    // Write some data
+
+    client.write(b"junk").unwrap();
+
+    socket.read(&mut buf[..1]).unwrap();
+
+    drop(socket);
+
+    poll.wait_for(Token(0), Ready::readable());
+    poll.wait_for(Token(0), Ready::writable());
+    wait_for_hup!(poll);
+
+    let res = client.read(&mut buf);
+    assert!(res.is_err(), "res = {:?}", res);
 }

--- a/test/test_tcp_shutdown.rs
+++ b/test/test_tcp_shutdown.rs
@@ -225,7 +225,7 @@ fn test_abrupt_shutdown() {
                   PollOpt::edge());
 
     let (mut socket, _) = assert_ok!(listener.accept());
-    // assert_ok!(socket.set_linger(None));
+    assert_ok!(socket.set_linger(None));
 
     // Wait to be connected
     assert_ready!(poll, Token(0), Ready::writable());


### PR DESCRIPTION
This adds more tests verifying the behavior around returning `HUP` events.

This includes the start of a test helper (`TestPoll`) that will eventually be used in more tests. It is currently implemented directly in the test file to aid in merging back into master.