### PR TITLE
Implement vectored I/O for TcpStream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ publish = false
 iovec = "0.1.2"
 log   = "0.4.6"
 net2  = "0.2.33"
-slab  = "0.4.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.58"
@@ -41,4 +40,5 @@ winapi = { version = "0.3.7", features = ["minwindef", "minwinbase", "ioapiset",
 [dev-dependencies]
 bytes      = "0.4.12"
 env_logger = { version = "0.6.1", default-features = false }
+slab       = "0.4.2"
 tempdir    = "0.3.7"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
     name: nightly
     displayName: Nightly
     # Pin nightly to avoid being impacted by breakage
-    rust_version: nightly-2019-04-22
+    rust_version: nightly-2019-07-16
     benches: true
 
 # This represents the minimum Rust version supported by

--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -2,7 +2,10 @@ steps:
   # Linux and macOS.
   - script: |
       set -e
-      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUSTUP_TOOLCHAIN
+      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
+      export PATH=$PATH:$HOME/.cargo/bin
+      rustup toolchain install $RUSTUP_TOOLCHAIN
+      rustup default $RUSTUP_TOOLCHAIN
       echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
     env:
       RUSTUP_TOOLCHAIN: ${{parameters.rust_version}}
@@ -12,8 +15,10 @@ steps:
   # Windows.
   - script: |
       curl -sSf -o rustup-init.exe https://win.rustup.rs
-      rustup-init.exe -y --default-toolchain %RUSTUP_TOOLCHAIN%
+      rustup-init.exe -y --default-toolchain none
       set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+      rustup toolchain install %RUSTUP_TOOLCHAIN%
+      rustup default %RUSTUP_TOOLCHAIN%
       echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
     env:
       RUSTUP_TOOLCHAIN: ${{parameters.rust_version}}
@@ -22,7 +27,6 @@ steps:
 
   # All platforms.
   - script: |
-        rustup update # Force update to make sure we have the latests versions.
         rustup toolchain list
         rustc -Vv
         cargo -V

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -14,7 +14,7 @@ use crate::{event, sys, Interests, Registry, Token};
 use iovec::IoVec;
 use net2::TcpBuilder;
 use std::fmt;
-use std::io::{self, Read, Write};
+use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::time::Duration;
 
@@ -357,17 +357,29 @@ impl Read for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         (&self.sys).read(buf)
     }
+
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        (&self.sys).read_vectored(bufs)
+    }
 }
 
 impl<'a> Read for &'a TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         (&self.sys).read(buf)
     }
+
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        (&self.sys).read_vectored(bufs)
+    }
 }
 
 impl Write for TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         (&self.sys).write(buf)
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        (&self.sys).write_vectored(bufs)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -378,6 +390,10 @@ impl Write for TcpStream {
 impl<'a> Write for &'a TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         (&self.sys).write(buf)
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        (&self.sys).write_vectored(bufs)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -11,7 +11,6 @@
 use crate::poll::SelectorId;
 use crate::{event, sys, Interests, Registry, Token};
 
-use iovec::IoVec;
 use net2::TcpBuilder;
 use std::fmt;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
@@ -299,42 +298,6 @@ impl TcpStream {
     /// `MSG_PEEK` as a flag to the underlying recv system call.
     pub fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.sys.peek(buf)
-    }
-
-    /// Read in a list of buffers all at once.
-    ///
-    /// This operation will attempt to read bytes from this socket and place
-    /// them into the list of buffers provided. Note that each buffer is an
-    /// `IoVec` which can be created from a byte slice.
-    ///
-    /// The buffers provided will be filled in sequentially. A buffer will be
-    /// entirely filled up before the next is written to.
-    ///
-    /// The number of bytes read is returned, if successful, or an error is
-    /// returned otherwise. If no bytes are available to be read yet then
-    /// a "would block" error is returned. This operation does not block.
-    ///
-    /// On Unix this corresponds to the `readv` syscall.
-    pub fn read_bufs(&self, bufs: &mut [&mut IoVec]) -> io::Result<usize> {
-        self.sys.readv(bufs)
-    }
-
-    /// Write a list of buffers all at once.
-    ///
-    /// This operation will attempt to write a list of byte buffers to this
-    /// socket. Note that each buffer is an `IoVec` which can be created from a
-    /// byte slice.
-    ///
-    /// The buffers provided will be written sequentially. A buffer will be
-    /// entirely written before the next is written.
-    ///
-    /// The number of bytes written is returned, if successful, or an error is
-    /// returned otherwise. If the socket is not currently writable then a
-    /// "would block" error is returned. This operation does not block.
-    ///
-    /// On Unix this corresponds to the `writev` syscall.
-    pub fn write_bufs(&self, bufs: &[&IoVec]) -> io::Result<usize> {
-        self.sys.writev(bufs)
     }
 }
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -7,7 +7,7 @@ use iovec::IoVec;
 use libc;
 use net2::TcpStreamExt;
 use std::fmt;
-use std::io::{self, Read, Write};
+use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::{self, SocketAddr};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::time::Duration;
@@ -122,11 +122,19 @@ impl<'a> Read for &'a TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         (&self.inner).read(buf)
     }
+
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        (&self.inner).read_vectored(bufs)
+    }
 }
 
 impl<'a> Write for &'a TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         (&self.inner).write(buf)
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        (&self.inner).write_vectored(bufs)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -1,9 +1,7 @@
 use crate::sys::unix::io::set_nonblock;
-use crate::sys::unix::uio::VecIo;
 use crate::sys::unix::SourceFd;
 use crate::{event, Interests, Registry, Token};
 
-use iovec::IoVec;
 use libc;
 use net2::TcpStreamExt;
 use std::fmt;
@@ -107,14 +105,6 @@ impl TcpStream {
 
     pub fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.peek(buf)
-    }
-
-    pub fn readv(&self, bufs: &mut [&mut IoVec]) -> io::Result<usize> {
-        self.inner.readv(bufs)
-    }
-
-    pub fn writev(&self, bufs: &[&IoVec]) -> io::Result<usize> {
-        self.inner.writev(bufs)
     }
 }
 

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -2,7 +2,6 @@ use crate::sys::windows::from_raw_arc::FromRawArc;
 use crate::sys::windows::selector::{Overlapped, ReadyBinding};
 use crate::sys::windows::{Family, Ready, Registration};
 use crate::{event, Interests, Registry, Token};
-use iovec::IoVec;
 use log::trace;
 use miow::iocp::CompletionStatus;
 use miow::net::*;
@@ -279,87 +278,6 @@ impl TcpStream {
                 Err(e)
             }
         }
-    }
-
-    pub fn readv(&self, bufs: &mut [&mut IoVec]) -> io::Result<usize> {
-        let mut me = self.before_read()?;
-
-        // TODO: Does WSARecv work on a nonblocking sockets? We ideally want to
-        //       call that instead of looping over all the buffers and calling
-        //       `recv` on each buffer. I'm not sure though if an overlapped
-        //       socket in nonblocking mode would work with that use case,
-        //       however, so for now we just call `recv`.
-
-        let mut amt = 0;
-        for buf in bufs {
-            match (&self.imp.inner.socket).read(buf) {
-                // If we did a partial read, then return what we've read so far
-                Ok(n) if n < buf.len() => return Ok(amt + n),
-
-                // Otherwise filled this buffer entirely, so try to fill the
-                // next one as well.
-                Ok(n) => amt += n,
-
-                // If we hit an error then things get tricky if we've already
-                // read some data. If the error is "would block" then we just
-                // return the data we've read so far while scheduling another
-                // 0-byte read.
-                //
-                // If we've read data and the error kind is not "would block",
-                // then we stash away the error to get returned later and return
-                // the data that we've read.
-                //
-                // Finally if we haven't actually read any data we just
-                // reschedule a 0-byte read to happen again and then return the
-                // error upwards.
-                Err(e) => {
-                    if amt > 0 && e.kind() == io::ErrorKind::WouldBlock {
-                        me.read = State::Empty;
-                        self.imp.schedule_read(&mut me);
-                        return Ok(amt);
-                    } else if amt > 0 {
-                        me.read = State::Error(e);
-                        return Ok(amt);
-                    } else {
-                        me.read = State::Empty;
-                        self.imp.schedule_read(&mut me);
-                        return Err(e);
-                    }
-                }
-            }
-        }
-
-        Ok(amt)
-    }
-
-    pub fn writev(&self, bufs: &[&IoVec]) -> io::Result<usize> {
-        let mut me = self.inner();
-        let me = &mut *me;
-
-        match mem::replace(&mut me.write, State::Empty) {
-            State::Empty => {}
-            State::Error(e) => return Err(e),
-            other => {
-                me.write = other;
-                return Err(io::ErrorKind::WouldBlock.into());
-            }
-        }
-
-        if !me.iocp.registered() {
-            return Err(io::ErrorKind::WouldBlock.into());
-        }
-
-        if bufs.is_empty() {
-            return Ok(0);
-        }
-
-        let len = bufs.iter().map(|b| b.len()).fold(0, |a, b| a + b);
-        let mut intermediate = me.iocp.get_buffer(len);
-        for buf in bufs {
-            intermediate.extend_from_slice(buf);
-        }
-        self.imp.schedule_write(intermediate, 0, me);
-        Ok(len)
     }
 }
 


### PR DESCRIPTION
@carllerche I know you've said your not a fan of this approach but at least we can start using more nightly features on the crate without breaking the stable builds this way.

TODO:
- [x] Remove `TcpStream::{read_bufs, write_bufs}`.
- [x] Windows implementation, already uses `IoVec` so it shouldn't be too hard.
- [x] Remove `iovec` dependency.

Updates #957.