### PR TITLE
Add interests associated constants to net types

### DIFF
--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -690,6 +690,10 @@ impl Interests {
     /// Returns a `Interests` set representing writable interests.
     pub const WRITABLE: Interests = Interests(unsafe { NonZeroU8::new_unchecked(WRITABLE) });
 
+    /// Both readable and writable.
+    pub(crate) const BOTH: Interests =
+        Interests(unsafe { NonZeroU8::new_unchecked(READABLE | WRITABLE) });
+
     /// Returns a `Interests` set representing AIO completion interests.
     #[cfg(any(
         target_os = "dragonfly",

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -70,6 +70,10 @@ fn set_nonblocking(stream: &net::TcpStream) -> io::Result<()> {
 }
 
 impl TcpStream {
+    /// The interests to use when registering to receive both readable and
+    /// writable events.
+    pub const INTERESTS: Interests = Interests::BOTH;
+
     /// Create a new TCP stream and issue a non-blocking connect to the
     /// specified address.
     ///
@@ -452,6 +456,10 @@ pub struct TcpListener {
 }
 
 impl TcpListener {
+    /// The interests to use when registering to receive acceptable connections
+    /// events.
+    pub const INTERESTS: Interests = Interests::READABLE;
+
     /// Convenience method to bind a new TCP listener to the specified address
     /// to receive new connections.
     ///

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -97,6 +97,10 @@ pub struct UdpSocket {
 }
 
 impl UdpSocket {
+    /// The interests to use when registering to receive both readable and
+    /// writable events.
+    pub const INTERESTS: Interests = Interests::BOTH;
+
     /// Creates a UDP socket from the given address.
     ///
     /// # Examples


### PR DESCRIPTION
Useful to quickly register a type with the correct (or most used)
interests.