### PR TITLE
Make Event a wrapper around a platform event

### DIFF
--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -287,11 +287,6 @@ impl Interests {
     pub fn is_lio(&self) -> bool {
         (self.0.get() & LIO) != 0
     }
-
-    #[cfg(windows)]
-    pub(crate) fn to_ready(&self) -> Ready {
-        Ready(self.0.get() as u8)
-    }
 }
 
 impl ops::BitOr for Interests {
@@ -398,15 +393,14 @@ fn test_debug_interests() {
 
 /// An readiness event returned by [`Poll::poll`].
 ///
-/// `Event` is a [readiness state] paired with a [`Token`]. It is returned by
+/// `Event` is a readiness state paired with a [`Token`]. It is returned by
 /// [`Poll::poll`].
 ///
 /// For more documentation on polling and events, see [`Poll`].
 ///
-/// [`Poll::poll`]: ../struct.Poll.html#method.poll
-/// [`Poll`]: ../struct.Poll.html
-/// [readiness state]: ../struct.Ready.html
-/// [`Token`]: ../struct.Token.html
+/// [`Poll::poll`]: crate::Poll::poll
+/// [`Poll`]: crate::Poll
+/// [`Token`]: crate::Token
 #[repr(transparent)]
 pub struct Event {
     inner: sys::Event,
@@ -418,19 +412,19 @@ impl Event {
         self.inner.token()
     }
 
-    /// Returns true if the `Ready` set contains readable readiness.
+    /// Returns true if the event contains readable readiness.
     #[inline]
     pub fn is_readable(&self) -> bool {
         self.inner.is_readable()
     }
 
-    /// Returns true if the `Ready` set contains writable readiness.
+    /// Returns true if the event contains writable readiness.
     #[inline]
     pub fn is_writable(&self) -> bool {
         self.inner.is_writable()
     }
 
-    /// Returns true if the `Ready` set contains error readiness.
+    /// Returns true if the event contains error readiness.
     ///
     /// Error events occur when the socket enters an error state. In this case,
     /// the socket will also receive a readable or writable event. Reading or
@@ -445,7 +439,7 @@ impl Event {
         self.inner.is_error()
     }
 
-    /// Returns true if the `Ready` set contains HUP readiness.
+    /// Returns true if the event contains HUP readiness.
     ///
     /// HUP events occur when the remote end of a socket hangs up. In the TCP
     /// case, this occurs when the remote end of a TCP socket shuts down writes.
@@ -462,7 +456,7 @@ impl Event {
         self.inner.is_hup()
     }
 
-    /// Returns true if the `Ready` set contains priority readiness.
+    /// Returns true if the event contains priority readiness.
     ///
     /// # Notes
     ///
@@ -473,7 +467,7 @@ impl Event {
         self.inner.is_priority()
     }
 
-    /// Returns true if the `Ready` set contains AIO readiness.
+    /// Returns true if the event contains AIO readiness.
     ///
     /// # Notes
     ///
@@ -484,7 +478,7 @@ impl Event {
         self.inner.is_aio()
     }
 
-    /// Returns true if the `Ready` set contains LIO readiness.
+    /// Returns true if the event contains LIO readiness.
     ///
     /// # Notes
     ///

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -511,6 +511,15 @@ impl Event {
 
 impl fmt::Debug for Event {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
+        f.debug_struct("Event")
+            .field("token", &self.token())
+            .field("readable", &self.is_readable())
+            .field("writable", &self.is_writable())
+            .field("error", &self.is_error())
+            .field("hup", &self.is_hup())
+            .field("priority", &self.is_priority())
+            .field("aio", &self.is_aio())
+            .field("lio", &self.is_lio())
+            .finish()
     }
 }

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -497,14 +497,14 @@ impl Event {
 
     /// Get access to the platform specific event, the returned value differs
     /// per platform.
-    pub fn raw_event(&self) -> &SysEvent {
-        &self.inner.raw_event()
+    pub fn sys_event(&self) -> &SysEvent {
+        &self.inner.sys_event()
     }
 
     /// Create an `Event` from a platform specific event.
-    pub fn from_raw_event(raw_event: SysEvent) -> Event {
+    pub fn from_sys_event(sys_event: SysEvent) -> Event {
         Event {
-            inner: sys::Event::from_raw_event(raw_event),
+            inner: sys::Event::from_sys_event(sys_event),
         }
     }
 }

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -495,12 +495,6 @@ impl Event {
         self.inner.is_lio()
     }
 
-    /// Get access to the platform specific event, the returned value differs
-    /// per platform.
-    pub fn sys_event(&self) -> &SysEvent {
-        &self.inner.sys_event()
-    }
-
     /// Create an `Event` from a platform specific event.
     pub fn from_sys_event(sys_event: SysEvent) -> Event {
         Event {

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -287,6 +287,11 @@ impl Interests {
     pub fn is_lio(&self) -> bool {
         (self.0.get() & LIO) != 0
     }
+
+    #[cfg(windows)]
+    pub(crate) fn as_u8(self) -> u8 {
+        self.0.get()
+    }
 }
 
 impl ops::BitOr for Interests {

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -1,4 +1,4 @@
-use crate::{Registry, Token};
+use crate::{sys, Registry, Token};
 use std::num::NonZeroU8;
 use std::{fmt, io, ops};
 
@@ -144,522 +144,6 @@ impl<T: Evented> Evented for ::std::sync::Arc<T> {
     }
 }
 
-/// A set of readiness event kinds
-///
-/// `Ready` is a set of operation descriptors indicating which kind of an
-/// operation is ready to be performed. For example, `Ready::READABLE`
-/// indicates that the associated `Evented` handle is ready to perform a
-/// `read` operation.
-///
-/// `Ready` values can be combined together using the various bitwise operators.
-///
-/// For high level documentation on polling and readiness, see [`Poll`].
-///
-/// [`Poll`]: crate::Poll
-///
-/// # Notes
-///
-/// This struct represents both portable an non-portable readiness indicators.
-/// Only [readable] and [writable] events are guaranteed to be raised on
-/// all systems, and so those are available on all systems.
-///
-/// But this also provides a number of non-portable readiness indicators, such
-/// as [error], [hup], [priority], [AIO] and [LIO]. These are **not** available
-/// on all platforms, and can only be created on platforms that support it.
-/// However it is possible to check for their presence in a set on all
-/// platforms. These indicators should be treated as a hint.
-///
-/// [readable]: Ready::READABLE
-/// [writable]: Ready::WRITABLE
-/// [error]: Ready::ERROR
-/// [hup]: Ready::HUP
-/// [priority]: Ready::PRIORITY
-/// [AIO]: Ready::AIO
-/// [LIO]: Ready::LIO
-///
-/// # Examples
-///
-/// ```
-/// use mio::Ready;
-///
-/// let ready = Ready::READABLE | Ready::WRITABLE;
-///
-/// assert!(ready.is_readable());
-/// assert!(ready.is_writable());
-/// ```
-#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
-pub struct Ready(u8);
-
-// These must be unique. These are shared with `Interests`.
-const EMPTY: u8 = 0b0_000_000;
-const READABLE: u8 = 0b0_000_001;
-const WRITABLE: u8 = 0b0_000_010;
-// The following are not available on all platforms.
-const ERROR: u8 = 0b0_000_100;
-const HUP: u8 = 0b0_001_000;
-const PRIORITY: u8 = 0b0_010_000;
-const AIO: u8 = 0b0_100_000;
-const LIO: u8 = 0b1_000_000;
-
-impl Ready {
-    /// Returns an empty `Ready` set.
-    pub const EMPTY: Ready = Ready(EMPTY);
-
-    /// Returns a `Ready` set representing readable readiness.
-    pub const READABLE: Ready = Ready(READABLE);
-
-    /// Returns a `Ready` set representing writable readiness.
-    pub const WRITABLE: Ready = Ready(WRITABLE);
-
-    /// Returns a `Ready` set representing error readiness.
-    #[cfg(unix)]
-    pub const ERROR: Ready = Ready(ERROR);
-
-    /// Returns a `Ready` set representing HUP readiness.
-    #[cfg(unix)]
-    pub const HUP: Ready = Ready(HUP);
-
-    /// Returns a `Ready` set representing priority readiness.
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
-    pub const PRIORITY: Ready = Ready(PRIORITY);
-
-    /// Returns a `Ready` set representing AIO completion readiness.
-    #[cfg(any(
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos"
-    ))]
-    pub const AIO: Ready = Ready(AIO);
-
-    /// Returns a `Ready` set representing LIO completion readiness.
-    #[cfg(any(target_os = "freebsd"))]
-    pub const LIO: Ready = Ready(LIO);
-
-    /// Returns true if the `Ready` set is empty.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::Ready;
-    ///
-    /// let ready = Ready::EMPTY;
-    /// assert!(ready.is_empty());
-    /// ```
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.0 == EMPTY
-    }
-
-    /// Returns true if the `Ready` set contains readable readiness.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::Ready;
-    ///
-    /// let ready = Ready::READABLE;
-    /// assert!(ready.is_readable());
-    /// ```
-    #[inline]
-    pub fn is_readable(&self) -> bool {
-        self.contains(Ready::READABLE)
-    }
-
-    /// Returns true if the `Ready` set contains writable readiness.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::Ready;
-    ///
-    /// let ready = Ready::WRITABLE;
-    /// assert!(ready.is_writable());
-    /// ```
-    #[inline]
-    pub fn is_writable(&self) -> bool {
-        self.contains(Ready::WRITABLE)
-    }
-
-    /// Returns true if the `Ready` set contains error readiness.
-    ///
-    /// Error events occur when the socket enters an error state. In this case,
-    /// the socket will also receive a readable or writable event. Reading or
-    /// writing to the socket will result in an error.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[cfg(unix)]
-    /// # {
-    /// use mio::Ready;
-    ///
-    /// let ready = Ready::ERROR;
-    /// assert!(ready.is_error());
-    /// # }
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// Method is available on all platforms, but not all platforms (can) use
-    /// this indicator.
-    #[inline]
-    pub fn is_error(&self) -> bool {
-        self.contains(Ready(ERROR))
-    }
-
-    /// Returns true if the `Ready` set contains HUP readiness.
-    ///
-    /// HUP events occur when the remote end of a socket hangs up. In the TCP
-    /// case, this occurs when the remote end of a TCP socket shuts down writes.
-    ///
-    /// It is also unclear if HUP readiness will remain in 0.7. See
-    /// [here](https://github.com/tokio-rs/mio/issues/941)
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[cfg(unix)]
-    /// # {
-    /// use mio::Ready;
-    ///
-    /// let ready = Ready::HUP;
-    /// assert!(ready.is_hup());
-    /// # }
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// Method is available on all platforms, but not all platforms (can) use
-    /// this indicator.
-    #[inline]
-    pub fn is_hup(&self) -> bool {
-        self.contains(Ready(HUP))
-    }
-
-    /// Returns true if the `Ready` set contains priority readiness.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
-    /// # {
-    /// use mio::Ready;
-    ///
-    /// let ready = Ready::PRIORITY;
-    /// assert!(ready.is_priority());
-    /// # }
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// Method is available on all platforms, but not all platforms (can) use
-    /// this indicator.
-    #[inline]
-    pub fn is_priority(&self) -> bool {
-        self.contains(Ready(PRIORITY))
-    }
-
-    /// Returns true if the `Ready` set contains AIO readiness.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[cfg(any( target_os = "dragonfly", target_os = "freebsd", target_os = "ios", target_os = "macos"))]
-    /// # {
-    /// use mio::Ready;
-    ///
-    /// let ready = Ready::AIO;
-    /// assert!(ready.is_aio());
-    /// # }
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// Method is available on all platforms, but not all platforms (can) use
-    /// this indicator.
-    #[inline]
-    pub fn is_aio(&self) -> bool {
-        self.contains(Ready(AIO))
-    }
-
-    /// Returns true if the `Ready` set contains LIO readiness.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[cfg(any(target_os = "freebsd"))]
-    /// # {
-    /// use mio::Ready;
-    ///
-    /// let ready = Ready::LIO;
-    /// assert!(ready.is_lio());
-    /// # }
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// Method is available on all platforms, but not all platforms (can) use
-    /// this indicator.
-    #[inline]
-    pub fn is_lio(&self) -> bool {
-        self.contains(Ready(LIO))
-    }
-
-    /// Adds all readiness in the `other` set into `self`.
-    ///
-    /// This is equivalent to `*self = *self | other`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::Ready;
-    ///
-    /// let mut readiness = Ready::EMPTY;
-    /// readiness.insert(Ready::READABLE);
-    /// assert!(readiness.is_readable());
-    /// ```
-    #[inline]
-    pub fn insert(&mut self, other: Ready) {
-        self.0 |= other.0;
-    }
-
-    /// Removes all options represented by `other` from `self`.
-    ///
-    /// This is equivalent to `*self = *self & !other`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::Ready;
-    ///
-    /// let mut readiness = Ready::READABLE;
-    /// readiness.remove(Ready::READABLE);
-    /// assert!(!readiness.is_readable());
-    /// ```
-    #[inline]
-    pub fn remove(&mut self, other: Ready) {
-        self.0 &= !other.0;
-    }
-
-    /// Returns true if `self` is a superset of `other`.
-    ///
-    /// The `other` set may represent more than one readiness operations, in
-    /// which case the function only returns true if `self` contains **all**
-    /// readiness specified in `other`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::Ready;
-    ///
-    /// let readiness = Ready::READABLE;
-    /// assert!(readiness.contains(Ready::READABLE));
-    /// assert!(!readiness.contains(Ready::WRITABLE));
-    /// ```
-    ///
-    /// ```
-    /// use mio::Ready;
-    ///
-    /// let readiness = Ready::READABLE | Ready::WRITABLE;
-    ///
-    /// assert!(readiness.contains(Ready::READABLE));
-    /// assert!(readiness.contains(Ready::WRITABLE));
-    /// ```
-    ///
-    /// ```
-    /// use mio::Ready;
-    ///
-    /// let readiness = Ready::READABLE | Ready::WRITABLE;
-    /// assert!(!Ready::READABLE.contains(readiness));
-    /// assert!(readiness.contains(readiness));
-    /// ```
-    #[inline]
-    pub fn contains(&self, other: Ready) -> bool {
-        (self.0 & other.0) == other.0
-    }
-
-    /// Create a `Ready` instance using the given `usize` representation.
-    ///
-    /// The `usize` representation must have been obtained from a call to
-    /// `Ready::as_usize`.
-    ///
-    /// The `usize` representation must be treated as opaque. There is no
-    /// guaranteed correlation between the returned value and platform defined
-    /// constants. Also, there is no guarantee that the `usize` representation
-    /// will remain constant across patch releases of Mio.
-    ///
-    /// This function is mainly provided to allow the caller to loa a
-    /// readiness value from an `AtomicUsize`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::Ready;
-    ///
-    /// let ready = Ready::READABLE;
-    /// let ready_usize = ready.as_usize();
-    /// let ready2 = Ready::from_usize(ready_usize);
-    /// assert_eq!(ready, ready2);
-    /// ```
-    pub fn from_usize(val: usize) -> Ready {
-        Ready(val as u8)
-    }
-
-    /// Returns a `usize` representation of the `Ready` value.
-    ///
-    /// This `usize` representation must be treated as opaque. There is no
-    /// guaranteed correlation between the returned value and platform defined
-    /// constants. Also, there is no guarantee that the `usize` representation
-    /// will remain constant across patch releases of Mio.
-    ///
-    /// This function is mainly provided to allow the caller to store a
-    /// readiness value in an `AtomicUsize`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::Ready;
-    ///
-    /// let ready = Ready::READABLE;
-    /// let ready_usize = ready.as_usize();
-    /// let ready2 = Ready::from_usize(ready_usize);
-    /// assert_eq!(ready, ready2);
-    /// ```
-    pub fn as_usize(&self) -> usize {
-        self.0 as usize
-    }
-}
-
-impl ops::BitOr for Ready {
-    type Output = Ready;
-
-    #[inline]
-    fn bitor(self, other: Ready) -> Ready {
-        Ready(self.0 | other.0)
-    }
-}
-
-impl ops::BitOrAssign for Ready {
-    #[inline]
-    fn bitor_assign(&mut self, other: Ready) {
-        self.0 |= other.0;
-    }
-}
-
-impl ops::BitXor for Ready {
-    type Output = Ready;
-
-    #[inline]
-    fn bitxor(self, other: Ready) -> Ready {
-        Ready(self.0 ^ other.0)
-    }
-}
-
-impl ops::BitXorAssign for Ready {
-    #[inline]
-    fn bitxor_assign(&mut self, other: Ready) {
-        self.0 ^= other.0;
-    }
-}
-
-impl ops::BitAnd for Ready {
-    type Output = Ready;
-
-    #[inline]
-    fn bitand(self, other: Ready) -> Ready {
-        Ready(self.0 & other.0)
-    }
-}
-
-impl ops::BitAndAssign for Ready {
-    #[inline]
-    fn bitand_assign(&mut self, other: Ready) {
-        self.0 &= other.0
-    }
-}
-
-impl ops::Sub for Ready {
-    type Output = Ready;
-
-    #[inline]
-    fn sub(self, other: Ready) -> Ready {
-        Ready(self.0 & !other.0)
-    }
-}
-
-impl ops::SubAssign for Ready {
-    #[inline]
-    fn sub_assign(&mut self, other: Ready) {
-        self.0 &= !other.0;
-    }
-}
-
-impl fmt::Debug for Ready {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut one = false;
-        let flags = [
-            (Ready(READABLE), "Readable"),
-            (Ready(WRITABLE), "Writable"),
-            (Ready(ERROR), "Error"),
-            (Ready(HUP), "Hup"),
-            (Ready(PRIORITY), "Priority"),
-            (Ready(AIO), "AIO"),
-            (Ready(LIO), "LIO"),
-        ];
-
-        for &(flag, msg) in &flags {
-            if self.contains(flag) {
-                if one {
-                    write!(fmt, " | ")?
-                }
-                write!(fmt, "{}", msg)?;
-
-                one = true
-            }
-        }
-
-        if !one {
-            fmt.write_str("(empty)")?;
-        }
-
-        Ok(())
-    }
-}
-
-#[test]
-fn fmt_debug() {
-    assert_eq!("(empty)", format!("{:?}", Ready::EMPTY));
-    assert_eq!("Readable", format!("{:?}", Ready::READABLE));
-    assert_eq!("Writable", format!("{:?}", Ready::WRITABLE));
-    assert_eq!("Error", format!("{:?}", Ready(ERROR)));
-    assert_eq!("Hup", format!("{:?}", Ready(HUP)));
-    assert_eq!("Priority", format!("{:?}", Ready(PRIORITY)));
-    assert_eq!("AIO", format!("{:?}", Ready(AIO)));
-    assert_eq!("LIO", format!("{:?}", Ready(LIO)));
-    assert_eq!(
-        "Readable | Writable",
-        format!("{:?}", Ready::READABLE | Ready::WRITABLE)
-    );
-}
-
-/* TODO(Thomas): check if this is still relevant.
-#[test]
-fn test_ready_all() {
-    let readable = Ready::READABLE.as_usize();
-    let writable = Ready::WRITABLE.as_usize();
-
-    assert_eq!(
-        READY_ALL | readable | writable,
-        ERROR + HUP + AIO + LIO + PRI + readable + writable
-    );
-
-    // Issue #896.
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
-    assert!(!Ready::from(Ready::PRIORITY).is_writable());
-}
-*/
-
 /// Interests used in registering.
 ///
 /// Interests are used in registering [`Evented`] handles with [`Poll`],
@@ -683,6 +167,21 @@ fn test_ready_all() {
 #[repr(transparent)]
 pub struct Interests(NonZeroU8);
 
+// These must be unique.
+const READABLE: u8 = 0b0_000_001;
+const WRITABLE: u8 = 0b0_000_010;
+// The following are not available on all platforms.
+#[allow(dead_code)]
+const ERROR: u8 = 0b0_000_100;
+#[allow(dead_code)]
+const HUP: u8 = 0b0_001_000;
+#[allow(dead_code)]
+const PRIORITY: u8 = 0b0_010_000;
+#[allow(dead_code)]
+const AIO: u8 = 0b0_100_000;
+#[allow(dead_code)]
+const LIO: u8 = 0b1_000_000;
+
 impl Interests {
     /// Returns a `Interests` set representing readable interests.
     pub const READABLE: Interests = Interests(unsafe { NonZeroU8::new_unchecked(READABLE) });
@@ -700,7 +199,7 @@ impl Interests {
     pub const AIO: Interests = Interests(unsafe { NonZeroU8::new_unchecked(AIO) });
 
     /// Returns a `Interests` set representing LIO completion interests.
-    #[cfg(any(target_os = "freebsd"))]
+    #[cfg(target_os = "freebsd")]
     pub const LIO: Interests = Interests(unsafe { NonZeroU8::new_unchecked(LIO) });
 
     /// Returns true if the value includes readable readiness.
@@ -906,7 +405,7 @@ fn test_debug_interests() {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// use mio::{Ready, Token};
 /// use mio::event::Event;
 ///
@@ -920,85 +419,110 @@ fn test_debug_interests() {
 /// [`Poll`]: ../struct.Poll.html
 /// [readiness state]: ../struct.Ready.html
 /// [`Token`]: ../struct.Token.html
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[repr(transparent)]
 pub struct Event {
-    kind: Ready,
-    token: Token,
+    inner: sys::Event,
 }
 
 impl Event {
-    /// Creates a new `Event` containing `readiness` and `token`
+    /// Returns the event's token.
+    pub fn token(&self) -> Token {
+        self.inner.token()
+    }
+
+    /// Returns true if the `Ready` set contains readable readiness.
+    #[inline]
+    pub fn is_readable(&self) -> bool {
+        self.inner.is_readable()
+    }
+
+    /// Returns true if the `Ready` set contains writable readiness.
+    #[inline]
+    pub fn is_writable(&self) -> bool {
+        self.inner.is_writable()
+    }
+
+    /// Returns true if the `Ready` set contains error readiness.
     ///
-    /// # Examples
+    /// Error events occur when the socket enters an error state. In this case,
+    /// the socket will also receive a readable or writable event. Reading or
+    /// writing to the socket will result in an error.
     ///
-    /// ```
-    /// use mio::{Ready, Token};
-    /// use mio::event::Event;
+    /// # Notes
     ///
-    /// let event = Event::new(Ready::READABLE | Ready::WRITABLE, Token(0));
+    /// Method is available on all platforms, but not all platforms (can) use
+    /// this indicator.
+    #[inline]
+    pub fn is_error(&self) -> bool {
+        self.inner.is_error()
+    }
+
+    /// Returns true if the `Ready` set contains HUP readiness.
     ///
-    /// assert_eq!(event.readiness(), Ready::READABLE | Ready::WRITABLE);
-    /// assert_eq!(event.token(), Token(0));
-    /// ```
-    pub fn new(readiness: Ready, token: Token) -> Event {
+    /// HUP events occur when the remote end of a socket hangs up. In the TCP
+    /// case, this occurs when the remote end of a TCP socket shuts down writes.
+    ///
+    /// It is also unclear if HUP readiness will remain in 0.7. See
+    /// [here](https://github.com/tokio-rs/mio/issues/941)
+    ///
+    /// # Notes
+    ///
+    /// Method is available on all platforms, but not all platforms (can) use
+    /// this indicator.
+    #[inline]
+    pub fn is_hup(&self) -> bool {
+        self.inner.is_hup()
+    }
+
+    /// Returns true if the `Ready` set contains priority readiness.
+    ///
+    /// # Notes
+    ///
+    /// Method is available on all platforms, but not all platforms (can) use
+    /// this indicator.
+    #[inline]
+    pub fn is_priority(&self) -> bool {
+        self.inner.is_priority()
+    }
+
+    /// Returns true if the `Ready` set contains AIO readiness.
+    ///
+    /// # Notes
+    ///
+    /// Method is available on all platforms, but not all platforms (can) use
+    /// this indicator.
+    #[inline]
+    pub fn is_aio(&self) -> bool {
+        self.inner.is_aio()
+    }
+
+    /// Returns true if the `Ready` set contains LIO readiness.
+    ///
+    /// # Notes
+    ///
+    /// Method is available on all platforms, but not all platforms (can) use
+    /// this indicator.
+    #[inline]
+    pub fn is_lio(&self) -> bool {
+        self.inner.is_lio()
+    }
+
+    /// Get access to the platform specific event, the returned value differs
+    /// per platform.
+    pub fn raw_event(&self) -> &sys::RawEvent {
+        &self.inner.raw_event()
+    }
+
+    /// Create an `Event` from a platform specific event.
+    pub fn from_raw_event(raw_event: sys::RawEvent) -> Event {
         Event {
-            kind: readiness,
-            token,
+            inner: sys::Event::from_raw_event(raw_event),
         }
     }
+}
 
-    /// Returns the event's readiness.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::{Ready, Token};
-    /// use mio::event::Event;
-    ///
-    /// let event = Event::new(Ready::READABLE | Ready::WRITABLE, Token(0));
-    ///
-    /// assert_eq!(event.readiness(), Ready::READABLE | Ready::WRITABLE);
-    /// ```
-    pub fn readiness(&self) -> Ready {
-        self.kind
+impl fmt::Debug for Event {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
     }
-
-    /// Returns the event's token.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::{Ready, Token};
-    /// use mio::event::Event;
-    ///
-    /// let event = Event::new(Ready::READABLE | Ready::WRITABLE, Token(0));
-    ///
-    /// assert_eq!(event.token(), Token(0));
-    /// ```
-    pub fn token(&self) -> Token {
-        self.token
-    }
-}
-
-/*
- *
- * ===== Mio internal helpers =====
- *
- */
-
-#[cfg(windows)]
-pub fn ready_as_usize(events: Ready) -> usize {
-    events.as_usize()
-}
-
-#[cfg(windows)]
-pub fn ready_from_usize(events: usize) -> Ready {
-    Ready::from_usize(events)
-}
-
-// Used internally to mutate an `Event` in place
-// Not used on all platforms
-#[allow(dead_code)]
-pub fn kind_mut(event: &mut Event) -> &mut Ready {
-    &mut event.kind
 }

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -496,7 +496,7 @@ impl Event {
     }
 
     /// Create an `Event` from a platform specific event.
-    pub fn from_sys_event(sys_event: SysEvent) -> Event {
+    pub(crate) fn from_sys_event(sys_event: SysEvent) -> Event {
         Event {
             inner: sys::Event::from_sys_event(sys_event),
         }

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -1,3 +1,4 @@
+use crate::sys::SysEvent;
 use crate::{sys, Registry, Token};
 use std::num::NonZeroU8;
 use std::{fmt, io, ops};
@@ -496,12 +497,12 @@ impl Event {
 
     /// Get access to the platform specific event, the returned value differs
     /// per platform.
-    pub fn raw_event(&self) -> &sys::RawEvent {
+    pub fn raw_event(&self) -> &SysEvent {
         &self.inner.raw_event()
     }
 
     /// Create an `Event` from a platform specific event.
-    pub fn from_raw_event(raw_event: sys::RawEvent) -> Event {
+    pub fn from_raw_event(raw_event: SysEvent) -> Event {
         Event {
             inner: sys::Event::from_raw_event(raw_event),
         }

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -403,18 +403,6 @@ fn test_debug_interests() {
 ///
 /// For more documentation on polling and events, see [`Poll`].
 ///
-/// # Examples
-///
-/// ```ignore
-/// use mio::{Ready, Token};
-/// use mio::event::Event;
-///
-/// let event = Event::new(Ready::READABLE | Ready::WRITABLE, Token(0));
-///
-/// assert_eq!(event.readiness(), Ready::READABLE | Ready::WRITABLE);
-/// assert_eq!(event.token(), Token(0));
-/// ```
-///
 /// [`Poll::poll`]: ../struct.Poll.html#method.poll
 /// [`Poll`]: ../struct.Poll.html
 /// [readiness state]: ../struct.Ready.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ mod waker;
 
 pub mod net;
 
-pub use event_imp::{Interests, Ready};
+pub use event_imp::Interests;
 pub use poll::{Poll, Registry};
 pub use token::Token;
 pub use waker::Waker;

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -173,10 +173,10 @@ use std::{fmt, io, usize};
 /// able to handle an error or HUP situation when performing the actual read
 /// operation.
 ///
-/// [`readable`]: Ready::READABLE
-/// [`writable`]: Ready::WRITABLE
-/// [`error`]: Ready::ERROR
-/// [`hup`]: Ready::HUP
+/// [`readable`]: crate::event::Event::is_readable
+/// [`writable`]: crate::event::Event::is_writable
+/// [`error`]: crate::event::Event::is_error
+/// [`hup`]: crate::event::Event::is_hup
 ///
 /// ### Registering handles
 ///
@@ -697,8 +697,8 @@ impl Registry {
     ///
     /// [`struct`]: #
     /// [`register`]: #method.register
-    /// [`readable`]: Ready::READABLE
-    /// [`writable`]: Ready::WRITABLE
+    /// [`readable`]: crate::event::Event::is_readable
+    /// [`writable`]: crate::event::Event::is_writable
     pub fn reregister<E: ?Sized>(
         &self,
         handle: &E,

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1026,7 +1026,7 @@ impl<'a> Iterator for Iter<'a> {
     type Item = Event;
 
     fn next(&mut self) -> Option<Event> {
-        let ret = self.inner.inner.get(self.pos).map(Event::from_raw_event);
+        let ret = self.inner.inner.get(self.pos).map(Event::from_sys_event);
         self.pos += 1;
         ret
     }
@@ -1048,7 +1048,7 @@ impl Iterator for IntoIter {
     type Item = Event;
 
     fn next(&mut self) -> Option<Event> {
-        let ret = self.inner.inner.get(self.pos).map(Event::from_raw_event);
+        let ret = self.inner.inner.get(self.pos).map(Event::from_sys_event);
         self.pos += 1;
         ret
     }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -535,8 +535,8 @@ impl Registry {
     /// See documentation on [`Token`] for an example showing how to pick
     /// [`Token`] values.
     ///
-    /// `interest: Ready`: Specifies which operations `Poll` should monitor for
-    /// readiness. `Poll` will only return readiness events for operations
+    /// `interest: Interests`: Specifies which operations `Poll` should monitor
+    /// for readiness. `Poll` will only return readiness events for operations
     /// specified by this argument.
     ///
     /// If a socket is registered with readable interest and the socket becomes

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -114,7 +114,7 @@ use std::{fmt, io, usize};
 ///     poll.poll(&mut events, None)?;
 ///
 ///     for event in &events {
-///         if event.token() == Token(0) && event.readiness().is_writable() {
+///         if event.token() == Token(0) && event.is_writable() {
 ///             // The socket connected (probably, it could still be a spurious
 ///             // wakeup)
 ///             return Ok(());
@@ -377,7 +377,7 @@ impl Poll {
     ///
     /// ```
     /// # use std::error::Error;
-    /// # fn try_main() -> Result<(), Box<Error>> {
+    /// # fn try_main() -> Result<(), Box<dyn Error>> {
     /// use mio::{Events, Poll, Interests, Token};
     /// use mio::net::TcpStream;
     ///
@@ -414,7 +414,7 @@ impl Poll {
     ///     poll.poll(&mut events, None)?;
     ///
     ///     for event in &events {
-    ///         if event.token() == Token(0) && event.readiness().is_writable() {
+    ///         if event.token() == Token(0) && event.is_writable() {
     ///             // The socket connected (probably, it could still be a spurious
     ///             // wakeup)
     ///             return Ok(());
@@ -1026,7 +1026,7 @@ impl<'a> Iterator for Iter<'a> {
     type Item = Event;
 
     fn next(&mut self) -> Option<Event> {
-        let ret = self.inner.inner.get(self.pos);
+        let ret = self.inner.inner.get(self.pos).map(Event::from_raw_event);
         self.pos += 1;
         ret
     }
@@ -1048,7 +1048,7 @@ impl Iterator for IntoIter {
     type Item = Event;
 
     fn next(&mut self) -> Option<Event> {
-        let ret = self.inner.inner.get(self.pos);
+        let ret = self.inner.inner.get(self.pos).map(Event::from_raw_event);
         self.pos += 1;
         ret
     }

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(unix)]
 pub use self::unix::{
-    pipe, set_nonblock, Event, EventedFd, Events, Io, RawEvent, Selector, TcpListener, TcpStream,
+    pipe, set_nonblock, Event, EventedFd, Events, Io, Selector, SysEvent, TcpListener, TcpStream,
     UdpSocket, Waker,
 };
 
@@ -9,7 +9,7 @@ pub mod unix;
 
 #[cfg(windows)]
 pub use self::windows::{
-    Binding, Event, Events, Overlapped, RawEvent, Selector, TcpListener, TcpStream, UdpSocket,
+    Binding, Event, Events, Overlapped, Selector, SysEvent, TcpListener, TcpStream, UdpSocket,
     Waker,
 };
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(unix)]
 pub use self::unix::{
-    pipe, set_nonblock, EventedFd, Events, Io, Selector, TcpListener, TcpStream, UdpSocket, Waker,
+    pipe, set_nonblock, Event, EventedFd, Events, Io, RawEvent, Selector, TcpListener, TcpStream,
+    UdpSocket, Waker,
 };
 
 #[cfg(unix)]
@@ -8,7 +9,8 @@ pub mod unix;
 
 #[cfg(windows)]
 pub use self::windows::{
-    Binding, Events, Overlapped, Selector, TcpListener, TcpStream, UdpSocket, Waker,
+    Binding, Event, Events, Overlapped, RawEvent, Selector, TcpListener, TcpStream, UdpSocket,
+    Waker,
 };
 
 #[cfg(windows)]

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -8,7 +8,7 @@ use std::os::unix::io::AsRawFd;
 use std::os::unix::io::RawFd;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
-use std::{cmp, fmt, i32, io};
+use std::{cmp, i32, io};
 
 /// Each Selector has a globally unique(ish) ID associated with it. This ID
 /// gets tracked by `TcpStream`, `TcpListener`, etc... when they are first
@@ -212,11 +212,11 @@ impl Event {
         false
     }
 
-    pub fn raw_event(&self) -> &SysEvent {
+    pub fn sys_event(&self) -> &SysEvent {
         &self.inner
     }
 
-    pub fn from_raw_event(epoll_event: SysEvent) -> Event {
+    pub fn from_sys_event(epoll_event: SysEvent) -> Event {
         Event { inner: epoll_event }
     }
 }

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -221,16 +221,6 @@ impl Event {
     }
 }
 
-impl fmt::Debug for Event {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: add readiness.
-        f.debug_struct("Event")
-            .field("token", &self.token())
-            //.field("readiness", &self.readiness())
-            .finish()
-    }
-}
-
 pub struct Events {
     events: Vec<libc::epoll_event>,
 }

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -212,10 +212,6 @@ impl Event {
         false
     }
 
-    pub fn sys_event(&self) -> &SysEvent {
-        &self.inner
-    }
-
     pub fn from_sys_event(epoll_event: SysEvent) -> Event {
         Event { inner: epoll_event }
     }

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -168,11 +168,11 @@ impl Drop for Selector {
     }
 }
 
-pub type RawEvent = libc::epoll_event;
+pub type SysEvent = libc::epoll_event;
 
 #[repr(transparent)]
 pub struct Event {
-    inner: RawEvent,
+    inner: SysEvent,
 }
 
 impl Event {
@@ -212,11 +212,11 @@ impl Event {
         false
     }
 
-    pub fn raw_event(&self) -> &RawEvent {
+    pub fn raw_event(&self) -> &SysEvent {
         &self.inner
     }
 
-    pub fn from_raw_event(epoll_event: RawEvent) -> Event {
+    pub fn from_raw_event(epoll_event: SysEvent) -> Event {
         Event { inner: epoll_event }
     }
 }
@@ -258,7 +258,7 @@ impl Events {
     }
 
     #[inline]
-    pub fn get(&self, idx: usize) -> Option<RawEvent> {
+    pub fn get(&self, idx: usize) -> Option<SysEvent> {
         self.events.get(idx).cloned()
     }
 

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -406,16 +406,6 @@ impl Event {
     }
 }
 
-impl fmt::Debug for Event {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: add readiness.
-        f.debug_struct("Event")
-            .field("token", &self.token())
-            //.field("readiness", &self.readiness())
-            .finish()
-    }
-}
-
 pub struct Events {
     events: Vec<SysEvent>,
 }

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -397,10 +397,6 @@ impl Event {
         }
     }
 
-    pub fn sys_event(&self) -> &SysEvent {
-        &self.inner
-    }
-
     pub fn from_sys_event(kevent: SysEvent) -> Event {
         Event { inner: kevent }
     }

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -317,11 +317,11 @@ impl Drop for Selector {
     }
 }
 
-pub type RawEvent = libc::kevent;
+pub type SysEvent = libc::kevent;
 
 #[repr(transparent)]
 pub struct Event {
-    inner: RawEvent,
+    inner: SysEvent,
 }
 
 impl Event {
@@ -397,11 +397,11 @@ impl Event {
         }
     }
 
-    pub fn raw_event(&self) -> &RawEvent {
+    pub fn raw_event(&self) -> &SysEvent {
         &self.inner
     }
 
-    pub fn from_raw_event(kevent: RawEvent) -> Event {
+    pub fn from_raw_event(kevent: SysEvent) -> Event {
         Event { inner: kevent }
     }
 }
@@ -417,7 +417,7 @@ impl fmt::Debug for Event {
 }
 
 pub struct Events {
-    events: Vec<RawEvent>,
+    events: Vec<SysEvent>,
 }
 
 impl Events {
@@ -442,7 +442,7 @@ impl Events {
         self.events.is_empty()
     }
 
-    pub fn get(&self, idx: usize) -> Option<RawEvent> {
+    pub fn get(&self, idx: usize) -> Option<SysEvent> {
         self.events.get(idx).cloned()
     }
 

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -397,11 +397,11 @@ impl Event {
         }
     }
 
-    pub fn raw_event(&self) -> &SysEvent {
+    pub fn sys_event(&self) -> &SysEvent {
         &self.inner
     }
 
-    pub fn from_raw_event(kevent: SysEvent) -> Event {
+    pub fn from_sys_event(kevent: SysEvent) -> Event {
         Event { inner: kevent }
     }
 }

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -1,11 +1,9 @@
-use crate::event_imp::{self as event, Event};
 use crate::sys::unix::cvt;
 use crate::sys::unix::io::set_cloexec;
-use crate::{Interests, Ready, Token};
+use crate::{Interests, Token};
 
 use libc::{self, time_t};
 use log::trace;
-use std::collections::HashMap;
 use std::io;
 #[cfg(not(target_os = "netbsd"))]
 use std::os::raw::{c_int, c_short};
@@ -71,7 +69,7 @@ impl Selector {
     pub fn select(
         &self,
         evts: &mut Events,
-        waker: Token,
+        _waker: Token,
         timeout: Option<Duration>,
     ) -> io::Result<bool> {
         let timeout = timeout.map(|to| libc::timespec {
@@ -93,12 +91,12 @@ impl Selector {
                 self.kq,
                 ptr::null(),
                 0,
-                evts.sys_events.0.as_mut_ptr(),
-                evts.sys_events.0.capacity() as Count,
+                evts.events.as_mut_ptr(),
+                evts.events.capacity() as Count,
                 timeout,
             ))?;
-            evts.sys_events.0.set_len(cnt as usize);
-            Ok(evts.coalesce(waker))
+            evts.events.set_len(cnt as usize);
+            Ok(true)
         }
     }
 
@@ -319,23 +317,113 @@ impl Drop for Selector {
     }
 }
 
-pub struct Events {
-    sys_events: KeventList,
-    events: Vec<Event>,
-    event_map: HashMap<Token, usize>,
+pub type RawEvent = libc::kevent;
+
+#[repr(transparent)]
+pub struct Event {
+    inner: RawEvent,
 }
 
-struct KeventList(Vec<libc::kevent>);
+impl Event {
+    pub fn token(&self) -> Token {
+        Token(self.inner.udata as usize)
+    }
 
-unsafe impl Send for KeventList {}
-unsafe impl Sync for KeventList {}
+    pub fn is_readable(&self) -> bool {
+        self.inner.filter == libc::EVFILT_READ || {
+            #[cfg(any(target_os = "freebsd", target_os = "ios", target_os = "macos"))]
+            // Used by the `Awakener`. On platforms that use `eventfd` or a unix
+            // pipe it will emit a readable event so we'll fake that here as
+            // well.
+            {
+                self.inner.filter == libc::EVFILT_USER
+            }
+            #[cfg(not(any(target_os = "freebsd", target_os = "ios", target_os = "macos")))]
+            {
+                false
+            }
+        }
+    }
+
+    pub fn is_writable(&self) -> bool {
+        self.inner.filter == libc::EVFILT_WRITE
+    }
+
+    pub fn is_error(&self) -> bool {
+        (self.inner.flags & libc::EV_ERROR) != 0 ||
+            // When the read end of the socket is closed, EV_EOF is set on
+            // flags, and fflags contains the error if there is one.
+            (self.inner.flags & libc::EV_EOF) != 0 && self.inner.fflags != 0
+    }
+
+    pub fn is_hup(&self) -> bool {
+        (self.inner.flags & libc::EV_EOF) != 0
+    }
+
+    pub fn is_priority(&self) -> bool {
+        // kqueue doesn't have priority indicators.
+        false
+    }
+
+    pub fn is_aio(&self) -> bool {
+        #[cfg(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos"
+        ))]
+        {
+            self.inner.filter == libc::EVFILT_AIO
+        }
+        #[cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "macos"
+        )))]
+        {
+            false
+        }
+    }
+
+    pub fn is_lio(&self) -> bool {
+        #[cfg(target_os = "freebsd")]
+        {
+            self.inner.filter == libc::EVFILT_LIO
+        }
+        #[cfg(not(target_os = "freebsd"))]
+        {
+            false
+        }
+    }
+
+    pub fn raw_event(&self) -> &RawEvent {
+        &self.inner
+    }
+
+    pub fn from_raw_event(kevent: RawEvent) -> Event {
+        Event { inner: kevent }
+    }
+}
+
+impl fmt::Debug for Event {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: add readiness.
+        f.debug_struct("Event")
+            .field("token", &self.token())
+            //.field("readiness", &self.readiness())
+            .finish()
+    }
+}
+
+pub struct Events {
+    events: Vec<RawEvent>,
+}
 
 impl Events {
     pub fn with_capacity(cap: usize) -> Events {
         Events {
-            sys_events: KeventList(Vec::with_capacity(cap)),
             events: Vec::with_capacity(cap),
-            event_map: HashMap::with_capacity(cap),
         }
     }
 
@@ -354,85 +442,19 @@ impl Events {
         self.events.is_empty()
     }
 
-    pub fn get(&self, idx: usize) -> Option<Event> {
+    pub fn get(&self, idx: usize) -> Option<RawEvent> {
         self.events.get(idx).cloned()
     }
 
-    fn coalesce(&mut self, waker: Token) -> bool {
-        let mut ret = false;
-        self.events.clear();
-        self.event_map.clear();
-
-        for e in self.sys_events.0.iter() {
-            let token = Token(e.udata as usize);
-            let len = self.events.len();
-
-            if token == waker {
-                // TODO: Should this return an error if event is an error. It
-                // is not critical as spurious wakeups are permitted.
-                ret = true;
-                continue;
-            }
-
-            let idx = *self.event_map.entry(token).or_insert(len);
-
-            if idx == len {
-                // New entry, insert the default
-                self.events.push(Event::new(Ready::EMPTY, token));
-            }
-
-            if e.flags & libc::EV_ERROR != 0 {
-                event::kind_mut(&mut self.events[idx]).insert(Ready::ERROR);
-            }
-
-            if e.filter == libc::EVFILT_READ as Filter {
-                event::kind_mut(&mut self.events[idx]).insert(Ready::READABLE);
-            } else if e.filter == libc::EVFILT_WRITE as Filter {
-                event::kind_mut(&mut self.events[idx]).insert(Ready::WRITABLE);
-            }
-            #[cfg(any(
-                target_os = "dragonfly",
-                target_os = "freebsd",
-                target_os = "ios",
-                target_os = "macos"
-            ))]
-            {
-                if e.filter == libc::EVFILT_AIO {
-                    event::kind_mut(&mut self.events[idx]).insert(Ready::AIO);
-                }
-            }
-            #[cfg(any(target_os = "freebsd"))]
-            {
-                if e.filter == libc::EVFILT_LIO {
-                    event::kind_mut(&mut self.events[idx]).insert(Ready::LIO);
-                }
-            }
-
-            // Used by the `Waker`. On platforms that use `eventfd` or a unix
-            // pipe it will emit a readable event so we'll fake that here as
-            // well.
-            #[cfg(any(target_os = "freebsd", target_os = "ios", target_os = "macos"))]
-            {
-                if e.filter == libc::EVFILT_USER {
-                    event::kind_mut(&mut self.events[idx]).insert(Ready::READABLE);
-                }
-            }
-        }
-
-        ret
-    }
-
     pub fn clear(&mut self) {
-        self.sys_events.0.truncate(0);
-        self.events.truncate(0);
-        self.event_map.clear();
+        self.events.clear();
     }
 }
 
 impl fmt::Debug for Events {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Events")
-            .field("len", &self.sys_events.0.len())
+            .field("len", &self.events.len())
             .finish()
     }
 }
@@ -451,22 +473,4 @@ fn does_not_register_rw() {
     poll.registry()
         .register(&kqf, Token(1234), Interests::READABLE)
         .unwrap();
-}
-
-#[cfg(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos"
-))]
-#[test]
-fn test_coalesce_aio() {
-    let mut events = Events::with_capacity(1);
-    events
-        .sys_events
-        .0
-        .push(kevent!(0x1234, libc::EVFILT_AIO, 0, 42));
-    events.coalesce(Token(0));
-    assert!(events.events[0].readiness() == Ready::AIO);
-    assert!(events.events[0].token() == Token(42));
 }

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -7,7 +7,7 @@ pub mod dlsym;
 mod epoll;
 
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
-pub use self::epoll::{Events, Selector};
+pub use self::epoll::{Event, Events, RawEvent, Selector};
 
 #[cfg(any(
     target_os = "bitrig",
@@ -29,7 +29,7 @@ mod kqueue;
     target_os = "netbsd",
     target_os = "openbsd"
 ))]
-pub use self::kqueue::{Events, Selector};
+pub use self::kqueue::{Event, Events, RawEvent, Selector};
 
 mod eventedfd;
 mod io;

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -7,7 +7,7 @@ pub mod dlsym;
 mod epoll;
 
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
-pub use self::epoll::{Event, Events, RawEvent, Selector};
+pub use self::epoll::{Event, Events, Selector, SysEvent};
 
 #[cfg(any(
     target_os = "bitrig",
@@ -29,7 +29,7 @@ mod kqueue;
     target_os = "netbsd",
     target_os = "openbsd"
 ))]
-pub use self::kqueue::{Event, Events, RawEvent, Selector};
+pub use self::kqueue::{Event, Events, Selector, SysEvent};
 
 mod eventedfd;
 mod io;

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -4,7 +4,7 @@ use super::Ready;
 
 pub type SysEvent = Event;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Event {
     token: Token,
     readiness: Ready,

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -47,10 +47,6 @@ impl Event {
         self.readiness.is_lio()
     }
 
-    pub fn sys_event(&self) -> &SysEvent {
-        self
-    }
-
     pub fn from_sys_event(event: SysEvent) -> Event {
         event
     }

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -1,0 +1,57 @@
+use crate::Token;
+
+use super::Ready;
+
+pub type RawEvent = Event;
+
+#[derive(Debug, Clone)]
+pub struct Event {
+    token: Token,
+    readiness: Ready,
+}
+
+impl Event {
+    pub(crate) fn new(readiness: Ready, token: Token) -> Event {
+        Event { token, readiness }
+    }
+
+    pub fn token(&self) -> Token {
+        self.token
+    }
+
+    pub fn is_readable(&self) -> bool {
+        self.readiness.is_readable()
+    }
+
+    pub fn is_writable(&self) -> bool {
+        self.readiness.is_writable()
+    }
+
+    pub fn is_error(&self) -> bool {
+        self.readiness.is_error()
+    }
+
+    pub fn is_hup(&self) -> bool {
+        self.readiness.is_hup()
+    }
+
+    pub fn is_priority(&self) -> bool {
+        self.readiness.is_priority()
+    }
+
+    pub fn is_aio(&self) -> bool {
+        self.readiness.is_aio()
+    }
+
+    pub fn is_lio(&self) -> bool {
+        self.readiness.is_lio()
+    }
+
+    pub fn raw_event(&self) -> &RawEvent {
+        self
+    }
+
+    pub fn from_raw_event(event: RawEvent) -> Event {
+        event
+    }
+}

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -4,7 +4,7 @@ use super::Ready;
 
 pub type SysEvent = Event;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Event {
     token: Token,
     readiness: Ready,
@@ -47,11 +47,11 @@ impl Event {
         self.readiness.is_lio()
     }
 
-    pub fn raw_event(&self) -> &SysEvent {
+    pub fn sys_event(&self) -> &SysEvent {
         self
     }
 
-    pub fn from_raw_event(event: SysEvent) -> Event {
+    pub fn from_sys_event(event: SysEvent) -> Event {
         event
     }
 }

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -2,7 +2,7 @@ use crate::Token;
 
 use super::Ready;
 
-pub type RawEvent = Event;
+pub type SysEvent = Event;
 
 #[derive(Debug, Clone)]
 pub struct Event {
@@ -47,11 +47,11 @@ impl Event {
         self.readiness.is_lio()
     }
 
-    pub fn raw_event(&self) -> &RawEvent {
+    pub fn raw_event(&self) -> &SysEvent {
         self
     }
 
-    pub fn from_raw_event(event: RawEvent) -> Event {
+    pub fn from_raw_event(event: SysEvent) -> Event {
         event
     }
 }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -153,7 +153,7 @@ mod tcp;
 mod udp;
 mod waker;
 
-pub use self::event::{Event, RawEvent};
+pub use self::event::{Event, SysEvent};
 pub use self::selector::{Binding, Events, Overlapped, Selector};
 pub use self::tcp::{TcpListener, TcpStream};
 pub use self::udp::UdpSocket;

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -140,17 +140,20 @@ use std::os::windows::prelude::*;
 
 use winapi;
 
-mod waker;
 #[macro_use]
 mod selector;
 mod buffer_pool;
+mod event;
 mod from_raw_arc;
 mod lazycell;
 mod poll_opt;
 mod queue;
+mod ready;
 mod tcp;
 mod udp;
+mod waker;
 
+pub use self::event::{Event, RawEvent};
 pub use self::selector::{Binding, Events, Overlapped, Selector};
 pub use self::tcp::{TcpListener, TcpStream};
 pub use self::udp::UdpSocket;
@@ -158,6 +161,7 @@ pub use self::waker::Waker;
 
 use self::poll_opt::PollOpt;
 use self::queue::{ReadinessQueue, Registration, SetReadiness};
+use self::ready::Ready;
 use self::selector::SelectorInner;
 
 #[derive(Copy, Clone)]

--- a/src/sys/windows/ready.rs
+++ b/src/sys/windows/ready.rs
@@ -1,0 +1,239 @@
+use std::{fmt, ops};
+
+use crate::Interests;
+
+#[derive(Copy, Clone)]
+pub struct Ready(u8);
+
+// These must be the same as the values in for `Interests`, see
+// `Ready::from_interests`.
+const EMPTY: u8 = 0b0_000_000;
+const READABLE: u8 = 0b0_000_001;
+const WRITABLE: u8 = 0b0_000_010;
+// The following are not available on all platforms.
+const ERROR: u8 = 0b0_000_100;
+const HUP: u8 = 0b0_001_000;
+const PRIORITY: u8 = 0b0_010_000;
+const AIO: u8 = 0b0_100_000;
+const LIO: u8 = 0b1_000_000;
+
+impl Ready {
+    /// Returns an empty `Ready` set.
+    pub const EMPTY: Ready = Ready(EMPTY);
+
+    /// Returns a `Ready` set representing readable readiness.
+    pub const READABLE: Ready = Ready(READABLE);
+
+    /// Returns a `Ready` set representing writable readiness.
+    pub const WRITABLE: Ready = Ready(WRITABLE);
+
+    /// Returns a `Ready` set representing error readiness.
+    #[cfg(unix)]
+    pub const ERROR: Ready = Ready(ERROR);
+
+    /// Returns a `Ready` set representing HUP readiness.
+    #[cfg(unix)]
+    pub const HUP: Ready = Ready(HUP);
+
+    /// Returns a `Ready` set representing priority readiness.
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
+    pub const PRIORITY: Ready = Ready(PRIORITY);
+
+    /// Returns a `Ready` set representing AIO completion readiness.
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos"
+    ))]
+    pub const AIO: Ready = Ready(AIO);
+
+    /// Returns a `Ready` set representing LIO completion readiness.
+    #[cfg(any(target_os = "freebsd"))]
+    pub const LIO: Ready = Ready(LIO);
+
+    /// Returns true if the `Ready` set is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0 == EMPTY
+    }
+
+    /// Returns true if the `Ready` set contains readable readiness.
+    #[inline]
+    pub fn is_readable(&self) -> bool {
+        self.contains(Ready::READABLE)
+    }
+
+    /// Returns true if the `Ready` set contains writable readiness.
+    #[inline]
+    pub fn is_writable(&self) -> bool {
+        self.contains(Ready::WRITABLE)
+    }
+
+    /// Returns true if the `Ready` set contains error readiness.
+    ///
+    /// Error events occur when the socket enters an error state. In this case,
+    /// the socket will also receive a readable or writable event. Reading or
+    /// writing to the socket will result in an error.
+    ///
+    /// # Notes
+    ///
+    /// Method is available on all platforms, but not all platforms (can) use
+    /// this indicator.
+    #[inline]
+    pub fn is_error(&self) -> bool {
+        self.contains(Ready(ERROR))
+    }
+
+    /// Returns true if the `Ready` set contains HUP readiness.
+    ///
+    /// HUP events occur when the remote end of a socket hangs up. In the TCP
+    /// case, this occurs when the remote end of a TCP socket shuts down writes.
+    ///
+    /// It is also unclear if HUP readiness will remain in 0.7. See
+    /// [here](https://github.com/tokio-rs/mio/issues/941)
+    ///
+    /// # Notes
+    ///
+    /// Method is available on all platforms, but not all platforms (can) use
+    /// this indicator.
+    #[inline]
+    pub fn is_hup(&self) -> bool {
+        self.contains(Ready(HUP))
+    }
+
+    /// Returns true if the `Ready` set contains priority readiness.
+    ///
+    /// # Notes
+    ///
+    /// Method is available on all platforms, but not all platforms (can) use
+    /// this indicator.
+    #[inline]
+    pub fn is_priority(&self) -> bool {
+        self.contains(Ready(PRIORITY))
+    }
+
+    /// Returns true if the `Ready` set contains AIO readiness.
+    ///
+    /// # Notes
+    ///
+    /// Method is available on all platforms, but not all platforms (can) use
+    /// this indicator.
+    #[inline]
+    pub fn is_aio(&self) -> bool {
+        self.contains(Ready(AIO))
+    }
+
+    /// Returns true if the `Ready` set contains LIO readiness.
+    ///
+    /// # Notes
+    ///
+    /// Method is available on all platforms, but not all platforms (can) use
+    /// this indicator.
+    #[inline]
+    pub fn is_lio(&self) -> bool {
+        self.contains(Ready(LIO))
+    }
+
+    /// Returns true if `self` is a superset of `other`.
+    ///
+    /// The `other` set may represent more than one readiness operations, in
+    /// which case the function only returns true if `self` contains **all**
+    /// readiness specified in `other`.
+    #[inline]
+    pub fn contains(&self, other: Ready) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    /// Create a `Ready` instance using the given `usize` representation.
+    ///
+    /// The `usize` representation must have been obtained from a call to
+    /// `Ready::as_usize`.
+    ///
+    /// The `usize` representation must be treated as opaque. There is no
+    /// guaranteed correlation between the returned value and platform defined
+    /// constants. Also, there is no guarantee that the `usize` representation
+    /// will remain constant across patch releases of Mio.
+    ///
+    /// This function is mainly provided to allow the caller to loa a
+    /// readiness value from an `AtomicUsize`.
+    pub(crate) fn from_usize(val: usize) -> Ready {
+        Ready(val as u8)
+    }
+
+    /// Returns a `usize` representation of the `Ready` value.
+    ///
+    /// This `usize` representation must be treated as opaque. There is no
+    /// guaranteed correlation between the returned value and platform defined
+    /// constants. Also, there is no guarantee that the `usize` representation
+    /// will remain constant across patch releases of Mio.
+    ///
+    /// This function is mainly provided to allow the caller to store a
+    /// readiness value in an `AtomicUsize`.
+    pub(crate) fn as_usize(&self) -> usize {
+        self.0 as usize
+    }
+
+    pub(crate) fn from_interests(interests: Interests) -> Ready {
+        Ready(interests.as_u8())
+    }
+}
+
+impl ops::BitOr for Ready {
+    type Output = Ready;
+
+    #[inline]
+    fn bitor(self, other: Ready) -> Ready {
+        Ready(self.0 | other.0)
+    }
+}
+
+impl ops::BitAnd for Ready {
+    type Output = Ready;
+
+    #[inline]
+    fn bitand(self, other: Ready) -> Ready {
+        Ready(self.0 & other.0)
+    }
+}
+
+impl ops::Sub for Ready {
+    type Output = Ready;
+
+    #[inline]
+    fn sub(self, other: Ready) -> Ready {
+        Ready(self.0 & !other.0)
+    }
+}
+
+impl fmt::Debug for Ready {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut one = false;
+        let flags = [
+            (Ready(READABLE), "Readable"),
+            (Ready(WRITABLE), "Writable"),
+            (Ready(ERROR), "Error"),
+            (Ready(HUP), "Hup"),
+            (Ready(PRIORITY), "Priority"),
+            (Ready(AIO), "AIO"),
+            (Ready(LIO), "LIO"),
+        ];
+
+        for &(flag, msg) in &flags {
+            if self.contains(flag) {
+                if one {
+                    write!(fmt, " | ")?
+                }
+                write!(fmt, "{}", msg)?;
+
+                one = true
+            }
+        }
+
+        if !one {
+            fmt.write_str("(empty)")?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -1,8 +1,10 @@
-use crate::event_imp::{Event, Evented, Interests, Ready};
+use crate::event_imp::{Evented, Interests};
 use crate::poll::{self, Registry};
 use crate::sys::windows::buffer_pool::BufferPool;
 use crate::sys::windows::lazycell::AtomicLazyCell;
-use crate::sys::windows::{PollOpt, ReadinessQueue, Registration, SetReadiness};
+use crate::sys::windows::{
+    Event, PollOpt, RawEvent, ReadinessQueue, Ready, Registration, SetReadiness,
+};
 use crate::Token;
 use log::trace;
 use miow;
@@ -489,7 +491,7 @@ pub struct Events {
     /// Literal events returned by `get` to the upwards `EventLoop`. This file
     /// doesn't really modify this (except for the waker), instead almost all
     /// events are filled in by the `ReadinessQueue` from the `poll` module.
-    events: Vec<Event>,
+    events: Vec<RawEvent>,
 }
 
 impl Events {
@@ -515,8 +517,8 @@ impl Events {
         self.events.capacity()
     }
 
-    pub fn get(&self, idx: usize) -> Option<Event> {
-        self.events.get(idx).map(|e| *e)
+    pub fn get(&self, idx: usize) -> Option<RawEvent> {
+        self.events.get(idx).cloned()
     }
 
     pub fn push_event(&mut self, event: Event) {

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -3,7 +3,7 @@ use crate::poll::{self, Registry};
 use crate::sys::windows::buffer_pool::BufferPool;
 use crate::sys::windows::lazycell::AtomicLazyCell;
 use crate::sys::windows::{
-    Event, PollOpt, RawEvent, ReadinessQueue, Ready, Registration, SetReadiness,
+    Event, PollOpt, ReadinessQueue, Ready, Registration, SetReadiness, SysEvent,
 };
 use crate::Token;
 use log::trace;
@@ -491,7 +491,7 @@ pub struct Events {
     /// Literal events returned by `get` to the upwards `EventLoop`. This file
     /// doesn't really modify this (except for the waker), instead almost all
     /// events are filled in by the `ReadinessQueue` from the `poll` module.
-    events: Vec<RawEvent>,
+    events: Vec<SysEvent>,
 }
 
 impl Events {
@@ -517,7 +517,7 @@ impl Events {
         self.events.capacity()
     }
 
-    pub fn get(&self, idx: usize) -> Option<RawEvent> {
+    pub fn get(&self, idx: usize) -> Option<SysEvent> {
         self.events.get(idx).cloned()
     }
 

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -1,8 +1,8 @@
 use crate::event::Evented;
 use crate::sys::windows::from_raw_arc::FromRawArc;
 use crate::sys::windows::selector::{Overlapped, ReadyBinding};
-use crate::sys::windows::{Family, Registration};
-use crate::{Interests, Ready, Registry, Token};
+use crate::sys::windows::{Family, Ready, Registration};
+use crate::{Interests, Registry, Token};
 use iovec::IoVec;
 use log::trace;
 use miow::iocp::CompletionStatus;

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -6,8 +6,8 @@
 use crate::event::Evented;
 use crate::sys::windows::from_raw_arc::FromRawArc;
 use crate::sys::windows::selector::{Overlapped, ReadyBinding};
-use crate::sys::windows::Registration;
-use crate::{Interests, Ready, Registry, Token};
+use crate::sys::windows::{Ready, Registration};
+use crate::{Interests, Registry, Token};
 use log::trace;
 use miow::iocp::CompletionStatus;
 use miow::net::SocketAddrBuf;

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -35,7 +35,7 @@ use crate::{poll, sys, Registry, Token};
 ///
 /// Wake an [`Poll`] from another thread.
 ///
-/// ```
+/// ```ignore
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use std::io;
 /// use std::thread;

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -35,7 +35,7 @@ use crate::{poll, sys, Registry, Token};
 ///
 /// Wake an [`Poll`] from another thread.
 ///
-/// ```ignore
+/// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use std::io;
 /// use std::thread;
@@ -43,7 +43,7 @@ use crate::{poll, sys, Registry, Token};
 /// use std::sync::Arc;
 ///
 /// use mio::event::Event;
-/// use mio::{Events, Ready, Token, Poll, Waker};
+/// use mio::{Events, Token, Poll, Waker};
 ///
 /// const WAKE_TOKEN: Token = Token(10);
 ///
@@ -69,9 +69,9 @@ use crate::{poll, sys, Registry, Token};
 /// // After about 500 milliseconds we should we awoken by the other thread we
 /// // started, getting a single event.
 /// assert!(!events.is_empty());
-/// for event in &events {
-///     assert_eq!(event, Event::new(Ready::READABLE, WAKE_TOKEN));
-/// }
+/// let waker_event = events.iter().next().unwrap();
+/// assert!(waker_event.is_readable());
+/// assert_eq!(waker_event.token(), WAKE_TOKEN);
 /// # handle.join().unwrap();
 /// #     Ok(())
 /// # }

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -4,10 +4,12 @@ use crate::{poll, sys, Registry, Token};
 
 /// Waker allows cross-thread waking of [`Poll`].
 ///
-/// When created it will cause events with [`Ready::READABLE`] and the provided
-/// `token` if [`wake`] is called, possibly from another thread.
+/// When created it will cause events with [`readable`] readiness and the
+/// provided `token` if [`wake`] is called, possibly from another thread.
 ///
 /// [`Poll`]: crate::Poll
+/// [`readable`]: crate::event::Event::is_readable
+/// [`wake`]: Waker::wake
 ///
 /// # Notes
 ///
@@ -19,13 +21,10 @@ use crate::{poll, sys, Registry, Token};
 /// happens if multiple `Waker`s are registered with the same `Poll` is
 /// undefined.
 ///
-/// [`Ready::READABLE`]: crate::Ready::READABLE
-/// [`wake`]: Waker::wake
-///
 /// # Implementation notes
 ///
 /// On platforms that support kqueue this will use the `EVFILT_USER` event
-/// filter, see [implementation notes of `Poll`] to see what platform supports
+/// filter, see [implementation notes of `Poll`] to see what platforms support
 /// kqueue. On Linux it uses [eventfd].
 ///
 /// [implementation notes of `Poll`]: ../index.html#implementation-notes
@@ -33,7 +32,7 @@ use crate::{poll, sys, Registry, Token};
 ///
 /// # Examples
 ///
-/// Wake an [`Poll`] from another thread.
+/// Wake a [`Poll`] instance from another thread.
 ///
 /// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -18,7 +18,7 @@ mod test_smoke;
 mod test_tcp;
 mod test_tcp_shutdown;
 mod test_udp_socket;
-//mod test_waker;
+mod test_waker;
 mod test_write_then_drop;
 
 use bytes::{Buf, BufMut};
@@ -140,44 +140,6 @@ pub fn sleep_ms(ms: u64) {
     use std::thread;
     thread::sleep(Duration::from_millis(ms));
 }
-
-/*
-pub fn expect_events(
-    poll: &mut Poll,
-    event_buffer: &mut Events,
-    poll_try_count: usize,
-    mut expected: Vec<Event>,
-) {
-    const MS: u64 = 1_000;
-
-    for _ in 0..poll_try_count {
-        poll.poll(event_buffer, Some(Duration::from_millis(MS)))
-            .unwrap();
-        for event in event_buffer.iter() {
-            let pos_opt = match expected.iter().position(|exp_event| {
-                (event.token() == exp_event.token())
-                    && event.readiness().contains(exp_event.readiness())
-            }) {
-                Some(x) => Some(x),
-                None => None,
-            };
-            if let Some(pos) = pos_opt {
-                expected.remove(pos);
-            }
-        }
-
-        if expected.is_empty() {
-            break;
-        }
-    }
-
-    assert!(
-        expected.is_empty(),
-        "The following expected events were not found: {:?}",
-        expected
-    );
-}
-*/
 
 pub fn expect_no_events(poll: &mut Poll, events: &mut Events) {
     poll.poll(events, Some(Duration::from_millis(50)))

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -18,11 +18,10 @@ mod test_smoke;
 mod test_tcp;
 mod test_tcp_shutdown;
 mod test_udp_socket;
-mod test_waker;
+//mod test_waker;
 mod test_write_then_drop;
 
 use bytes::{Buf, BufMut};
-use mio::event::Event;
 use mio::{Events, Poll};
 use std::io::{self, Read, Write};
 use std::time::Duration;
@@ -142,6 +141,7 @@ pub fn sleep_ms(ms: u64) {
     thread::sleep(Duration::from_millis(ms));
 }
 
+/*
 pub fn expect_events(
     poll: &mut Poll,
     event_buffer: &mut Events,
@@ -177,6 +177,7 @@ pub fn expect_events(
         expected
     );
 }
+*/
 
 pub fn expect_no_events(poll: &mut Poll, events: &mut Events) {
     poll.poll(events, Some(Duration::from_millis(50)))

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -1,7 +1,7 @@
 use crate::{localhost, TryRead};
 use bytes::BytesMut;
 use mio::net::{TcpListener, TcpStream};
-use mio::{Events, Interests, Poll, Ready, Token};
+use mio::{Events, Interests, Poll, Token};
 
 use self::TestState::{AfterRead, Initial};
 
@@ -31,8 +31,8 @@ impl TestHandler {
         }
     }
 
-    fn handle_read(&mut self, poll: &mut Poll, tok: Token, events: Ready) {
-        debug!("readable; tok={:?}; hint={:?}", tok, events);
+    fn handle_read(&mut self, poll: &mut Poll, tok: Token) {
+        debug!("readable; tok={:?}", tok);
 
         match tok {
             SERVER => {
@@ -66,7 +66,7 @@ impl TestHandler {
             .unwrap();
     }
 
-    fn handle_write(&mut self, poll: &mut Poll, tok: Token, _: Ready) {
+    fn handle_write(&mut self, poll: &mut Poll, tok: Token) {
         match tok {
             SERVER => panic!("received writable for token 0"),
             CLIENT => {
@@ -114,12 +114,12 @@ pub fn test_close_on_drop() {
         poll.poll(&mut events, None).unwrap();
 
         for event in &events {
-            if event.readiness().is_readable() {
-                handler.handle_read(&mut poll, event.token(), event.readiness());
+            if event.is_readable() {
+                handler.handle_read(&mut poll, event.token());
             }
 
-            if event.readiness().is_writable() {
-                handler.handle_write(&mut poll, event.token(), event.readiness());
+            if event.is_writable() {
+                handler.handle_write(&mut poll, event.token());
             }
         }
     }

--- a/test/test_echo_server.rs
+++ b/test/test_echo_server.rs
@@ -308,8 +308,8 @@ pub fn test_echo_server() {
         poll.poll(&mut events, None).unwrap();
 
         for event in &events {
-            debug!("ready {:?} {:?}", event.token(), event.readiness());
-            if event.readiness().is_readable() {
+            debug!("ready {:?} {:?}", event.token(), event);
+            if event.is_readable() {
                 match event.token() {
                     SERVER => handler.server.accept(poll.registry()).unwrap(),
                     CLIENT => handler.client.readable(poll.registry()).unwrap(),
@@ -317,7 +317,7 @@ pub fn test_echo_server() {
                 }
             }
 
-            if event.readiness().is_writable() {
+            if event.is_writable() {
                 match event.token() {
                     SERVER => panic!("received writable for token 0"),
                     CLIENT => handler.client.writable(poll.registry()).unwrap(),

--- a/test/test_multicast.rs
+++ b/test/test_multicast.rs
@@ -5,7 +5,7 @@
 use crate::localhost;
 use bytes::{BufMut, Bytes, BytesMut};
 use mio::net::UdpSocket;
-use mio::{Events, Interests, Poll, Ready, Registry, Token};
+use mio::{Events, Interests, Poll, Registry, Token};
 use std::net::IpAddr;
 use std::str;
 
@@ -36,7 +36,7 @@ impl UdpHandler {
         }
     }
 
-    fn handle_read(&mut self, _: &Registry, token: Token, _: Ready) {
+    fn handle_read(&mut self, _: &Registry, token: Token) {
         if let LISTENER = token {
             debug!("We are receiving a datagram now...");
             match unsafe { self.rx.recv_from(self.rx_buf.bytes_mut()) } {
@@ -53,7 +53,7 @@ impl UdpHandler {
         }
     }
 
-    fn handle_write(&mut self, _: &Registry, token: Token, _: Ready) {
+    fn handle_write(&mut self, _: &Registry, token: Token) {
         if let SENDER = token {
             let addr = self.rx.local_addr().unwrap();
             let cnt = self.tx.send_to(self.buf.as_ref(), &addr).unwrap();
@@ -103,12 +103,12 @@ pub fn test_multicast() {
         poll.poll(&mut events, None).unwrap();
 
         for event in &events {
-            if event.readiness().is_readable() {
-                handler.handle_read(poll.registry(), event.token(), event.readiness());
+            if event.is_readable() {
+                handler.handle_read(poll.registry(), event.token());
             }
 
-            if event.readiness().is_writable() {
-                handler.handle_write(poll.registry(), event.token(), event.readiness());
+            if event.is_writable() {
+                handler.handle_write(poll.registry(), event.token());
             }
         }
     }

--- a/test/test_register_deregister.rs
+++ b/test/test_register_deregister.rs
@@ -87,11 +87,11 @@ pub fn test_register_deregister() {
         poll.poll(&mut events, None).unwrap();
 
         if let Some(event) = events.iter().next() {
-            if event.readiness().is_readable() {
+            if event.is_readable() {
                 handler.handle_read(poll.registry(), event.token());
             }
 
-            if event.readiness().is_writable() {
+            if event.is_writable() {
                 handler.handle_write(poll.registry(), event.token());
                 break;
             }

--- a/test/test_tcp.rs
+++ b/test/test_tcp.rs
@@ -45,7 +45,7 @@ fn accept() {
         for event in &events {
             h.hit = true;
             assert_eq!(event.token(), Token(1));
-            assert!(event.readiness().is_readable());
+            assert!(event.is_readable());
             assert!(h.listener.accept().is_ok());
             h.shutdown = true;
         }
@@ -93,8 +93,8 @@ fn connect() {
         for event in &events {
             assert_eq!(event.token(), Token(1));
             match h.hit {
-                0 => assert!(event.readiness().is_writable()),
-                1 => assert!(event.readiness().is_readable()),
+                0 => assert!(event.is_writable()),
+                1 => assert!(event.is_readable()),
                 _ => panic!(),
             }
             h.hit += 1;
@@ -111,8 +111,8 @@ fn connect() {
         for event in &events {
             assert_eq!(event.token(), Token(1));
             match h.hit {
-                0 => assert!(event.readiness().is_writable()),
-                1 => assert!(event.readiness().is_readable()),
+                0 => assert!(event.is_writable()),
+                1 => assert!(event.is_readable()),
                 _ => panic!(),
             }
             h.hit += 1;
@@ -543,7 +543,7 @@ fn multiple_writes_immediate_success() {
     'outer: loop {
         poll.poll(&mut events, None).unwrap();
         for event in events.iter() {
-            if event.token() == Token(1) && event.readiness().is_writable() {
+            if event.token() == Token(1) && event.is_writable() {
                 break 'outer;
             }
         }
@@ -620,7 +620,7 @@ fn connection_reset_by_peer() {
 
         for event in &events {
             if event.token() == Token(3) {
-                assert!(event.readiness().is_readable());
+                assert!(event.is_readable());
 
                 match server.read(&mut buf) {
                     Ok(0) | Err(_) => {}
@@ -658,7 +658,7 @@ fn connect_error() {
 
         for event in &events {
             if event.token() == Token(0) {
-                assert!(event.readiness().is_writable());
+                assert!(event.is_writable());
                 break 'outer;
             }
         }
@@ -690,7 +690,7 @@ fn write_error() {
         poll.poll(&mut events, None).unwrap();
 
         for event in &events {
-            if event.token() == Token(0) && event.readiness().is_writable() {
+            if event.token() == Token(0) && event.is_writable() {
                 break 'outer;
             }
         }

--- a/test/test_tcp_shutdown.rs
+++ b/test/test_tcp_shutdown.rs
@@ -33,9 +33,9 @@ macro_rules! wait {
                     target_os = "openbsd"
                 ))]
                 {
-                if $expect_hup {
-                    assert!(event.is_hup());
-                }
+                    if $expect_hup {
+                        assert!(event.is_hup());
+                    }
                 }
 
                 if !$expect_hup {

--- a/test/test_tcp_shutdown.rs
+++ b/test/test_tcp_shutdown.rs
@@ -22,9 +22,24 @@ macro_rules! wait {
                 .unwrap();
 
             for event in &events {
-                #[cfg(unix)]
+                // Hup is only generated on kqueue platforms.
+                #[cfg(any(
+                    target_os = "bitrig",
+                    target_os = "dragonfly",
+                    target_os = "freebsd",
+                    target_os = "ios",
+                    target_os = "macos",
+                    target_os = "netbsd",
+                    target_os = "openbsd"
+                ))]
                 {
-                    assert!(event.is_hup() == $expect_hup);
+                if $expect_hup {
+                    assert!(event.is_hup());
+                }
+                }
+
+                if !$expect_hup {
+                    assert!(!event.is_hup());
                 }
 
                 if event.token() == Token(0) && event.$ready() {

--- a/test/test_tcp_shutdown.rs
+++ b/test/test_tcp_shutdown.rs
@@ -24,10 +24,10 @@ macro_rules! wait {
             for event in &events {
                 #[cfg(unix)]
                 {
-                    assert!(!event.readiness().is_hup());
+                    assert!(!event.is_hup());
                 }
 
-                if event.token() == Token(0) && event.readiness().$ready() {
+                if event.token() == Token(0) && event.$ready() {
                     found = true;
                     break;
                 }
@@ -37,6 +37,7 @@ macro_rules! wait {
 }
 
 #[test]
+#[ignore = "FIXME(Thomas): !event.is_hup() fails"]
 fn test_write_shutdown() {
     let mut poll = Poll::new().unwrap();
 
@@ -61,7 +62,7 @@ fn test_write_shutdown() {
         .unwrap();
 
     let next = events.iter().next();
-    assert_eq!(next, None);
+    assert!(next.is_none());
 
     println!("SHUTTING DOWN");
     // Now, shutdown the write half of the socket.

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -71,7 +71,7 @@ fn test_send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
         poll.poll(&mut events, None).unwrap();
 
         for event in &events {
-            if event.readiness().is_readable() {
+            if event.is_readable() {
                 if let LISTENER = event.token() {
                     debug!("We are receiving a datagram now...");
                     let cnt = unsafe {
@@ -90,7 +90,7 @@ fn test_send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
                 }
             }
 
-            if event.readiness().is_writable() {
+            if event.is_writable() {
                 if let SENDER = event.token() {
                     let cnt = if !handler.connected {
                         let addr = handler.rx.local_addr().unwrap();
@@ -176,7 +176,7 @@ pub fn test_udp_socket_discard() {
         .unwrap();
 
     for event in &events {
-        if event.readiness().is_readable() {
+        if event.is_readable() {
             if let LISTENER = event.token() {
                 panic!("Expected to no receive a packet but got something")
             }
@@ -226,7 +226,7 @@ pub fn test_udp_socket_send_recv_bufs() {
         poll.poll(&mut events, None).unwrap();
 
         for event in &events {
-            if event.readiness().is_readable() {
+            if event.is_readable() {
                 if let LISTENER = event.token() {
                     loop {
                         let cnt = match rx.recv_bufs(read_bufs.as_mut()) {
@@ -249,7 +249,7 @@ pub fn test_udp_socket_send_recv_bufs() {
                 }
             }
 
-            if event.readiness().is_writable() {
+            if event.is_writable() {
                 if let SENDER = event.token() {
                     while wtimes < times {
                         let cnt = match tx.send_bufs(write_bufs.as_slice()) {

--- a/test/test_waker.rs
+++ b/test/test_waker.rs
@@ -91,8 +91,7 @@ fn waker_multiple_wakeups_different_thread() {
 }
 
 fn expect_waker_event(poll: &mut Poll, events: &mut Events, token: Token) {
-    poll.poll(events, Some(Duration::from_millis(100)))
-        .unwrap();
+    poll.poll(events, Some(Duration::from_millis(100))).unwrap();
     let mut events = events.iter();
     let event = events.next().unwrap();
     assert_eq!(event.token(), token);

--- a/test/test_waker.rs
+++ b/test/test_waker.rs
@@ -92,9 +92,9 @@ fn waker_multiple_wakeups_different_thread() {
 
 fn expect_waker_event(poll: &mut Poll, events: &mut Events, token: Token) {
     poll.poll(events, Some(Duration::from_millis(100))).unwrap();
-    let mut events = events.iter();
-    let event = events.next().unwrap();
-    assert_eq!(event.token(), token);
-    assert!(event.is_readable());
-    assert!(events.next().is_none());
+    assert!(!events.is_empty());
+    for event in events.iter() {
+        assert_eq!(event.token(), token);
+        assert!(event.is_readable());
+    }
 }


### PR DESCRIPTION
Now `Event` is just a wrapper around a platform specific event to provide
a nice API, with methods such as is_readable.

This removes the `Ready` type and moves all its methods to the `Event` type.

TODO:
* [x] Make this work on all platforms:
  * [x] kqueue,
  * [x] epoll,
  * [x] Windows.
* [x] Fix tests:
  * [x] Fix `test_write_shutdown` test, the following fails `assert!(!event.is_hup())`.
  * [x] Update all tests in `test_waker` module (uses now removed `Event::new`).
* [x] Fix examples:
  * [x] in Waker.
* [x] Fix docs everywhere.
