### PR TITLE
Change sys::Events to Vec<sys::Event> on Unix

### DIFF
--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -16,7 +16,7 @@ macro_rules! syscall {
 mod epoll;
 
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
-pub use self::epoll::{event, Event, Events, Selector};
+pub use self::epoll::{event, Event, Selector};
 
 #[cfg(any(
     target_os = "bitrig",
@@ -38,7 +38,7 @@ mod kqueue;
     target_os = "netbsd",
     target_os = "openbsd"
 ))]
-pub use self::kqueue::{event, Event, Events, Selector};
+pub use self::kqueue::{event, Event, Selector};
 
 mod io;
 mod sourcefd;
@@ -51,3 +51,5 @@ pub use self::sourcefd::SourceFd;
 pub use self::tcp::{TcpListener, TcpStream};
 pub use self::udp::UdpSocket;
 pub use self::waker::Waker;
+
+pub type Events = Vec<Event>;


### PR DESCRIPTION
I'm not sure we want to do this, but I just noticed we don't really need to wrapper on epoll and kqueue.