### PR TITLE
Remove unix::TcpStream::(set_)only_v6

### DIFF
--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -94,14 +94,6 @@ impl TcpStream {
         self.inner.ttl()
     }
 
-    pub fn set_only_v6(&self, only_v6: bool) -> io::Result<()> {
-        self.inner.set_only_v6(only_v6)
-    }
-
-    pub fn only_v6(&self) -> io::Result<bool> {
-        self.inner.only_v6()
-    }
-
     pub fn set_linger(&self, dur: Option<Duration>) -> io::Result<()> {
         self.inner.set_linger(dur)
     }


### PR DESCRIPTION
Not used.

Closes #684.

/cc @dtolnay