### PR TITLE
Remove SysEvent

### DIFF
--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -1,4 +1,3 @@
-use crate::sys::SysEvent;
 use crate::{sys, Token};
 
 use std::fmt;
@@ -22,19 +21,19 @@ impl Event {
     /// Returns the event's token.
     #[inline]
     pub fn token(&self) -> Token {
-        self.inner.token()
+        sys::event::token(&self.inner)
     }
 
     /// Returns true if the event contains readable readiness.
     #[inline]
     pub fn is_readable(&self) -> bool {
-        self.inner.is_readable()
+        sys::event::is_readable(&self.inner)
     }
 
     /// Returns true if the event contains writable readiness.
     #[inline]
     pub fn is_writable(&self) -> bool {
-        self.inner.is_writable()
+        sys::event::is_writable(&self.inner)
     }
 
     /// Returns true if the event contains error readiness.
@@ -49,7 +48,7 @@ impl Event {
     /// this indicator.
     #[inline]
     pub fn is_error(&self) -> bool {
-        self.inner.is_error()
+        sys::event::is_error(&self.inner)
     }
 
     /// Returns true if the event contains HUP readiness.
@@ -74,7 +73,7 @@ impl Event {
     /// only provides a convenience method to read it.
     #[inline]
     pub fn is_hup(&self) -> bool {
-        self.inner.is_hup()
+        sys::event::is_hup(&self.inner)
     }
 
     /// Returns true if the event contains priority readiness.
@@ -85,7 +84,7 @@ impl Event {
     /// this indicator.
     #[inline]
     pub fn is_priority(&self) -> bool {
-        self.inner.is_priority()
+        sys::event::is_priority(&self.inner)
     }
 
     /// Returns true if the event contains AIO readiness.
@@ -96,7 +95,7 @@ impl Event {
     /// this indicator.
     #[inline]
     pub fn is_aio(&self) -> bool {
-        self.inner.is_aio()
+        sys::event::is_aio(&self.inner)
     }
 
     /// Returns true if the event contains LIO readiness.
@@ -107,15 +106,14 @@ impl Event {
     /// this indicator.
     #[inline]
     pub fn is_lio(&self) -> bool {
-        self.inner.is_lio()
+        sys::event::is_lio(&self.inner)
     }
 
     /// Create a reference to an `Event` from a platform specific event.
-    pub(crate) fn from_sys_event_ref(sys_event: &SysEvent) -> &Event {
+    pub(crate) fn from_sys_event_ref(sys_event: &sys::Event) -> &Event {
         unsafe {
-            // This is safe because `Event` only because the memory layout of
-            // `SysEvent` is the same as `Event`, also see the comments in the
-            // `sys` module.
+            // This is safe because only because the memory layout of `Event` is
+            // the same as `sys::Event` due to the `repr(transparent)` attribute.
             std::mem::transmute(sys_event)
         }
     }

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,16 +1,13 @@
 //! Module with system specific types.
 //!
-//! `SysEvent`: must be a type alias for the system specific event, e.g.
-//!             `kevent` or `epoll_event`.
-//! `Event`: **must be** a `transparent` wrapper around `SysEvent`, i.e. the
-//!          type must have `#[repr(transparent)]` with only `SysEvent` as
-//!          field. This is safety requirement, see `Event::from_sys_event_ref`.
-//!          Furthermore on this type a number of methods must be implemented
-//!          that are used by `Event` (in the `event` module).
+//! `Event`: a type alias for the system specific event, e.g.
+//!          `kevent` or `epoll_event`.
+//! `event`: a module with various helper functions for `Event`, see
+//!          `crate::event::Event` for the required functions.
 
 #[cfg(unix)]
 pub use self::unix::{
-    Event, EventedFd, Events, Selector, SysEvent, TcpListener, TcpStream, UdpSocket, Waker,
+    event, Event, EventedFd, Events, Selector, TcpListener, TcpStream, UdpSocket, Waker,
 };
 
 #[cfg(unix)]
@@ -18,8 +15,7 @@ pub mod unix;
 
 #[cfg(windows)]
 pub use self::windows::{
-    Binding, Event, Events, Overlapped, Selector, SysEvent, TcpListener, TcpStream, UdpSocket,
-    Waker,
+    event, Binding, Event, Events, Overlapped, Selector, TcpListener, TcpStream, UdpSocket, Waker,
 };
 
 #[cfg(windows)]

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -152,46 +152,44 @@ impl Drop for Selector {
     }
 }
 
-pub type SysEvent = libc::epoll_event;
+pub type Event = libc::epoll_event;
 
-#[repr(transparent)]
-pub struct Event {
-    inner: SysEvent,
-}
+pub mod event {
+    use crate::sys::Event;
+    use crate::Token;
 
-impl Event {
-    pub fn token(&self) -> Token {
-        Token(self.inner.u64 as usize)
+    pub fn token(event: &Event) -> Token {
+        Token(event.u64 as usize)
     }
 
-    pub fn is_readable(&self) -> bool {
-        (self.inner.events as libc::c_int & libc::EPOLLIN) != 0
-            || (self.inner.events as libc::c_int & libc::EPOLLPRI) != 0
+    pub fn is_readable(event: &Event) -> bool {
+        (event.events as libc::c_int & libc::EPOLLIN) != 0
+            || (event.events as libc::c_int & libc::EPOLLPRI) != 0
     }
 
-    pub fn is_writable(&self) -> bool {
-        (self.inner.events as libc::c_int & libc::EPOLLOUT) != 0
+    pub fn is_writable(event: &Event) -> bool {
+        (event.events as libc::c_int & libc::EPOLLOUT) != 0
     }
 
-    pub fn is_error(&self) -> bool {
-        (self.inner.events as libc::c_int & libc::EPOLLERR) != 0
+    pub fn is_error(event: &Event) -> bool {
+        (event.events as libc::c_int & libc::EPOLLERR) != 0
     }
 
-    pub fn is_hup(&self) -> bool {
-        (self.inner.events as libc::c_int & libc::EPOLLHUP) != 0
-            || (self.inner.events as libc::c_int & libc::EPOLLRDHUP) != 0
+    pub fn is_hup(event: &Event) -> bool {
+        (event.events as libc::c_int & libc::EPOLLHUP) != 0
+            || (event.events as libc::c_int & libc::EPOLLRDHUP) != 0
     }
 
-    pub fn is_priority(&self) -> bool {
-        (self.inner.events as libc::c_int & libc::EPOLLPRI) != 0
+    pub fn is_priority(event: &Event) -> bool {
+        (event.events as libc::c_int & libc::EPOLLPRI) != 0
     }
 
-    pub fn is_aio(&self) -> bool {
+    pub fn is_aio(_: &Event) -> bool {
         // Not supported in the kernel, only in libc.
         false
     }
 
-    pub fn is_lio(&self) -> bool {
+    pub fn is_lio(_: &Event) -> bool {
         // Not supported.
         false
     }
@@ -224,7 +222,7 @@ impl Events {
     }
 
     #[inline]
-    pub fn get(&self, idx: usize) -> Option<&SysEvent> {
+    pub fn get(&self, idx: usize) -> Option<&Event> {
         self.events.get(idx)
     }
 

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -2,7 +2,7 @@
 mod epoll;
 
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
-pub use self::epoll::{Event, Events, Selector, SysEvent};
+pub use self::epoll::{event, Event, Events, Selector};
 
 #[cfg(any(
     target_os = "bitrig",
@@ -24,7 +24,7 @@ mod kqueue;
     target_os = "netbsd",
     target_os = "openbsd"
 ))]
-pub use self::kqueue::{Event, Events, Selector, SysEvent};
+pub use self::kqueue::{event, Event, Events, Selector};
 
 mod eventedfd;
 mod io;

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -2,8 +2,6 @@ use crate::Token;
 
 use super::Ready;
 
-pub type SysEvent = Event;
-
 #[derive(Debug, Clone)]
 pub struct Event {
     token: Token,
@@ -14,36 +12,36 @@ impl Event {
     pub(crate) fn new(readiness: Ready, token: Token) -> Event {
         Event { token, readiness }
     }
+}
 
-    pub fn token(&self) -> Token {
-        self.token
-    }
+pub fn token(event: &Event) -> Token {
+    event.token
+}
 
-    pub fn is_readable(&self) -> bool {
-        self.readiness.is_readable()
-    }
+pub fn is_readable(event: &Event) -> bool {
+    event.readiness.is_readable()
+}
 
-    pub fn is_writable(&self) -> bool {
-        self.readiness.is_writable()
-    }
+pub fn is_writable(event: &Event) -> bool {
+    event.readiness.is_writable()
+}
 
-    pub fn is_error(&self) -> bool {
-        self.readiness.is_error()
-    }
+pub fn is_error(event: &Event) -> bool {
+    event.readiness.is_error()
+}
 
-    pub fn is_hup(&self) -> bool {
-        self.readiness.is_hup()
-    }
+pub fn is_hup(event: &Event) -> bool {
+    event.readiness.is_hup()
+}
 
-    pub fn is_priority(&self) -> bool {
-        self.readiness.is_priority()
-    }
+pub fn is_priority(event: &Event) -> bool {
+    event.readiness.is_priority()
+}
 
-    pub fn is_aio(&self) -> bool {
-        self.readiness.is_aio()
-    }
+pub fn is_aio(event: &Event) -> bool {
+    event.readiness.is_aio()
+}
 
-    pub fn is_lio(&self) -> bool {
-        self.readiness.is_lio()
-    }
+pub fn is_lio(event: &Event) -> bool {
+    event.readiness.is_lio()
 }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -143,7 +143,6 @@ use winapi;
 #[macro_use]
 mod selector;
 mod buffer_pool;
-mod event;
 mod from_raw_arc;
 mod lazycell;
 mod poll_opt;
@@ -153,7 +152,9 @@ mod tcp;
 mod udp;
 mod waker;
 
-pub use self::event::{Event, SysEvent};
+pub mod event;
+
+pub use self::event::Event;
 pub use self::selector::{Binding, Events, Overlapped, Selector};
 pub use self::tcp::{TcpListener, TcpStream};
 pub use self::udp::UdpSocket;

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -2,9 +2,7 @@ use crate::event::Evented;
 use crate::poll::{self, Registry};
 use crate::sys::windows::buffer_pool::BufferPool;
 use crate::sys::windows::lazycell::AtomicLazyCell;
-use crate::sys::windows::{
-    Event, PollOpt, ReadinessQueue, Ready, Registration, SetReadiness, SysEvent,
-};
+use crate::sys::windows::{Event, PollOpt, ReadinessQueue, Ready, Registration, SetReadiness};
 use crate::Interests;
 use crate::Token;
 use log::trace;
@@ -488,7 +486,7 @@ pub struct Events {
     /// Literal events returned by `get` to the upwards `EventLoop`. This file
     /// doesn't really modify this (except for the waker), instead almost all
     /// events are filled in by the `ReadinessQueue` from the `poll` module.
-    events: Vec<SysEvent>,
+    events: Vec<Event>,
 }
 
 impl Events {
@@ -514,7 +512,7 @@ impl Events {
         self.events.capacity()
     }
 
-    pub fn get(&self, idx: usize) -> Option<&SysEvent> {
+    pub fn get(&self, idx: usize) -> Option<&Event> {
         self.events.get(idx)
     }
 


### PR DESCRIPTION
Changes `sys::Event` to be an alias for the platform specific event, e.g.
`kevent` or `epoll_event`, what `SysEvent` used to be.

Next all methods on the old `sys::Event` become standalone functions in a
new `sys::event` module, which are used by `crate::Event`.