### PR TITLE
Upgrade winapi to 0.3.7 and miow to 0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,8 @@ iovec = "0.1.1"
 libc = "0.2.42"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2.6"
-miow = "0.2.1"
-kernel32-sys = "0.2"
+winapi = { version = "0.3.7", features = ["minwindef", "minwinbase", "ioapiset", "winsock2"] }
+miow = "0.3.3"
 
 [dev-dependencies]
 env_logger = { version = "0.4.0", default-features = false }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -139,7 +139,6 @@
 use std::io;
 use std::os::windows::prelude::*;
 
-use kernel32;
 use winapi;
 
 mod awakener;
@@ -162,8 +161,8 @@ enum Family {
 }
 
 unsafe fn cancel(socket: &dyn AsRawSocket, overlapped: &Overlapped) -> io::Result<()> {
-    let handle = socket.as_raw_socket() as winapi::HANDLE;
-    let ret = kernel32::CancelIoEx(handle, overlapped.as_mut_ptr());
+    let handle = socket.as_raw_socket() as winapi::um::winnt::HANDLE;
+    let ret = winapi::um::ioapiset::CancelIoEx(handle, overlapped.as_mut_ptr());
     if ret == 0 {
         Err(io::Error::last_os_error())
     } else {
@@ -171,15 +170,15 @@ unsafe fn cancel(socket: &dyn AsRawSocket, overlapped: &Overlapped) -> io::Resul
     }
 }
 
-unsafe fn no_notify_on_instant_completion(handle: winapi::HANDLE) -> io::Result<()> {
+unsafe fn no_notify_on_instant_completion(handle: winapi::um::winnt::HANDLE) -> io::Result<()> {
     // TODO: move those to winapi
-    const FILE_SKIP_COMPLETION_PORT_ON_SUCCESS: winapi::UCHAR = 1;
-    const FILE_SKIP_SET_EVENT_ON_HANDLE: winapi::UCHAR = 2;
+    const FILE_SKIP_COMPLETION_PORT_ON_SUCCESS: winapi::shared::minwindef::UCHAR = 1;
+    const FILE_SKIP_SET_EVENT_ON_HANDLE: winapi::shared::minwindef::UCHAR = 2;
 
     let flags = FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE;
 
-    let r = kernel32::SetFileCompletionNotificationModes(handle, flags);
-    if r == winapi::TRUE {
+    let r = winapi::um::winbase::SetFileCompletionNotificationModes(handle, flags);
+    if r == winapi::shared::minwindef::TRUE {
         Ok(())
     } else {
         Err(io::Error::last_os_error())

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -13,8 +13,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{fmt, io};
 use winapi::shared::winerror::WAIT_TIMEOUT;
-use winapi::um::minwinbase::OVERLAPPED_ENTRY;
 use winapi::um::minwinbase::OVERLAPPED;
+use winapi::um::minwinbase::OVERLAPPED_ENTRY;
 
 /// Each Selector has a globally unique(ish) ID associated with it. This ID
 /// gets tracked by `TcpStream`, `TcpListener`, etc... when they are first

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -12,7 +12,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{fmt, io};
-use winapi::*;
+use winapi::shared::winerror::WAIT_TIMEOUT;
+use winapi::um::minwinbase::OVERLAPPED_ENTRY;
+use winapi::um::minwinbase::OVERLAPPED;
 
 /// Each Selector has a globally unique(ish) ID associated with it. This ID
 /// gets tracked by `TcpStream`, `TcpListener`, etc... when they are first

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -767,7 +767,6 @@ impl ListenerImp {
                 self.inner.accept.as_mut_ptr(),
             )?;
             Ok((socket, ready))
-
         });
         match res {
             Ok((socket, _)) => {

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -19,7 +19,8 @@ use std::io::prelude::*;
 use std::mem;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::{Mutex, MutexGuard};
-use winapi::*;
+use winapi::um::winsock2::WSAEMSGSIZE;
+use winapi::um::minwinbase::OVERLAPPED_ENTRY;
 
 pub struct UdpSocket {
     imp: Imp,

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -19,8 +19,8 @@ use std::io::prelude::*;
 use std::mem;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::{Mutex, MutexGuard};
-use winapi::um::winsock2::WSAEMSGSIZE;
 use winapi::um::minwinbase::OVERLAPPED_ENTRY;
+use winapi::um::winsock2::WSAEMSGSIZE;
 
 pub struct UdpSocket {
     imp: Imp,

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -1,6 +1,5 @@
 #![allow(deprecated)]
 
-
 #[macro_use]
 extern crate log;
 

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -1,6 +1,5 @@
 #![allow(deprecated)]
 
-use net2;
 
 #[macro_use]
 extern crate log;
@@ -172,7 +171,6 @@ mod ports {
 
 pub fn sleep_ms(ms: u64) {
     use std::thread;
-    use std::time::Duration;
     thread::sleep(Duration::from_millis(ms));
 }
 

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -1,6 +1,5 @@
 use crate::localhost;
 use bytes::{Buf, MutBuf, RingBuf, SliceBuf};
-use iovec::IoVec;
 use mio::net::UdpSocket;
 use mio::{Events, Interests, Poll, PollOpt, Token};
 use std::io::ErrorKind;

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -187,6 +187,8 @@ pub fn test_udp_socket_discard() {
 #[cfg(unix)]
 #[test]
 pub fn test_udp_socket_send_recv_bufs() {
+    use iovec::IoVec;
+
     let (tx, rx) = connected_sockets();
 
     let mut poll = Poll::new().unwrap();


### PR DESCRIPTION
winapi `0.2` is still being pulled in by `iovec`, but that would be fixed with https://github.com/carllerche/iovec/pull/24