### PR TITLE
Remove EV_CLEAR kqueue flag

### DIFF
--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -108,7 +108,7 @@ impl Selector {
     pub fn register(&self, fd: RawFd, token: Token, interests: Interests) -> io::Result<()> {
         trace!("registering; token={:?}; interests={:?}", token, interests);
 
-        let flags = libc::EV_CLEAR | libc::EV_RECEIPT;
+        let flags = libc::EV_RECEIPT;
 
         unsafe {
             let r = if interests.is_readable() {


### PR DESCRIPTION
To fix https://github.com/tokio-rs/mio/issues/1011

I implemented similar implementation of #1011 in C. The following program doesn't have this problem.
https://gist.github.com/c-bata/86155cdc1a66bd4a3a0bf7d301efac3f

I guess the cause of #1011 is registered fd is cleared when calling `register` method. So I applied this patch, then it works.

```
$ ab -n 1000 -c 10 http://127.0.0.1:13265/
This is ApacheBench, Version 2.3 <$Revision: 1826891 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking 127.0.0.1 (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        MIOHttpServer
Server Hostname:        127.0.0.1
Server Port:            13265

Document Path:          /
Document Length:        7 bytes

Concurrency Level:      10
Time taken for tests:   0.165 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      128000 bytes
HTML transferred:       7000 bytes
Requests per second:    6044.96 [#/sec] (mean)
Time per request:       1.654 [ms] (mean)
Time per request:       0.165 [ms] (mean, across all concurrent requests)
Transfer rate:          755.62 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1   0.6      0       5
Processing:     0    1   0.9      1       7
Waiting:        0    1   0.7      1       6
Total:          0    2   1.2      1       7
WARNING: The median and mean for the initial connection time are not within a normal deviation
        These results are probably not that reliable.

Percentage of the requests served within a certain time (ms)
  50%      1
  66%      1
  75%      2
  80%      2
  90%      3
  95%      4
  98%      6
  99%      6
 100%      7 (longest request)
```