### PR TITLE
tcp: make TcpStream accept any ToSocketAddrs implementor

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -273,7 +273,7 @@ use std::{isize, mem, ops};
 /// use std::time::Duration;
 /// use std::thread;
 ///
-/// let sock = TcpStream::connect(&"216.58.193.100:80".parse()?)?;
+/// let sock = TcpStream::connect("216.58.193.100:80")?;
 ///
 /// thread::sleep(Duration::from_secs(1));
 ///
@@ -889,7 +889,7 @@ impl Registry {
     ///
     /// let mut poll = Poll::new()?;
     /// let registry = poll.registry().clone();
-    /// let socket = TcpStream::connect(&"216.58.193.100:80".parse()?)?;
+    /// let socket = TcpStream::connect("216.58.193.100:80")?;
     ///
     /// // Register the socket with `poll`
     /// registry.register(
@@ -985,7 +985,7 @@ impl Registry {
     ///
     /// let mut poll = Poll::new()?;
     /// let registry = poll.registry().clone();
-    /// let socket = TcpStream::connect(&"216.58.193.100:80".parse()?)?;
+    /// let socket = TcpStream::connect("216.58.193.100:80")?;
     ///
     /// // Register the socket with `poll`, requesting readable
     /// registry.register(
@@ -1063,7 +1063,7 @@ impl Registry {
     ///
     /// let mut poll = Poll::new()?;
     /// let registry = poll.registry().clone();
-    /// let socket = TcpStream::connect(&"216.58.193.100:80".parse()?)?;
+    /// let socket = TcpStream::connect("216.58.193.100:80")?;
     ///
     /// // Register the socket with `poll`
     /// registry.register(

--- a/test/test_tcp.rs
+++ b/test/test_tcp.rs
@@ -644,7 +644,7 @@ fn connect_error() {
     let mut events = Events::with_capacity(16);
 
     // Pick a "random" port that shouldn't be in use.
-    let l = match TcpStream::connect(&"127.0.0.1:38381".parse().unwrap()) {
+    let l = match TcpStream::connect("127.0.0.1:38381") {
         Ok(l) => l,
         Err(ref e) if e.kind() == io::ErrorKind::ConnectionRefused => {
             // Connection failed synchronously.  This is not a bug, but it


### PR DESCRIPTION
This mirrors what `std::net::TcpStream` does.

You can still pass a `&SocketAddr` as it implements `ToSocketAddrs`
so it is backward compatible in this regards.

Because of type inference though, this prevents from doing:
```
TcpStream::connect(&"127.0.0.1:80".parse())
```
But it allows this instead:
```
TcpStream::connect("127.0.0.1:80")
```
It also has the benefit of adding DNS support so this is ok too:
```
TcpStream::connect("localhost:80")
```