### PR TITLE
Only use SelectorId when debug assertions are enabled

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -12,3 +12,17 @@ mod udp;
 
 pub use self::tcp::{TcpListener, TcpStream};
 pub use self::udp::UdpSocket;
+
+#[test]
+#[cfg(not(debug_assertions))]
+fn assert_size() {
+    use std::mem::size_of;
+
+    use crate::sys;
+
+    // Without debug assertions enabled `TcpListener`, `TcpStream` and `UdpSocket` should have the
+    // same size as the system specific socket, i.e. just a file descriptor on Unix platforms.
+    assert_eq!(size_of::<TcpListener>(), size_of::<sys::TcpListener>());
+    assert_eq!(size_of::<TcpStream>(), size_of::<sys::TcpStream>());
+    assert_eq!(size_of::<UdpSocket>(), size_of::<sys::UdpSocket>());
+}

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -5,8 +5,10 @@
 //! [portability guidelines] are followed, the behavior should be identical no
 //! matter the target platform.
 //!
-/// [portability guidelines]: ../struct.Poll.html#portability
+//! [portability guidelines]: ../struct.Poll.html#portability
+
 use crate::event::Evented;
+#[cfg(debug_assertions)]
 use crate::poll::SelectorId;
 use crate::{sys, Interests, Registry, Token};
 
@@ -56,6 +58,7 @@ use std::time::Duration;
 /// ```
 pub struct TcpStream {
     sys: sys::TcpStream,
+    #[cfg(debug_assertions)]
     selector_id: SelectorId,
 }
 
@@ -109,6 +112,7 @@ impl TcpStream {
     pub fn connect_stream(stream: net::TcpStream, addr: SocketAddr) -> io::Result<TcpStream> {
         Ok(TcpStream {
             sys: sys::TcpStream::connect(stream, addr)?,
+            #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         })
     }
@@ -128,6 +132,7 @@ impl TcpStream {
 
         Ok(TcpStream {
             sys: sys::TcpStream::from_stream(stream),
+            #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         })
     }
@@ -151,6 +156,7 @@ impl TcpStream {
     pub fn try_clone(&self) -> io::Result<TcpStream> {
         self.sys.try_clone().map(|s| TcpStream {
             sys: s,
+            #[cfg(debug_assertions)]
             selector_id: self.selector_id.clone(),
         })
     }
@@ -382,6 +388,7 @@ impl<'a> Write for &'a TcpStream {
 
 impl Evented for TcpStream {
     fn register(&self, registry: &Registry, token: Token, interests: Interests) -> io::Result<()> {
+        #[cfg(debug_assertions)]
         self.selector_id.associate_selector(registry)?;
         self.sys.register(registry, token, interests)
     }
@@ -440,6 +447,7 @@ impl fmt::Debug for TcpStream {
 /// ```
 pub struct TcpListener {
     sys: sys::TcpListener,
+    #[cfg(debug_assertions)]
     selector_id: SelectorId,
 }
 
@@ -477,6 +485,7 @@ impl TcpListener {
         let listener = sock.listen(1024)?;
         Ok(TcpListener {
             sys: sys::TcpListener::new(listener)?,
+            #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         })
     }
@@ -493,6 +502,7 @@ impl TcpListener {
     pub fn from_std(listener: net::TcpListener) -> io::Result<TcpListener> {
         sys::TcpListener::new(listener).map(|s| TcpListener {
             sys: s,
+            #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         })
     }
@@ -532,6 +542,7 @@ impl TcpListener {
     pub fn try_clone(&self) -> io::Result<TcpListener> {
         self.sys.try_clone().map(|s| TcpListener {
             sys: s,
+            #[cfg(debug_assertions)]
             selector_id: self.selector_id.clone(),
         })
     }
@@ -565,6 +576,7 @@ impl TcpListener {
 
 impl Evented for TcpListener {
     fn register(&self, registry: &Registry, token: Token, interests: Interests) -> io::Result<()> {
+        #[cfg(debug_assertions)]
         self.selector_id.associate_selector(registry)?;
         self.sys.register(registry, token, interests)
     }
@@ -617,6 +629,7 @@ impl FromRawFd for TcpStream {
     unsafe fn from_raw_fd(fd: RawFd) -> TcpStream {
         TcpStream {
             sys: FromRawFd::from_raw_fd(fd),
+            #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         }
     }
@@ -641,6 +654,7 @@ impl FromRawFd for TcpListener {
     unsafe fn from_raw_fd(fd: RawFd) -> TcpListener {
         TcpListener {
             sys: FromRawFd::from_raw_fd(fd),
+            #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         }
     }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -8,6 +8,7 @@
 //! [portability guidelines]: ../struct.Poll.html#portability
 
 use crate::event::Evented;
+#[cfg(debug_assertions)]
 use crate::poll::SelectorId;
 use crate::{sys, Interests, Registry, Token};
 
@@ -89,6 +90,7 @@ use iovec::IoVec;
 /// ```
 pub struct UdpSocket {
     sys: sys::UdpSocket,
+    #[cfg(debug_assertions)]
     selector_id: SelectorId,
 }
 
@@ -135,6 +137,7 @@ impl UdpSocket {
     pub fn from_socket(socket: net::UdpSocket) -> io::Result<UdpSocket> {
         Ok(UdpSocket {
             sys: sys::UdpSocket::new(socket)?,
+            #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         })
     }
@@ -189,6 +192,7 @@ impl UdpSocket {
     pub fn try_clone(&self) -> io::Result<UdpSocket> {
         self.sys.try_clone().map(|s| UdpSocket {
             sys: s,
+            #[cfg(debug_assertions)]
             selector_id: self.selector_id.clone(),
         })
     }
@@ -544,6 +548,7 @@ impl UdpSocket {
 
 impl Evented for UdpSocket {
     fn register(&self, registry: &Registry, token: Token, interests: Interests) -> io::Result<()> {
+        #[cfg(debug_assertions)]
         self.selector_id.associate_selector(registry)?;
         self.sys.register(registry, token, interests)
     }
@@ -596,6 +601,7 @@ impl FromRawFd for UdpSocket {
     unsafe fn from_raw_fd(fd: RawFd) -> UdpSocket {
         UdpSocket {
             sys: FromRawFd::from_raw_fd(fd),
+            #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         }
     }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -6,6 +6,7 @@ use log::trace;
 use std::os::unix::io::AsRawFd;
 #[cfg(unix)]
 use std::os::unix::io::RawFd;
+#[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -207,6 +208,7 @@ pub struct Registry {
 
 /// Used to associate an IO type with a Selector
 #[derive(Debug)]
+#[cfg(debug_assertions)]
 pub struct SelectorId {
     id: AtomicUsize,
 }
@@ -679,6 +681,7 @@ pub fn selector(registry: &Registry) -> &sys::Selector {
 fn is_send<T: Send>() {}
 fn is_sync<T: Sync>() {}
 
+#[cfg(debug_assertions)]
 impl SelectorId {
     pub fn new() -> SelectorId {
         SelectorId {
@@ -701,6 +704,7 @@ impl SelectorId {
     }
 }
 
+#[cfg(debug_assertions)]
 impl Clone for SelectorId {
     fn clone(&self) -> SelectorId {
         SelectorId {

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -6,6 +6,7 @@ use libc::{self, c_int};
 use libc::{EPOLLET, EPOLLIN, EPOLLOUT};
 use std::os::unix::io::AsRawFd;
 use std::os::unix::io::RawFd;
+#[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use std::{cmp, i32, io};
@@ -15,10 +16,12 @@ use std::{cmp, i32, io};
 /// registered with the `Selector`. If a type that is previously associated with
 /// a `Selector` attempts to register itself with a different `Selector`, the
 /// operation will return with an error. This matches windows behavior.
+#[cfg(debug_assertions)]
 static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug)]
 pub struct Selector {
+    #[cfg(debug_assertions)]
     id: usize,
     epfd: RawFd,
 }
@@ -42,11 +45,17 @@ impl Selector {
         };
 
         // offset by 1 to avoid choosing 0 as the id of a selector
+        #[cfg(debug_assertions)]
         let id = NEXT_ID.fetch_add(1, Ordering::Relaxed) + 1;
 
-        Ok(Selector { id: id, epfd: epfd })
+        Ok(Selector {
+            #[cfg(debug_assertions)]
+            id,
+            epfd,
+        })
     }
 
+    #[cfg(debug_assertions)]
     pub fn id(&self) -> usize {
         self.id
     }

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -12,6 +12,7 @@ use miow;
 use miow::iocp::{CompletionPort, CompletionStatus};
 use std::cell::UnsafeCell;
 use std::os::windows::prelude::*;
+#[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -27,6 +28,7 @@ const WAKE: Token = Token(std::usize::MAX);
 /// registered with the `Selector`. If a type that is previously associated with
 /// a `Selector` attempts to register itself with a different `Selector`, the
 /// operation will return with an error. This matches windows behavior.
+#[cfg(debug_assertions)]
 static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
 /// The guts of the Windows event loop, this is the struct which actually owns
@@ -48,6 +50,7 @@ pub struct Selector {
 #[derive(Debug)]
 pub(super) struct SelectorInner {
     /// Unique identifier of the `Selector`
+    #[cfg(debug_assertions)]
     id: usize,
 
     /// The actual completion port that's used to manage all I/O
@@ -63,10 +66,12 @@ pub(super) struct SelectorInner {
 impl Selector {
     pub fn new() -> io::Result<Selector> {
         // offset by 1 to avoid choosing 0 as the id of a selector
+        #[cfg(debug_assertions)]
         let id = NEXT_ID.fetch_add(1, Ordering::Relaxed) + 1;
         let cp = CompletionPort::new(1)?;
 
         let inner = Arc::new(SelectorInner {
+            #[cfg(debug_assertions)]
             id: id,
             port: cp,
             buffers: Mutex::new(BufferPool::new(256)),
@@ -150,6 +155,7 @@ impl Selector {
     }
 
     /// Return the `Selector`'s identifier
+    #[cfg(debug_assertions)]
     pub fn id(&self) -> usize {
         self.inner.id
     }

--- a/test/test_register_multiple_event_loops.rs
+++ b/test/test_register_multiple_event_loops.rs
@@ -4,6 +4,7 @@ use mio::*;
 use std::io::ErrorKind;
 
 #[test]
+#[cfg(debug_assertions)] // Check is only present when debug assertions are enabled.
 fn test_tcp_register_multiple_event_loops() {
     let addr = localhost();
     let listener = TcpListener::bind(addr).unwrap();
@@ -66,6 +67,7 @@ fn test_tcp_register_multiple_event_loops() {
 }
 
 #[test]
+#[cfg(debug_assertions)] // Check is only present when debug assertions are enabled.
 fn test_udp_register_multiple_event_loops() {
     let addr = localhost();
     let socket = UdpSocket::bind(addr).unwrap();


### PR DESCRIPTION
Continuation of #1002. I've added a test to check the sizes, but it only run in release mode (or when debug assertions are disabled), so I would like to run that in the CI as well.

Closes #999.