### PR TITLE
 Add RUST_BACKTRACE env variable to CI build 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,9 @@
 freebsd_instance:
   image: freebsd-11-2-release-amd64
 
+env:
+  RUST_BACKTRACE: full
+
 task:
   name: FreeBSD 11.2 amd64
   setup_script:

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -18,6 +18,9 @@ jobs:
   pool:
     vmImage: $(vmImage)
 
+  variables:
+    RUST_BACKTRACE: full
+
   steps:
   - template: azure-install-rust.yml
     parameters:


### PR DESCRIPTION
For obvious reasons the second commit shouldn't be commited and it's only to test the backtrace is shown properly.