### PR TITLE
Always accept SocketAddr, rather then a reference to it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //! let addr = "127.0.0.1:13265".parse().unwrap();
 //!
 //! // Setup the server socket
-//! let server = TcpListener::bind(&addr).unwrap();
+//! let server = TcpListener::bind(addr).unwrap();
 //!
 //! // Create a poll instance
 //! let mut poll = Poll::new().unwrap();
@@ -73,7 +73,7 @@
 //!     Interests::READABLE).unwrap();
 //!
 //! // Setup the client socket
-//! let sock = TcpStream::connect(&addr).unwrap();
+//! let sock = TcpStream::connect(addr).unwrap();
 //!
 //! // Register the socket
 //! registry.register(

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -79,15 +79,15 @@ impl TcpStream {
     /// `net2::TcpBuilder` to configure a socket and then pass its socket to
     /// `TcpStream::connect_stream` to transfer ownership into mio and schedule
     /// the connect operation.
-    pub fn connect(addr: &SocketAddr) -> io::Result<TcpStream> {
-        let sock = match *addr {
+    pub fn connect(addr: SocketAddr) -> io::Result<TcpStream> {
+        let sock = match addr {
             SocketAddr::V4(..) => TcpBuilder::new_v4(),
             SocketAddr::V6(..) => TcpBuilder::new_v6(),
         }?;
         // Required on Windows for a future `connect_overlapped` operation to be
         // executed successfully.
         if cfg!(windows) {
-            sock.bind(&inaddr_any(addr))?;
+            sock.bind(inaddr_any(addr))?;
         }
         TcpStream::connect_stream(sock.to_tcp_stream()?, addr)
     }
@@ -110,7 +110,7 @@ impl TcpStream {
     ///   loop. Note that on Windows you must `bind` a socket before it can be
     ///   connected, so if a custom `TcpBuilder` is used it should be bound
     ///   (perhaps to `INADDR_ANY`) before this method is called.
-    pub fn connect_stream(stream: net::TcpStream, addr: &SocketAddr) -> io::Result<TcpStream> {
+    pub fn connect_stream(stream: net::TcpStream, addr: SocketAddr) -> io::Result<TcpStream> {
         Ok(TcpStream {
             sys: sys::TcpStream::connect(stream, addr)?,
             selector_id: SelectorId::new(),
@@ -337,8 +337,8 @@ impl TcpStream {
     }
 }
 
-fn inaddr_any(other: &SocketAddr) -> SocketAddr {
-    match *other {
+fn inaddr_any(other: SocketAddr) -> SocketAddr {
+    match other {
         SocketAddr::V4(..) => {
             let any = Ipv4Addr::new(0, 0, 0, 0);
             let addr = SocketAddrV4::new(any, 0);
@@ -466,9 +466,9 @@ impl TcpListener {
     /// socket is desired then the `net2::TcpBuilder` methods can be used in
     /// combination with the `TcpListener::from_listener` method to transfer
     /// ownership into mio.
-    pub fn bind(addr: &SocketAddr) -> io::Result<TcpListener> {
+    pub fn bind(addr: SocketAddr) -> io::Result<TcpListener> {
         // Create the socket
-        let sock = match *addr {
+        let sock = match addr {
             SocketAddr::V4(..) => TcpBuilder::new_v4(),
             SocketAddr::V6(..) => TcpBuilder::new_v6(),
         }?;

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -39,7 +39,7 @@ use std::time::Duration;
 /// use mio::net::TcpStream;
 /// use std::time::Duration;
 ///
-/// let stream = TcpStream::connect(&"127.0.0.1:34254".parse()?)?;
+/// let stream = TcpStream::connect("127.0.0.1:34254".parse()?)?;
 ///
 /// let mut poll = Poll::new()?;
 /// let registry = poll.registry().clone();
@@ -427,7 +427,7 @@ impl fmt::Debug for TcpStream {
 /// use mio::net::TcpListener;
 /// use std::time::Duration;
 ///
-/// let listener = TcpListener::bind(&"127.0.0.1:34255".parse()?)?;
+/// let listener = TcpListener::bind("127.0.0.1:34255".parse()?)?;
 ///
 /// let mut poll = Poll::new()?;
 /// let registry = poll.registry().clone();

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -42,8 +42,8 @@ use iovec::IoVec;
 ///
 /// // This operation will fail if the address is in use, so we select different ports for each
 /// // socket.
-/// let sender_socket = UdpSocket::bind(&"127.0.0.1:0".parse()?)?;
-/// let echoer_socket = UdpSocket::bind(&"127.0.0.1:0".parse()?)?;
+/// let sender_socket = UdpSocket::bind("127.0.0.1:0".parse()?)?;
+/// let echoer_socket = UdpSocket::bind("127.0.0.1:0".parse()?)?;
 ///
 /// // If we do not use connect here, SENDER and ECHOER would need to call send_to and recv_from
 /// // respectively.
@@ -108,7 +108,7 @@ impl UdpSocket {
     /// use mio::net::UdpSocket;
     ///
     /// // We must bind it to an open address.
-    /// let socket = match UdpSocket::bind(&"127.0.0.1:0".parse()?) {
+    /// let socket = match UdpSocket::bind("127.0.0.1:0".parse()?) {
     ///     Ok(new_socket) => new_socket,
     ///     Err(fail) => {
     ///         // We panic! here, but you could try to bind it again on another address.
@@ -161,7 +161,7 @@ impl UdpSocket {
     /// use mio::net::UdpSocket;
     ///
     /// let addr = "127.0.0.1:0".parse()?;
-    /// let socket = UdpSocket::bind(&addr)?;
+    /// let socket = UdpSocket::bind(addr)?;
     /// #    Ok(())
     /// # }
     /// #
@@ -188,7 +188,7 @@ impl UdpSocket {
     /// use mio::net::UdpSocket;
     ///
     /// // We must bind it to an open address.
-    /// let socket = UdpSocket::bind(&"127.0.0.1:0".parse()?)?;
+    /// let socket = UdpSocket::bind("127.0.0.1:0".parse()?)?;
     /// let cloned_socket = socket.try_clone()?;
     ///
     /// assert_eq!(socket.local_addr()?, cloned_socket.local_addr()?);
@@ -220,12 +220,12 @@ impl UdpSocket {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// use mio::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind(&"127.0.0.1:0".parse()?)?;
+    /// let socket = UdpSocket::bind("127.0.0.1:0".parse()?)?;
     ///
     /// // We must check if the socket is writable before calling send_to,
     /// // or we could run into a WouldBlock error.
     ///
-    /// let bytes_sent = socket.send_to(&[9; 9], &"127.0.0.1:11100".parse()?)?;
+    /// let bytes_sent = socket.send_to(&[9; 9], "127.0.0.1:11100".parse()?)?;
     /// assert_eq!(bytes_sent, 9);
     /// #
     /// #    Ok(())
@@ -250,7 +250,7 @@ impl UdpSocket {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// use mio::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind(&"127.0.0.1:0".parse()?)?;
+    /// let socket = UdpSocket::bind("127.0.0.1:0".parse()?)?;
     ///
     /// // We must check if the socket is readable before calling recv_from,
     /// // or we could run into a WouldBlock error.
@@ -302,7 +302,7 @@ impl UdpSocket {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// use mio::net::UdpSocket;
     ///
-    /// let broadcast_socket = UdpSocket::bind(&"127.0.0.1:0".parse()?)?;
+    /// let broadcast_socket = UdpSocket::bind("127.0.0.1:0".parse()?)?;
     /// if broadcast_socket.broadcast()? == false {
     ///     broadcast_socket.set_broadcast(true)?;
     /// }
@@ -335,7 +335,7 @@ impl UdpSocket {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// use mio::net::UdpSocket;
     ///
-    /// let broadcast_socket = UdpSocket::bind(&"127.0.0.1:0".parse()?)?;
+    /// let broadcast_socket = UdpSocket::bind("127.0.0.1:0".parse()?)?;
     /// assert_eq!(broadcast_socket.broadcast()?, false);
     /// #
     /// #    Ok(())
@@ -419,7 +419,7 @@ impl UdpSocket {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// use mio::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind(&"127.0.0.1:0".parse()?)?;
+    /// let socket = UdpSocket::bind("127.0.0.1:0".parse()?)?;
     /// if socket.ttl()? < 255 {
     ///     socket.set_ttl(255)?;
     /// }
@@ -451,7 +451,7 @@ impl UdpSocket {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// use mio::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind(&"127.0.0.1:0".parse()?)?;
+    /// let socket = UdpSocket::bind("127.0.0.1:0".parse()?)?;
     /// socket.set_ttl(255)?;
     ///
     /// assert_eq!(socket.ttl()?, 255);

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -124,7 +124,7 @@ impl UdpSocket {
     /// #   try_main().unwrap();
     /// # }
     /// ```
-    pub fn bind(addr: &SocketAddr) -> io::Result<UdpSocket> {
+    pub fn bind(addr: SocketAddr) -> io::Result<UdpSocket> {
         let socket = net::UdpSocket::bind(addr)?;
         UdpSocket::from_socket(socket)
     }
@@ -235,7 +235,7 @@ impl UdpSocket {
     /// #   try_main().unwrap();
     /// # }
     /// ```
-    pub fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
+    pub fn send_to(&self, buf: &[u8], target: SocketAddr) -> io::Result<usize> {
         self.sys.send_to(buf, target)
     }
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -95,7 +95,7 @@ use std::{fmt, io, usize};
 ///
 /// // Bind a server socket to connect to.
 /// let addr: SocketAddr = "127.0.0.1:0".parse()?;
-/// let server = TcpListener::bind(&addr)?;
+/// let server = TcpListener::bind(addr)?;
 ///
 /// // Construct a new `Poll` handle as well as the `Events` we'll store into
 /// let mut poll = Poll::new()?;
@@ -103,7 +103,7 @@ use std::{fmt, io, usize};
 /// let mut events = Events::with_capacity(1024);
 ///
 /// // Connect the stream
-/// let stream = TcpStream::connect(&server.local_addr()?)?;
+/// let stream = TcpStream::connect(server.local_addr()?)?;
 ///
 /// // Register the stream with `Poll`
 /// registry.register(&stream, Token(0), Interests::READABLE | Interests::WRITABLE)?;
@@ -193,7 +193,7 @@ use std::{fmt, io, usize};
 /// use std::time::Duration;
 /// use std::thread;
 ///
-/// let sock = TcpStream::connect(&"216.58.193.100:80".parse()?)?;
+/// let sock = TcpStream::connect("216.58.193.100:80".parse()?)?;
 ///
 /// thread::sleep(Duration::from_secs(1));
 ///
@@ -386,7 +386,7 @@ impl Poll {
     ///
     /// // Bind a server socket to connect to.
     /// let addr: SocketAddr = "127.0.0.1:0".parse()?;
-    /// let server = TcpListener::bind(&addr)?;
+    /// let server = TcpListener::bind(addr)?;
     /// let addr = server.local_addr()?.clone();
     ///
     /// // Spawn a thread to accept the socket
@@ -400,7 +400,7 @@ impl Poll {
     /// let mut events = Events::with_capacity(1024);
     ///
     /// // Connect the stream
-    /// let stream = TcpStream::connect(&addr)?;
+    /// let stream = TcpStream::connect(addr)?;
     ///
     /// // Register the stream with `Poll`
     /// registry.register(
@@ -579,7 +579,7 @@ impl Registry {
     ///
     /// let mut poll = Poll::new()?;
     /// let registry = poll.registry().clone();
-    /// let socket = TcpStream::connect(&"216.58.193.100:80".parse()?)?;
+    /// let socket = TcpStream::connect("216.58.193.100:80".parse()?)?;
     ///
     /// // Register the socket with `poll`
     /// registry.register(
@@ -673,7 +673,7 @@ impl Registry {
     ///
     /// let mut poll = Poll::new()?;
     /// let registry = poll.registry().clone();
-    /// let socket = TcpStream::connect(&"216.58.193.100:80".parse()?)?;
+    /// let socket = TcpStream::connect("216.58.193.100:80".parse()?)?;
     ///
     /// // Register the socket with `poll`, requesting readable
     /// registry.register(
@@ -747,7 +747,7 @@ impl Registry {
     ///
     /// let mut poll = Poll::new()?;
     /// let registry = poll.registry().clone();
-    /// let socket = TcpStream::connect(&"216.58.193.100:80".parse()?)?;
+    /// let socket = TcpStream::connect("216.58.193.100:80".parse()?)?;
     ///
     /// // Register the socket with `poll`
     /// registry.register(

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -22,7 +22,7 @@ pub struct TcpListener {
 }
 
 impl TcpStream {
-    pub fn connect(stream: net::TcpStream, addr: &SocketAddr) -> io::Result<TcpStream> {
+    pub fn connect(stream: net::TcpStream, addr: SocketAddr) -> io::Result<TcpStream> {
         set_nonblock(stream.as_raw_fd())?;
 
         match stream.connect(addr) {

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -31,7 +31,7 @@ impl UdpSocket {
         self.io.try_clone().map(|io| UdpSocket { io })
     }
 
-    pub fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
+    pub fn send_to(&self, buf: &[u8], target: SocketAddr) -> io::Result<usize> {
         self.io.send_to(buf, target)
     }
 

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -88,7 +88,7 @@ impl UdpSocket {
     /// TODO: This... may be wrong in the long run. We're reporting that we
     ///       successfully wrote all of the bytes in `buf` but it's possible
     ///       that we don't actually end up writing all of them!
-    pub fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
+    pub fn send_to(&self, buf: &[u8], target: SocketAddr) -> io::Result<usize> {
         let mut me = self.inner();
         let me = &mut *me;
 
@@ -110,7 +110,7 @@ impl UdpSocket {
             trace!("scheduling a send");
             self.imp.inner.socket.send_to_overlapped(
                 &owned_buf,
-                target,
+                &target,
                 self.imp.inner.write.as_mut_ptr(),
             )
         }?;

--- a/src/token.rs
+++ b/src/token.rs
@@ -38,7 +38,7 @@
 /// let registry = poll.registry().clone();
 ///
 /// // Tcp listener
-/// let listener = TcpListener::bind(&"127.0.0.1:0".parse()?)?;
+/// let listener = TcpListener::bind("127.0.0.1:0".parse()?)?;
 ///
 /// // Register the listener
 /// registry.register(&listener,
@@ -53,7 +53,7 @@
 ///     // +1 here is to connect an extra socket to signal the socket to close
 ///     for _ in 0..(MAX_SOCKETS+1) {
 ///         // Connect then drop the socket
-///         let _ = TcpStream::connect(&addr).unwrap();
+///         let _ = TcpStream::connect(addr).unwrap();
 ///     }
 /// });
 ///

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -90,14 +90,14 @@ pub fn test_close_on_drop() {
     let addr = localhost();
 
     // == Create & setup server socket
-    let srv = TcpListener::bind(&addr).unwrap();
+    let srv = TcpListener::bind(addr).unwrap();
 
     poll.registry()
         .register(&srv, SERVER, Interests::READABLE)
         .unwrap();
 
     // == Create & setup client socket
-    let sock = TcpStream::connect(&addr).unwrap();
+    let sock = TcpStream::connect(addr).unwrap();
 
     poll.registry()
         .register(&sock, CLIENT, Interests::WRITABLE)

--- a/test/test_double_register.rs
+++ b/test/test_double_register.rs
@@ -9,7 +9,7 @@ pub fn test_double_register() {
     let poll = Poll::new().unwrap();
 
     // Create the listener
-    let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let l = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
     poll.registry()

--- a/test/test_echo_server.rs
+++ b/test/test_echo_server.rs
@@ -284,14 +284,14 @@ pub fn test_echo_server() {
     let mut poll = Poll::new().unwrap();
 
     let addr = localhost();
-    let srv = TcpListener::bind(&addr).unwrap();
+    let srv = TcpListener::bind(addr).unwrap();
 
     info!("listen for connections");
     poll.registry()
         .register(&srv, SERVER, Interests::READABLE)
         .unwrap();
 
-    let sock = TcpStream::connect(&addr).unwrap();
+    let sock = TcpStream::connect(addr).unwrap();
 
     // Connect to the server
     poll.registry()

--- a/test/test_local_addr_ready.rs
+++ b/test/test_local_addr_ready.rs
@@ -16,7 +16,7 @@ struct MyHandler {
 #[test]
 fn local_addr_ready() {
     let addr = "127.0.0.1:0".parse().unwrap();
-    let server = TcpListener::bind(&addr).unwrap();
+    let server = TcpListener::bind(addr).unwrap();
     let addr = server.local_addr().unwrap();
 
     let mut poll = Poll::new().unwrap();
@@ -24,7 +24,7 @@ fn local_addr_ready() {
         .register(&server, LISTEN, Interests::READABLE)
         .unwrap();
 
-    let sock = TcpStream::connect(&addr).unwrap();
+    let sock = TcpStream::connect(addr).unwrap();
     poll.registry()
         .register(&sock, CLIENT, Interests::READABLE)
         .unwrap();

--- a/test/test_multicast.rs
+++ b/test/test_multicast.rs
@@ -24,7 +24,7 @@ pub struct UdpHandler {
 
 impl UdpHandler {
     fn new(tx: UdpSocket, rx: UdpSocket, msg: &'static str) -> UdpHandler {
-        let sock = UdpSocket::bind(&"127.0.0.1:12345".parse().unwrap()).unwrap();
+        let sock = UdpSocket::bind("127.0.0.1:12345".parse().unwrap()).unwrap();
         UdpHandler {
             tx,
             rx,
@@ -56,7 +56,7 @@ impl UdpHandler {
     fn handle_write(&mut self, _: &Registry, token: Token, _: Ready) {
         if let SENDER = token {
             let addr = self.rx.local_addr().unwrap();
-            let cnt = self.tx.send_to(self.buf.as_ref(), &addr).unwrap();
+            let cnt = self.tx.send_to(self.buf.as_ref(), addr).unwrap();
             self.buf.advance(cnt);
         }
     }
@@ -71,8 +71,8 @@ pub fn test_multicast() {
     let addr = localhost();
     let any = "0.0.0.0:0".parse().unwrap();
 
-    let tx = UdpSocket::bind(&any).unwrap();
-    let rx = UdpSocket::bind(&addr).unwrap();
+    let tx = UdpSocket::bind(any).unwrap();
+    let rx = UdpSocket::bind(addr).unwrap();
 
     info!("Joining group 227.1.1.100");
     let any = "0.0.0.0".parse().unwrap();

--- a/test/test_register_deregister.rs
+++ b/test/test_register_deregister.rs
@@ -67,14 +67,14 @@ pub fn test_register_deregister() {
 
     let addr = localhost();
 
-    let server = TcpListener::bind(&addr).unwrap();
+    let server = TcpListener::bind(addr).unwrap();
 
     info!("register server socket");
     poll.registry()
         .register(&server, SERVER, Interests::READABLE)
         .unwrap();
 
-    let client = TcpStream::connect(&addr).unwrap();
+    let client = TcpStream::connect(addr).unwrap();
 
     // Register client socket only as writable
     poll.registry()

--- a/test/test_register_multiple_event_loops.rs
+++ b/test/test_register_multiple_event_loops.rs
@@ -6,7 +6,7 @@ use std::io::ErrorKind;
 #[test]
 fn test_tcp_register_multiple_event_loops() {
     let addr = localhost();
-    let listener = TcpListener::bind(&addr).unwrap();
+    let listener = TcpListener::bind(addr).unwrap();
 
     let poll1 = Poll::new().unwrap();
     poll1
@@ -40,7 +40,7 @@ fn test_tcp_register_multiple_event_loops() {
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 
     // Try the stream
-    let stream = TcpStream::connect(&addr).unwrap();
+    let stream = TcpStream::connect(addr).unwrap();
 
     poll1
         .registry()
@@ -68,7 +68,7 @@ fn test_tcp_register_multiple_event_loops() {
 #[test]
 fn test_udp_register_multiple_event_loops() {
     let addr = localhost();
-    let socket = UdpSocket::bind(&addr).unwrap();
+    let socket = UdpSocket::bind(addr).unwrap();
 
     let poll1 = Poll::new().unwrap();
     poll1

--- a/test/test_reregister_without_poll.rs
+++ b/test/test_reregister_without_poll.rs
@@ -11,14 +11,14 @@ pub fn test_reregister_different_without_poll() {
     let mut poll = Poll::new().unwrap();
 
     // Create the listener
-    let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let l = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
     poll.registry()
         .register(&l, Token(0), Interests::READABLE)
         .unwrap();
 
-    let s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
+    let s1 = TcpStream::connect(l.local_addr().unwrap()).unwrap();
     poll.registry()
         .register(&s1, Token(2), Interests::READABLE)
         .unwrap();

--- a/test/test_smoke.rs
+++ b/test/test_smoke.rs
@@ -15,7 +15,7 @@ fn run_once_with_nothing() {
 #[test]
 fn add_then_drop() {
     let mut events = Events::with_capacity(1024);
-    let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let l = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
     let mut poll = Poll::new().unwrap();
     poll.registry()
         .register(&l, Token(1), Interests::READABLE | Interests::WRITABLE)

--- a/test/test_tcp.rs
+++ b/test/test_tcp.rs
@@ -19,11 +19,11 @@ fn accept() {
         shutdown: bool,
     }
 
-    let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let l = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = l.local_addr().unwrap();
 
     let t = thread::spawn(move || {
-        net::TcpStream::connect(&addr).unwrap();
+        net::TcpStream::connect(addr).unwrap();
     });
 
     let mut poll = Poll::new().unwrap();
@@ -75,7 +75,7 @@ fn connect() {
     });
 
     let mut poll = Poll::new().unwrap();
-    let s = TcpStream::connect(&addr).unwrap();
+    let s = TcpStream::connect(addr).unwrap();
 
     poll.registry()
         .register(&s, Token(1), Interests::READABLE | Interests::WRITABLE)
@@ -145,7 +145,7 @@ fn read() {
     });
 
     let mut poll = Poll::new().unwrap();
-    let s = TcpStream::connect(&addr).unwrap();
+    let s = TcpStream::connect(addr).unwrap();
 
     poll.registry()
         .register(&s, Token(1), Interests::READABLE)
@@ -202,7 +202,7 @@ fn peek() {
     });
 
     let mut poll = Poll::new().unwrap();
-    let s = TcpStream::connect(&addr).unwrap();
+    let s = TcpStream::connect(addr).unwrap();
 
     poll.registry()
         .register(&s, Token(1), Interests::READABLE)
@@ -262,7 +262,7 @@ fn read_bufs() {
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(128);
 
-    let s = TcpStream::connect(&addr).unwrap();
+    let s = TcpStream::connect(addr).unwrap();
 
     poll.registry()
         .register(&s, Token(1), Interests::READABLE)
@@ -338,7 +338,7 @@ fn write() {
     });
 
     let mut poll = Poll::new().unwrap();
-    let s = TcpStream::connect(&addr).unwrap();
+    let s = TcpStream::connect(addr).unwrap();
 
     poll.registry()
         .register(&s, Token(1), Interests::WRITABLE)
@@ -398,7 +398,7 @@ fn write_bufs() {
 
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(128);
-    let s = TcpStream::connect(&addr).unwrap();
+    let s = TcpStream::connect(addr).unwrap();
     poll.registry()
         .register(&s, Token(1), Interests::WRITABLE)
         .unwrap();
@@ -436,8 +436,8 @@ fn connect_then_close() {
     }
 
     let mut poll = Poll::new().unwrap();
-    let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
-    let s = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
+    let l = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
+    let s = TcpStream::connect(l.local_addr().unwrap()).unwrap();
 
     poll.registry()
         .register(&l, Token(1), Interests::READABLE)
@@ -472,7 +472,7 @@ fn connect_then_close() {
 #[test]
 fn listen_then_close() {
     let mut poll = Poll::new().unwrap();
-    let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let l = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
 
     poll.registry()
         .register(&l, Token(1), Interests::READABLE)
@@ -505,9 +505,9 @@ fn test_tcp_sockets_are_send() {
 
 #[test]
 fn bind_twice_bad() {
-    let l1 = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let l1 = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = l1.local_addr().unwrap();
-    assert!(TcpListener::bind(&addr).is_err());
+    assert!(TcpListener::bind(addr).is_err());
 }
 
 #[test]
@@ -533,7 +533,7 @@ fn multiple_writes_immediate_success() {
     });
 
     let mut poll = Poll::new().unwrap();
-    let mut s = TcpStream::connect(&addr).unwrap();
+    let mut s = TcpStream::connect(addr).unwrap();
     poll.registry()
         .register(&s, Token(1), Interests::WRITABLE)
         .unwrap();
@@ -563,7 +563,7 @@ fn connection_reset_by_peer() {
     let mut buf = [0u8; 16];
 
     // Create listener
-    let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let l = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = l.local_addr().unwrap();
 
     // Connect client
@@ -639,7 +639,7 @@ fn connect_error() {
     let mut events = Events::with_capacity(16);
 
     // Pick a "random" port that shouldn't be in use.
-    let l = match TcpStream::connect(&"127.0.0.1:38381".parse().unwrap()) {
+    let l = match TcpStream::connect("127.0.0.1:38381".parse().unwrap()) {
         Ok(l) => l,
         Err(ref e) if e.kind() == io::ErrorKind::ConnectionRefused => {
             // Connection failed synchronously.  This is not a bug, but it
@@ -681,7 +681,7 @@ fn write_error() {
         drop(conn);
     });
 
-    let mut s = TcpStream::connect(&addr).unwrap();
+    let mut s = TcpStream::connect(addr).unwrap();
     poll.registry()
         .register(&s, Token(0), Interests::READABLE | Interests::WRITABLE)
         .unwrap();

--- a/test/test_tcp_shutdown.rs
+++ b/test/test_tcp_shutdown.rs
@@ -45,7 +45,7 @@ fn test_write_shutdown() {
 
     let interests = Interests::READABLE | Interests::WRITABLE;
 
-    let client = TcpStream::connect(&addr).unwrap();
+    let client = TcpStream::connect(addr).unwrap();
     poll.registry()
         .register(&client, Token(0), interests)
         .unwrap();

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -94,7 +94,7 @@ fn test_send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
                 if let SENDER = event.token() {
                     let cnt = if !handler.connected {
                         let addr = handler.rx.local_addr().unwrap();
-                        handler.tx.send_to(handler.buf.as_ref(), &addr).unwrap()
+                        handler.tx.send_to(handler.buf.as_ref(), addr).unwrap()
                     } else {
                         handler.tx.send(handler.buf.as_ref()).unwrap()
                     };
@@ -111,8 +111,8 @@ fn connected_sockets() -> (UdpSocket, UdpSocket) {
     let addr = localhost();
     let any = localhost();
 
-    let tx = UdpSocket::bind(&any).unwrap();
-    let rx = UdpSocket::bind(&addr).unwrap();
+    let tx = UdpSocket::bind(any).unwrap();
+    let rx = UdpSocket::bind(addr).unwrap();
 
     let tx_addr = tx.local_addr().unwrap();
     let rx_addr = rx.local_addr().unwrap();
@@ -128,8 +128,8 @@ pub fn test_udp_socket() {
     let addr = localhost();
     let any = localhost();
 
-    let tx = UdpSocket::bind(&any).unwrap();
-    let rx = UdpSocket::bind(&addr).unwrap();
+    let tx = UdpSocket::bind(any).unwrap();
+    let rx = UdpSocket::bind(addr).unwrap();
 
     test_send_recv_udp(tx, rx, false);
 }
@@ -147,9 +147,9 @@ pub fn test_udp_socket_discard() {
     let any = localhost();
     let outside = localhost();
 
-    let tx = UdpSocket::bind(&any).unwrap();
-    let rx = UdpSocket::bind(&addr).unwrap();
-    let udp_outside = UdpSocket::bind(&outside).unwrap();
+    let tx = UdpSocket::bind(any).unwrap();
+    let rx = UdpSocket::bind(addr).unwrap();
+    let udp_outside = UdpSocket::bind(outside).unwrap();
 
     let tx_addr = tx.local_addr().unwrap();
     let rx_addr = rx.local_addr().unwrap();

--- a/test/test_write_then_drop.rs
+++ b/test/test_write_then_drop.rs
@@ -8,9 +8,9 @@ use mio::{Events, Interests, Poll, Token};
 fn write_then_drop() {
     drop(env_logger::try_init());
 
-    let a = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let a = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = a.local_addr().unwrap();
-    let mut s = TcpStream::connect(&addr).unwrap();
+    let mut s = TcpStream::connect(addr).unwrap();
 
     let mut poll = Poll::new().unwrap();
 
@@ -61,9 +61,9 @@ fn write_then_drop() {
 fn write_then_deregister() {
     drop(env_logger::try_init());
 
-    let a = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let a = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = a.local_addr().unwrap();
-    let mut s = TcpStream::connect(&addr).unwrap();
+    let mut s = TcpStream::connect(addr).unwrap();
 
     let mut poll = Poll::new().unwrap();
 


### PR DESCRIPTION
SocketAddr is Copy so there is little point in accept a reference to it.

Closes #667, #988.