### PR TITLE
Change Iter to return &Event

### DIFF
--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -110,10 +110,13 @@ impl Event {
         self.inner.is_lio()
     }
 
-    /// Create an `Event` from a platform specific event.
-    pub(crate) fn from_sys_event(sys_event: SysEvent) -> Event {
-        Event {
-            inner: sys::Event::from_sys_event(sys_event),
+    /// Create a reference to an `Event` from a platform specific event.
+    pub(crate) fn from_sys_event_ref(sys_event: &SysEvent) -> &Event {
+        unsafe {
+            // This is safe because `Event` only because the memory layout of
+            // `SysEvent` is the same as `Event`, also see the comments in the
+            // `sys` module.
+            std::mem::transmute(sys_event)
         }
     }
 }

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -215,7 +215,11 @@ impl<'a> Iterator for Iter<'a> {
     type Item = &'a Event;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let ret = self.inner.inner.get(self.pos).map(Event::from_sys_event_ref);
+        let ret = self
+            .inner
+            .inner
+            .get(self.pos)
+            .map(Event::from_sys_event_ref);
         self.pos += 1;
         ret
     }

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -84,42 +84,6 @@ pub struct Iter<'a> {
     pos: usize,
 }
 
-/// Owned [`Events`] iterator.
-///
-/// This struct is created by the `into_iter` method on [`Events`].
-///
-/// # Examples
-///
-/// ```
-/// # use std::error::Error;
-/// # fn try_main() -> Result<(), Box<Error>> {
-/// use mio::{Events, Poll};
-/// use std::time::Duration;
-///
-/// let mut events = Events::with_capacity(1024);
-/// let mut poll = Poll::new()?;
-///
-/// // Register handles with `poll`
-///
-/// poll.poll(&mut events, Some(Duration::from_millis(100)))?;
-///
-/// for event in events {
-///     println!("event={:?}", event);
-/// }
-/// #     Ok(())
-/// # }
-/// #
-/// # fn main() {
-/// #     try_main().unwrap();
-/// # }
-/// ```
-/// [`Events`]: struct.Events.html
-#[derive(Debug)]
-pub struct IntoIter {
-    inner: Events,
-    pos: usize,
-}
-
 impl Events {
     /// Return a new `Events` capable of holding up to `capacity` events.
     ///
@@ -239,7 +203,7 @@ impl Events {
 }
 
 impl<'a> IntoIterator for &'a Events {
-    type Item = Event;
+    type Item = &'a Event;
     type IntoIter = Iter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -248,32 +212,10 @@ impl<'a> IntoIterator for &'a Events {
 }
 
 impl<'a> Iterator for Iter<'a> {
-    type Item = Event;
+    type Item = &'a Event;
 
-    fn next(&mut self) -> Option<Event> {
-        let ret = self.inner.inner.get(self.pos).map(Event::from_sys_event);
-        self.pos += 1;
-        ret
-    }
-}
-
-impl IntoIterator for Events {
-    type Item = Event;
-    type IntoIter = IntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        IntoIter {
-            inner: self,
-            pos: 0,
-        }
-    }
-}
-
-impl Iterator for IntoIter {
-    type Item = Event;
-
-    fn next(&mut self) -> Option<Event> {
-        let ret = self.inner.inner.get(self.pos).map(Event::from_sys_event);
+    fn next(&mut self) -> Option<Self::Item> {
+        let ret = self.inner.inner.get(self.pos).map(Event::from_sys_event_ref);
         self.pos += 1;
         ret
     }

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,3 +1,13 @@
+//! Module with system specific types.
+//!
+//! `SysEvent`: must be a type alias for the system specific event, e.g.
+//!             `kevent` or `epol_event`.
+//! `Event`: **must be** a `transparent` wrapper around `SysEvent`, i.e. the
+//!          type must have `#[repr(transparent)]` with only `SysEvent` as
+//!          field. This is safety requirement, see `Event::from_sys_event_ref`.
+//!          Furthermore on this type a number of methods must be implemented
+//!          that are used by `Event` (in the `event` module).
+
 #[cfg(unix)]
 pub use self::unix::{
     pipe, set_nonblock, Event, EventedFd, Events, Io, Selector, SysEvent, TcpListener, TcpStream,

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -211,10 +211,6 @@ impl Event {
         // Not supported.
         false
     }
-
-    pub fn from_sys_event(epoll_event: SysEvent) -> Event {
-        Event { inner: epoll_event }
-    }
 }
 
 pub struct Events {
@@ -244,8 +240,8 @@ impl Events {
     }
 
     #[inline]
-    pub fn get(&self, idx: usize) -> Option<SysEvent> {
-        self.events.get(idx).cloned()
+    pub fn get(&self, idx: usize) -> Option<&SysEvent> {
+        self.events.get(idx)
     }
 
     pub fn clear(&mut self) {

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -396,10 +396,6 @@ impl Event {
             false
         }
     }
-
-    pub fn from_sys_event(kevent: SysEvent) -> Event {
-        Event { inner: kevent }
-    }
 }
 
 pub struct Events {
@@ -428,8 +424,8 @@ impl Events {
         self.events.is_empty()
     }
 
-    pub fn get(&self, idx: usize) -> Option<SysEvent> {
-        self.events.get(idx).cloned()
+    pub fn get(&self, idx: usize) -> Option<&SysEvent> {
+        self.events.get(idx)
     }
 
     pub fn clear(&mut self) {

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -46,8 +46,4 @@ impl Event {
     pub fn is_lio(&self) -> bool {
         self.readiness.is_lio()
     }
-
-    pub fn from_sys_event(event: SysEvent) -> Event {
-        event
-    }
 }

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -518,8 +518,8 @@ impl Events {
         self.events.capacity()
     }
 
-    pub fn get(&self, idx: usize) -> Option<SysEvent> {
-        self.events.get(idx).cloned()
+    pub fn get(&self, idx: usize) -> Option<&SysEvent> {
+        self.events.get(idx)
     }
 
     pub fn push_event(&mut self, event: Event) {


### PR DESCRIPTION
Before Event was 16 bytes, but since it became a wrapper for platform specific event it grew on some platforms. For example kevent is 32 bytes. Furthermore all methods on Event only take a reference to, so we can do away with the cloning.

Removes IntoIter.