### PR TITLE
Add more CI targets for cross compilation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,9 +13,11 @@ task:
     - . $HOME/.cargo/env
     - cargo build
     - cargo build --no-default-features
-  test_script:
+  amd64_test_script:
     - . $HOME/.cargo/env
     - cargo test
-    - cargo test --no-default-features
+  i386_test_script:
+    - . $HOME/.cargo/env
+    - cargo test --target i686-unknown-freebsd
   before_cache_script:
     - rm -rf $HOME/.cargo/registry/index

--- a/ci/azure-cross-compile.yml
+++ b/ci/azure-cross-compile.yml
@@ -6,9 +6,17 @@ jobs:
   displayName: Cross
   strategy:
     matrix:
-      iOS:
+      iOS_64:
         vmImage: macOS-10.13
         target: x86_64-apple-ios
+
+      iOS_32:
+        vmImage: macOS-10.13
+        target: i386-apple-ios
+
+      iOS_ARM:
+        vmImage: macOS-10.13
+        target: armv7s-apple-ios
 
       Android:
         vmImage: ubuntu-16.04
@@ -26,6 +34,14 @@ jobs:
         vmImage: ubuntu-16.04
         target: x86_64-sun-solaris
 
+      Linux_ARM:
+        vmImage: ubuntu-16.04
+        target: arm-linux-androideabi
+
+      Linux_32:
+        vmImage: ubuntu-16.04
+        target: i686-unknown-linux-gnu
+
   pool:
     vmImage: $(vmImage)
 
@@ -37,7 +53,7 @@ jobs:
     - script: rustup target add $(target)
       displayName: "Add target"
 
-    - script: cargo check --target $(target)
+    - script: cargo build --target $(target)
       displayName: Check source
 
     - script: cargo check --tests --target $(target)


### PR DESCRIPTION
This should hopefully catch most errors related to secondary platforms.