### PR TITLE
System module cleanup

### DIFF
--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -1,27 +1,23 @@
-use crate::sys::unix::cvt;
-use crate::{Interests, Token};
-
-use libc::{EPOLLET, EPOLLIN, EPOLLOUT};
-use std::os::unix::io::AsRawFd;
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
-use std::{cmp, i32, io};
+use std::{ptr, cmp, i32, io};
 
-/// Each Selector has a globally unique(ish) ID associated with it. This ID
-/// gets tracked by `TcpStream`, `TcpListener`, etc... when they are first
-/// registered with the `Selector`. If a type that is previously associated with
-/// a `Selector` attempts to register itself with a different `Selector`, the
-/// operation will return with an error. This matches windows behavior.
+use libc::{EPOLLET, EPOLLIN, EPOLLOUT};
+use log::error;
+
+use crate::{Interests, Token};
+
+/// Unique id for use as `SelectorId`.
 #[cfg(debug_assertions)]
-static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
 
 #[derive(Debug)]
 pub struct Selector {
     #[cfg(debug_assertions)]
     id: usize,
-    epfd: RawFd,
+    ep: RawFd,
 }
 
 impl Selector {
@@ -29,16 +25,10 @@ impl Selector {
         // According to libuv `EPOLL_CLOEXEC` is not defined on Android API <
         // 21. But `EPOLL_CLOEXEC` is an alias for `O_CLOEXEC` on all platforms,
         // so we use that instead.
-        let epfd = cvt(unsafe { libc::epoll_create1(libc::O_CLOEXEC) })?;
-
-        // offset by 1 to avoid choosing 0 as the id of a selector
-        #[cfg(debug_assertions)]
-        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed) + 1;
-
-        Ok(Selector {
+        syscall!(libc::epoll_create1(libc::O_CLOEXEC)).map(|ep| Selector {
             #[cfg(debug_assertions)]
-            id,
-            epfd,
+            id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+            ep,
         })
     }
 
@@ -47,80 +37,48 @@ impl Selector {
         self.id
     }
 
-    /// Wait for events from the OS
     pub fn select(&self, evts: &mut Events, timeout: Option<Duration>) -> io::Result<()> {
-        let timeout_ms = timeout
-            .map(|to| cmp::min(millis(to), i32::MAX as u64) as i32)
+        let timeout = timeout
+            .map(|to| cmp::min(to.as_millis(), libc::c_int::max_value() as u128) as libc::c_int)
             .unwrap_or(-1);
 
-        // Wait for epoll events for at most timeout_ms milliseconds
         evts.clear();
-        unsafe {
-            let cnt = cvt(libc::epoll_wait(
-                self.epfd,
-                evts.events.as_mut_ptr(),
-                evts.events.capacity() as i32,
-                timeout_ms,
-            ))?;
-            let cnt = cnt as usize;
-            evts.events.set_len(cnt);
-        }
-
-        Ok(())
+        syscall!(libc::epoll_wait(
+            self.ep,
+            evts.events.as_mut_ptr(),
+            evts.events.capacity() as i32,
+            timeout,
+        ))
+        .map(|n_events| {
+            // This is safe because `epoll_wait` ensures that `n_events` are
+            // assigned.
+            unsafe { evts.events.set_len(n_events as usize) };
+        })
     }
 
-    /// Register event interests for the given IO handle with the OS
     pub fn register(&self, fd: RawFd, token: Token, interests: Interests) -> io::Result<()> {
-        let mut info = libc::epoll_event {
+        let mut event = libc::epoll_event {
             events: interests_to_epoll(interests),
             u64: usize::from(token) as u64,
         };
 
-        unsafe {
-            cvt(libc::epoll_ctl(
-                self.epfd,
-                libc::EPOLL_CTL_ADD,
-                fd,
-                &mut info,
-            ))?;
-            Ok(())
-        }
+        syscall!(libc::epoll_ctl(self.ep, libc::EPOLL_CTL_ADD, fd, &mut event))
+            .map(|_| ())
     }
 
-    /// Register event interests for the given IO handle with the OS
     pub fn reregister(&self, fd: RawFd, token: Token, interests: Interests) -> io::Result<()> {
-        let mut info = libc::epoll_event {
+        let mut event = libc::epoll_event {
             events: interests_to_epoll(interests),
             u64: usize::from(token) as u64,
         };
 
-        unsafe {
-            cvt(libc::epoll_ctl(
-                self.epfd,
-                libc::EPOLL_CTL_MOD,
-                fd,
-                &mut info,
-            ))?;
-            Ok(())
-        }
+        syscall!(libc::epoll_ctl(self.ep, libc::EPOLL_CTL_MOD, fd, &mut event))
+            .map(|_| ())
     }
 
-    /// Deregister event interests for the given IO handle with the OS
     pub fn deregister(&self, fd: RawFd) -> io::Result<()> {
-        // The &info argument should be ignored by the system,
-        // but linux < 2.6.9 required it to be not null.
-        // For compatibility, we provide a dummy EpollEvent.
-        let mut info = libc::epoll_event { events: 0, u64: 0 };
-
-        unsafe {
-            cvt(libc::epoll_ctl(
-                self.epfd,
-                libc::EPOLL_CTL_DEL,
-                fd,
-                &mut info,
-            ))?;
-            Ok(())
-        }
+        syscall!(libc::epoll_ctl(self.ep, libc::EPOLL_CTL_DEL, fd, ptr::null_mut()))
+            .map(|_| ())
     }
 }
 
@@ -140,14 +98,14 @@ fn interests_to_epoll(interests: Interests) -> u32 {
 
 impl AsRawFd for Selector {
     fn as_raw_fd(&self) -> RawFd {
-        self.epfd
+        self.ep
     }
 }
 
 impl Drop for Selector {
     fn drop(&mut self) {
-        unsafe {
-            let _ = libc::close(self.epfd);
+        if let Err(err) = syscall!(libc::close(self.ep)) {
+            error!("error closing epoll: {}", err);
         }
     }
 }
@@ -231,23 +189,6 @@ impl Events {
             self.events.set_len(0);
         }
     }
-}
-
-const NANOS_PER_MILLI: u32 = 1_000_000;
-const MILLIS_PER_SEC: u64 = 1_000;
-
-/// Convert a `Duration` to milliseconds, rounding up and saturating at
-/// `u64::MAX`.
-///
-/// The saturating is fine because `u64::MAX` milliseconds are still many
-/// million years.
-pub fn millis(duration: Duration) -> u64 {
-    // Round up.
-    let millis = (duration.subsec_nanos() + NANOS_PER_MILLI - 1) / NANOS_PER_MILLI;
-    duration
-        .as_secs()
-        .saturating_mul(MILLIS_PER_SEC)
-        .saturating_add(millis as u64)
 }
 
 #[test]

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -2,7 +2,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
-use std::{ptr, cmp, i32, io};
+use std::{cmp, i32, io, ptr};
 
 use libc::{EPOLLET, EPOLLIN, EPOLLOUT};
 use log::error;
@@ -62,8 +62,13 @@ impl Selector {
             u64: usize::from(token) as u64,
         };
 
-        syscall!(libc::epoll_ctl(self.ep, libc::EPOLL_CTL_ADD, fd, &mut event))
-            .map(|_| ())
+        syscall!(libc::epoll_ctl(
+            self.ep,
+            libc::EPOLL_CTL_ADD,
+            fd,
+            &mut event
+        ))
+        .map(|_| ())
     }
 
     pub fn reregister(&self, fd: RawFd, token: Token, interests: Interests) -> io::Result<()> {
@@ -72,13 +77,23 @@ impl Selector {
             u64: usize::from(token) as u64,
         };
 
-        syscall!(libc::epoll_ctl(self.ep, libc::EPOLL_CTL_MOD, fd, &mut event))
-            .map(|_| ())
+        syscall!(libc::epoll_ctl(
+            self.ep,
+            libc::EPOLL_CTL_MOD,
+            fd,
+            &mut event
+        ))
+        .map(|_| ())
     }
 
     pub fn deregister(&self, fd: RawFd) -> io::Result<()> {
-        syscall!(libc::epoll_ctl(self.ep, libc::EPOLL_CTL_DEL, fd, ptr::null_mut()))
-            .map(|_| ())
+        syscall!(libc::epoll_ctl(
+            self.ep,
+            libc::EPOLL_CTL_DEL,
+            fd,
+            ptr::null_mut()
+        ))
+        .map(|_| ())
     }
 }
 

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -1,7 +1,6 @@
 use std::io;
 
 pub fn set_nonblock(fd: libc::c_int) -> io::Result<()> {
-    syscall!(libc::fcntl(fd, libc::F_GETFL)).and_then(|flags| {
-        syscall!(libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK)).map(|_| ())
-    })
+    syscall!(fcntl(fd, libc::F_GETFL))
+        .and_then(|flags| syscall!(fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK)).map(|_| ()))
 }

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -3,10 +3,9 @@ use std::io;
 use crate::sys::unix::cvt;
 
 pub fn set_nonblock(fd: libc::c_int) -> io::Result<()> {
-    unsafe {
-        let flags = libc::fcntl(fd, libc::F_GETFL);
-        cvt(libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK)).map(|_| ())
-    }
+    syscall!(libc::fcntl(fd, libc::F_GETFL)).and_then(|flags| {
+        syscall!(libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK)).map(|_| ())
+    })
 }
 
 #[cfg(any(

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -1,25 +1,7 @@
 use std::io;
 
-use crate::sys::unix::cvt;
-
 pub fn set_nonblock(fd: libc::c_int) -> io::Result<()> {
     syscall!(libc::fcntl(fd, libc::F_GETFL)).and_then(|flags| {
         syscall!(libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK)).map(|_| ())
     })
-}
-
-#[cfg(any(
-    target_os = "bitrig",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-pub fn set_cloexec(fd: libc::c_int) -> io::Result<()> {
-    unsafe {
-        let flags = libc::fcntl(fd, libc::F_GETFD);
-        cvt(libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC)).map(|_| ())
-    }
 }

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -67,6 +67,7 @@ impl IsMinusOne for isize {
     }
 }
 
+#[allow(dead_code)] // Still used in some places.
 fn cvt<T: IsMinusOne>(t: T) -> std::io::Result<T> {
     use std::io;
 

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -1,3 +1,17 @@
+/// Helper macro to execute a system call that returns an `io::Result`.
+//
+// Macro must be defined before any modules that uses them.
+macro_rules! syscall {
+    ($e:expr) => {{
+        let res = unsafe { $e };
+        if res == -1 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(res)
+        }
+    }};
+}
+
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
 mod epoll;
 

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -38,8 +38,6 @@ pub use self::tcp::{TcpListener, TcpStream};
 pub use self::udp::UdpSocket;
 pub use self::waker::Waker;
 
-pub use iovec::IoVec;
-
 trait IsMinusOne {
     fn is_minus_one(&self) -> bool;
 }

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -2,8 +2,8 @@
 //
 // Macro must be defined before any modules that uses them.
 macro_rules! syscall {
-    ($e:expr) => {{
-        let res = unsafe { $e };
+    ($fn: ident ( $($arg: expr),* $(,)* ) ) => {{
+        let res = unsafe { libc::$fn($($arg, )*) };
         if res == -1 {
             Err(io::Error::last_os_error())
         } else {


### PR DESCRIPTION
This introduces the `syscall!` macro, replacing `cvt` (see #1015).

On kqueue side of things it:

 * Fixes some type definitions on NetBSD, macOS and iOS.
 * Optimises Selector::register to only pass a single event to kevent if not both readable and writable interests are specified.
 * Documents when and why some errors returned by kevent are ignored.
 * Moves calling kevent and checking of errors into there own functions to allow for greater reuse.
 * This should also fix #911, but we need a test to make sure.

Closes #1015.
Updates #911.