### PR TITLE
Remove net2 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ publish = false
 [features]
 
 [dependencies]
-log   = "0.4.6"
-net2  = "0.2.33"
+log = "0.4.6"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.58"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,4 @@ bytes      = "0.4.12"
 env_logger = { version = "0.6.1", default-features = false }
 slab       = "0.4.2"
 tempdir    = "0.3.7"
+net2       = "0.2.33"

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -63,13 +63,6 @@ use std::net::Shutdown;
 impl TcpStream {
     /// Create a new TCP stream and issue a non-blocking connect to the
     /// specified address.
-    ///
-    /// This convenience method is available and uses the system's default
-    /// options when creating a socket which is then connected. If fine-grained
-    /// control over the creation of the socket is desired, you can use
-    /// `net2::TcpBuilder` to configure a socket and then pass its socket to
-    /// `TcpStream::connect_stream` to transfer ownership into mio and schedule
-    /// the connect operation.
     pub fn connect(addr: SocketAddr) -> io::Result<TcpStream> {
         sys::TcpStream::connect(addr).map(|sys| TcpStream {
             sys,
@@ -288,14 +281,9 @@ impl TcpListener {
     /// This function will take the following steps:
     ///
     /// 1. Create a new TCP socket.
-    /// 2. Set the `SO_REUSEADDR` option on the socket.
+    /// 2. Set the `SO_REUSEADDR` option on the socket on Unix.
     /// 3. Bind the socket to the specified address.
-    /// 4. Call `listen` on the socket to prepare it to receive new connections.
-    ///
-    /// If fine-grained control over the binding and listening process for a
-    /// socket is desired then the `net2::TcpBuilder` methods can be used in
-    /// combination with the `TcpListener::from_listener` method to transfer
-    /// ownership into mio.
+    /// 4. Calls `listen` on the socket to prepare it to receive new connections.
     pub fn bind(addr: SocketAddr) -> io::Result<TcpListener> {
         sys::TcpListener::bind(addr).map(|sys| TcpListener {
             sys,

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -9,8 +9,7 @@
 
 use std::fmt;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
-use std::net::{self, SocketAddr};
-use std::time::Duration;
+use std::net::SocketAddr;
 
 #[cfg(debug_assertions)]
 use crate::poll::SelectorId;
@@ -61,10 +60,6 @@ pub struct TcpStream {
 
 use std::net::Shutdown;
 
-fn set_nonblocking(stream: &net::TcpStream) -> io::Result<()> {
-    stream.set_nonblocking(true)
-}
-
 impl TcpStream {
     /// Create a new TCP stream and issue a non-blocking connect to the
     /// specified address.
@@ -78,52 +73,6 @@ impl TcpStream {
     pub fn connect(addr: SocketAddr) -> io::Result<TcpStream> {
         sys::TcpStream::connect(addr).map(|sys| TcpStream {
             sys,
-            #[cfg(debug_assertions)]
-            selector_id: SelectorId::new(),
-        })
-    }
-
-    /// Creates a new `TcpStream` from the pending socket inside the given
-    /// `std::net::TcpBuilder`, connecting it to the address specified.
-    ///
-    /// This constructor allows configuring the socket before it's actually
-    /// connected, and this function will transfer ownership to the returned
-    /// `TcpStream` if successful. An unconnected `TcpStream` can be created
-    /// with the `net2::TcpBuilder` type (and also configured via that route).
-    ///
-    /// The platform specific behavior of this function looks like:
-    ///
-    /// * On Unix, the socket is placed into nonblocking mode and then a
-    ///   `connect` call is issued.
-    ///
-    /// * On Windows, the address is stored internally and the connect operation
-    ///   is issued when the returned `TcpStream` is registered with an event
-    ///   loop. Note that on Windows you must `bind` a socket before it can be
-    ///   connected, so if a custom `TcpBuilder` is used it should be bound
-    ///   (perhaps to `INADDR_ANY`) before this method is called.
-    pub fn connect_stream(stream: net::TcpStream, addr: SocketAddr) -> io::Result<TcpStream> {
-        Ok(TcpStream {
-            sys: sys::TcpStream::connect_stream(stream, addr)?,
-            #[cfg(debug_assertions)]
-            selector_id: SelectorId::new(),
-        })
-    }
-
-    /// Creates a new `TcpStream` from a standard `net::TcpStream`.
-    ///
-    /// This function is intended to be used to wrap a TCP stream from the
-    /// standard library in the mio equivalent. The conversion here will
-    /// automatically set `stream` to nonblocking and the returned object should
-    /// be ready to get associated with an event loop.
-    ///
-    /// Note that the TCP stream here will not have `connect` called on it, so
-    /// it should already be connected via some other means (be it manually, the
-    /// net2 crate, or the standard library).
-    pub fn from_stream(stream: net::TcpStream) -> io::Result<TcpStream> {
-        set_nonblocking(&stream)?;
-
-        Ok(TcpStream {
-            sys: sys::TcpStream::from_stream(stream),
             #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         })
@@ -182,68 +131,6 @@ impl TcpStream {
         self.sys.nodelay()
     }
 
-    /// Sets the value of the `SO_RCVBUF` option on this socket.
-    ///
-    /// Changes the size of the operating system's receive buffer associated
-    /// with the socket.
-    pub fn set_recv_buffer_size(&self, size: usize) -> io::Result<()> {
-        self.sys.set_recv_buffer_size(size)
-    }
-
-    /// Gets the value of the `SO_RCVBUF` option on this socket.
-    ///
-    /// For more information about this option, see
-    /// [`set_recv_buffer_size`][link].
-    ///
-    /// [link]: #method.set_recv_buffer_size
-    pub fn recv_buffer_size(&self) -> io::Result<usize> {
-        self.sys.recv_buffer_size()
-    }
-
-    /// Sets the value of the `SO_SNDBUF` option on this socket.
-    ///
-    /// Changes the size of the operating system's send buffer associated with
-    /// the socket.
-    pub fn set_send_buffer_size(&self, size: usize) -> io::Result<()> {
-        self.sys.set_send_buffer_size(size)
-    }
-
-    /// Gets the value of the `SO_SNDBUF` option on this socket.
-    ///
-    /// For more information about this option, see
-    /// [`set_send_buffer_size`][link].
-    ///
-    /// [link]: #method.set_send_buffer_size
-    pub fn send_buffer_size(&self) -> io::Result<usize> {
-        self.sys.send_buffer_size()
-    }
-
-    /// Sets whether keepalive messages are enabled to be sent on this socket.
-    ///
-    /// On Unix, this option will set the `SO_KEEPALIVE` as well as the
-    /// `TCP_KEEPALIVE` or `TCP_KEEPIDLE` option (depending on your platform).
-    /// On Windows, this will set the `SIO_KEEPALIVE_VALS` option.
-    ///
-    /// If `None` is specified then keepalive messages are disabled, otherwise
-    /// the duration specified will be the time to remain idle before sending a
-    /// TCP keepalive probe.
-    ///
-    /// Some platforms specify this value in seconds, so sub-second
-    /// specifications may be omitted.
-    pub fn set_keepalive(&self, keepalive: Option<Duration>) -> io::Result<()> {
-        self.sys.set_keepalive(keepalive)
-    }
-
-    /// Returns whether keepalive messages are enabled on this socket, and if so
-    /// the duration of time between them.
-    ///
-    /// For more information about this option, see [`set_keepalive`][link].
-    ///
-    /// [link]: #method.set_keepalive
-    pub fn keepalive(&self) -> io::Result<Option<Duration>> {
-        self.sys.keepalive()
-    }
-
     /// Sets the value for the `IP_TTL` option on this socket.
     ///
     /// This value sets the time-to-live field that is used in every packet sent
@@ -259,20 +146,6 @@ impl TcpStream {
     /// [link]: #method.set_ttl
     pub fn ttl(&self) -> io::Result<u32> {
         self.sys.ttl()
-    }
-
-    /// Sets the value for the `SO_LINGER` option on this socket.
-    pub fn set_linger(&self, dur: Option<Duration>) -> io::Result<()> {
-        self.sys.set_linger(dur)
-    }
-
-    /// Gets the value of the `SO_LINGER` option on this socket.
-    ///
-    /// For more information about this option, see [`set_linger`][link].
-    ///
-    /// [link]: #method.set_linger
-    pub fn linger(&self) -> io::Result<Option<Duration>> {
-        self.sys.linger()
     }
 
     /// Get the value of the `SO_ERROR` option on this socket.
@@ -431,23 +304,6 @@ impl TcpListener {
         })
     }
 
-    /// Creates a new `TcpListener` from an instance of a
-    /// `std::net::TcpListener` type.
-    ///
-    /// This function will set the `listener` provided into nonblocking mode on
-    /// Unix, and otherwise the stream will just be wrapped up in an mio stream
-    /// ready to accept new connections and become associated with an event
-    /// loop.
-    ///
-    /// The address provided must be the address that the listener is bound to.
-    pub fn from_std(listener: net::TcpListener) -> io::Result<TcpListener> {
-        sys::TcpListener::new(listener).map(|s| TcpListener {
-            sys: s,
-            #[cfg(debug_assertions)]
-            selector_id: SelectorId::new(),
-        })
-    }
-
     /// Accepts a new `TcpStream`.
     ///
     /// This may return an `Err(e)` where `e.kind()` is
@@ -457,17 +313,16 @@ impl TcpListener {
     /// If an accepted stream is returned, the remote address of the peer is
     /// returned along with it.
     pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
-        let (s, a) = self.accept_std()?;
-        Ok((TcpStream::from_stream(s)?, a))
-    }
-
-    /// Accepts a new `std::net::TcpStream`.
-    ///
-    /// This method is the same as `accept`, except that it returns a TCP socket
-    /// *in blocking mode* which isn't bound to `mio`. This can be later then
-    /// converted to a `mio` type, if necessary.
-    pub fn accept_std(&self) -> io::Result<(net::TcpStream, SocketAddr)> {
-        self.sys.accept()
+        self.sys.accept().map(|(sys, addr)| {
+            (
+                TcpStream {
+                    sys,
+                    #[cfg(debug_assertions)]
+                    selector_id: SelectorId::new(),
+                },
+                addr,
+            )
+        })
     }
 
     /// Returns the local socket address of this listener.

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -120,24 +120,6 @@ impl UdpSocket {
         UdpSocket::from_socket(socket)
     }
 
-    /// Creates a new mio-wrapped socket from an underlying and bound std
-    /// socket.
-    ///
-    /// This function requires that `socket` has previously been bound to an
-    /// address to work correctly, and returns an I/O object which can be used
-    /// with mio to send/receive UDP messages.
-    ///
-    /// This can be used in conjunction with net2's `UdpBuilder` interface to
-    /// configure a socket before it's handed off to mio, such as setting
-    /// options like `reuse_address` or binding to multiple addresses.
-    pub fn from_socket(socket: net::UdpSocket) -> io::Result<UdpSocket> {
-        Ok(UdpSocket {
-            sys: sys::UdpSocket::new(socket)?,
-            #[cfg(debug_assertions)]
-            selector_id: SelectorId::new(),
-        })
-    }
-
     /// Returns the socket address that this socket was created from.
     ///
     /// # Examples

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -13,7 +13,7 @@ use crate::{event, sys, Interests, Registry, Token};
 
 use std::fmt;
 use std::io;
-use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
 /// A User Datagram Protocol socket.
 ///
@@ -116,8 +116,11 @@ impl UdpSocket {
     /// # }
     /// ```
     pub fn bind(addr: SocketAddr) -> io::Result<UdpSocket> {
-        let socket = net::UdpSocket::bind(addr)?;
-        UdpSocket::from_socket(socket)
+        sys::UdpSocket::bind(addr).map(|sys| UdpSocket {
+            sys,
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        })
     }
 
     /// Returns the socket address that this socket was created from.

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -1,6 +1,0 @@
-use std::io;
-
-pub fn set_nonblock(fd: libc::c_int) -> io::Result<()> {
-    syscall!(fcntl(fd, libc::F_GETFL))
-        .and_then(|flags| syscall!(fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK)).map(|_| ()))
-}

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -51,3 +51,61 @@ pub use self::udp::UdpSocket;
 pub use self::waker::Waker;
 
 pub type Events = Vec<Event>;
+
+pub mod net {
+    use std::io;
+    use std::mem::size_of_val;
+    use std::net::SocketAddr;
+
+    /// Create a new non-blocking socket.
+    pub fn new_socket(addr: SocketAddr, socket_type: libc::c_int) -> io::Result<libc::c_int> {
+        let domain = match addr {
+            SocketAddr::V4(..) => libc::AF_INET,
+            SocketAddr::V6(..) => libc::AF_INET6,
+        };
+
+        #[cfg(any(
+            target_os = "android",
+            target_os = "bitrig",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "linux",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ))]
+        let socket_type = socket_type | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
+
+        // Gives a warning for platforms without SOCK_NONBLOCK.
+        #[allow(clippy::let_and_return)]
+        let socket = syscall!(socket(domain, socket_type, 0));
+
+        // Darwin doesn't have SOCK_NONBLOCK or SOCK_CLOEXEC. Not sure about
+        // Solaris, couldn't find anything online.
+        #[cfg(any(target_os = "ios", target_os = "macos", target_os = "solaris"))]
+        let socket = socket.and_then(|socket| {
+            // For platforms that don't support flags in socket, we need to
+            // set the flags ourselves.
+            syscall!(fcntl(
+                socket,
+                libc::F_SETFL,
+                libc::O_NONBLOCK | libc::O_CLOEXEC
+            ))
+            .map(|_| socket)
+        });
+
+        socket
+    }
+
+    pub fn socket_addr(addr: &SocketAddr) -> (*const libc::sockaddr, libc::socklen_t) {
+        match addr {
+            SocketAddr::V4(ref addr) => (
+                addr as *const _ as *const libc::sockaddr,
+                size_of_val(addr) as libc::socklen_t,
+            ),
+            SocketAddr::V6(ref addr) => (
+                addr as *const _ as *const libc::sockaddr,
+                size_of_val(addr) as libc::socklen_t,
+            ),
+        }
+    }
+}

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -40,7 +40,6 @@ mod kqueue;
 ))]
 pub use self::kqueue::{event, Event, Selector};
 
-mod io;
 mod sourcefd;
 mod tcp;
 mod udp;

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -316,6 +316,8 @@ fn new_socket(addr: SocketAddr) -> io::Result<libc::c_int> {
     ))]
     let socket_type = libc::SOCK_STREAM | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
 
+    // Gives a warning for platforms without SOCK_NONBLOCK.
+    #[allow(clippy::let_and_return)]
     let socket = syscall!(socket(domain, socket_type, 0));
 
     #[cfg(any(target_os = "ios", target_os = "macos", target_os = "solaris"))]

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,9 +1,10 @@
-use crate::unix::SourceFd;
-use crate::{event, Interests, Registry, Token};
-
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::{fmt, io, net};
+
+use crate::sys::unix::net::{new_socket, socket_addr};
+use crate::unix::SourceFd;
+use crate::{event, Interests, Registry, Token};
 
 pub struct UdpSocket {
     io: net::UdpSocket,
@@ -11,8 +12,36 @@ pub struct UdpSocket {
 
 impl UdpSocket {
     pub fn bind(addr: SocketAddr) -> io::Result<UdpSocket> {
-        net::UdpSocket::bind(addr)
-            .and_then(|io| io.set_nonblocking(true).map(|()| UdpSocket { io }))
+        // Gives a warning for non Apple platforms.
+        #[allow(clippy::let_and_return)]
+        let socket = new_socket(addr, libc::SOCK_DGRAM);
+
+        // Set SO_NOSIGPIPE on iOS and macOS (mirrors what libstd does).
+        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        let socket = socket.and_then(|socket| {
+            syscall!(setsockopt(
+                socket,
+                libc::SOL_SOCKET,
+                libc::SO_NOSIGPIPE,
+                &1 as *const libc::c_int as *const libc::c_void,
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            ))
+            .map(|_| socket)
+        });
+
+        socket.and_then(|socket| {
+            let (raw_addr, raw_addr_length) = socket_addr(&addr);
+            syscall!(bind(socket, raw_addr, raw_addr_length))
+                .map_err(|err| {
+                    // Close the socket if we hit an error, ignoring the error
+                    // from closing since we can't pass back two errors.
+                    let _ = unsafe { libc::close(socket) };
+                    err
+                })
+                .map(|_| UdpSocket {
+                    io: unsafe { net::UdpSocket::from_raw_fd(socket) },
+                })
+        })
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,20 +1,18 @@
 use crate::unix::SourceFd;
 use crate::{event, Interests, Registry, Token};
 
-use std;
-use std::fmt;
-use std::io;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::{fmt, io, net};
 
 pub struct UdpSocket {
-    io: std::net::UdpSocket,
+    io: net::UdpSocket,
 }
 
 impl UdpSocket {
-    pub fn new(socket: std::net::UdpSocket) -> io::Result<UdpSocket> {
-        socket.set_nonblocking(true)?;
-        Ok(UdpSocket { io: socket })
+    pub fn bind(addr: SocketAddr) -> io::Result<UdpSocket> {
+        net::UdpSocket::bind(addr)
+            .and_then(|io| io.set_nonblocking(true).map(|()| UdpSocket { io }))
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Once};
 
 /// Helper macro to execute a system call that returns an `io::Result`.
 //
@@ -31,4 +31,15 @@ pub use waker::Waker;
 pub trait SocketState {
     fn get_sock_state(&self) -> Option<Arc<Mutex<SockState>>>;
     fn set_sock_state(&self, sock_state: Option<Arc<Mutex<SockState>>>);
+}
+
+/// Initialise the network stack for Windows.
+fn init() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        // Let standard library call `WSAStartup` for us, we can't do it
+        // ourselves because otherwise using any type in `std::net` would panic
+        // when it tries to call `WSAStartup` a second time.
+        drop(std::net::UdpSocket::bind("127.0.0.1:0"));
+    });
 }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1,5 +1,19 @@
 use std::sync::{Arc, Mutex};
 
+/// Helper macro to execute a system call that returns an `io::Result`.
+//
+// Macro must be defined before any modules that uses them.
+macro_rules! syscall {
+    ($fn: ident ( $($arg: expr),* $(,)* ), $err_test: path, $err_value: expr) => {{
+        let res = unsafe { $fn($($arg, )*) };
+        if $err_test(&res, &$err_value) {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(res)
+        }
+    }};
+}
+
 mod afd;
 pub mod event;
 mod io_status_block;

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -15,6 +15,7 @@ use winapi::um::winsock2::{
 };
 
 use crate::poll;
+use crate::sys::windows::init;
 use crate::{event, Interests, Registry, Token};
 
 use super::selector::{Selector, SockState};
@@ -84,6 +85,7 @@ macro_rules! wouldblock {
 
 impl TcpStream {
     pub fn connect(addr: SocketAddr) -> io::Result<TcpStream> {
+        init();
         new_socket(addr)
             .and_then(|socket| {
                 // Required for a future `connect_overlapped` operation to be
@@ -369,6 +371,7 @@ impl AsRawSocket for TcpStream {
 
 impl TcpListener {
     pub fn bind(addr: SocketAddr) -> io::Result<TcpListener> {
+        init();
         new_socket(addr).and_then(|socket| {
             let (raw_addr, raw_addr_length) = socket_addr(&addr);
             syscall!(

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -98,6 +98,7 @@ impl TcpStream {
         )
         .and_then(|socket| {
             syscall!(ioctlsocket(socket, FIONBIO, &mut 1), PartialEq::ne, 0)
+                .or_else(ignore_in_progress)
                 .and_then(|_| {
                     // Required for a future `connect_overlapped` operation to be
                     // executed successfully.

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -6,7 +6,8 @@ use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket}
 use std::sync::{Arc, Mutex, RwLock};
 use std::{fmt, io};
 
-use super::selector::{Selector, SockState};
+use crate::sys::windows::init;
+use crate::sys::windows::selector::{Selector, SockState};
 
 struct InternalState {
     selector: Arc<Selector>,
@@ -52,6 +53,7 @@ macro_rules! wouldblock {
 
 impl UdpSocket {
     pub fn bind(addr: SocketAddr) -> io::Result<UdpSocket> {
+        init();
         net::UdpSocket::bind(addr).and_then(|io| {
             io.set_nonblocking(true).map(|()| UdpSocket {
                 internal: Arc::new(RwLock::new(None)),

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -1,11 +1,10 @@
 use crate::poll;
 use crate::{event, Interests, Registry, Token};
 
-use std::fmt;
-use std::io;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
 use std::sync::{Arc, Mutex, RwLock};
+use std::{fmt, io};
 
 use super::selector::{Selector, SockState};
 
@@ -29,7 +28,7 @@ impl InternalState {
 
 pub struct UdpSocket {
     internal: Arc<RwLock<Option<InternalState>>>,
-    io: std::net::UdpSocket,
+    io: net::UdpSocket,
 }
 
 macro_rules! wouldblock {
@@ -52,11 +51,12 @@ macro_rules! wouldblock {
 }
 
 impl UdpSocket {
-    pub fn new(socket: std::net::UdpSocket) -> io::Result<UdpSocket> {
-        socket.set_nonblocking(true)?;
-        Ok(UdpSocket {
-            internal: Arc::new(RwLock::new(None)),
-            io: socket,
+    pub fn bind(addr: SocketAddr) -> io::Result<UdpSocket> {
+        net::UdpSocket::bind(addr).and_then(|io| {
+            io.set_nonblocking(true).map(|()| UdpSocket {
+                internal: Arc::new(RwLock::new(None)),
+                io,
+            })
         })
     }
 

--- a/tests/close_on_drop.rs
+++ b/tests/close_on_drop.rs
@@ -87,6 +87,10 @@ impl TestHandler {
 
 #[test]
 pub fn test_close_on_drop() {
+    // FIXME: see issue #1046.
+    // Let stdandard library call WSAStartup for us.
+    drop(std::net::TcpListener::bind("255.255.255.255:0"));
+
     drop(env_logger::try_init());
     debug!("Starting TEST_CLOSE_ON_DROP");
     let mut poll = Poll::new().unwrap();

--- a/tests/close_on_drop.rs
+++ b/tests/close_on_drop.rs
@@ -6,7 +6,7 @@ use mio::{Events, Interests, Poll, Token};
 
 mod util;
 
-use util::{localhost, TryRead};
+use util::{init, localhost, TryRead};
 
 use self::TestState::{AfterRead, Initial};
 
@@ -87,11 +87,7 @@ impl TestHandler {
 
 #[test]
 pub fn test_close_on_drop() {
-    // FIXME: see issue #1046.
-    // Let stdandard library call WSAStartup for us.
-    drop(std::net::TcpListener::bind("255.255.255.255:0"));
-
-    drop(env_logger::try_init());
+    init();
     debug!("Starting TEST_CLOSE_ON_DROP");
     let mut poll = Poll::new().unwrap();
 

--- a/tests/double_register.rs
+++ b/tests/double_register.rs
@@ -6,6 +6,10 @@ pub fn test_double_register() {
     use mio::net::TcpListener;
     use mio::*;
 
+    // FIXME: see issue #1046.
+    // Let stdandard library call WSAStartup for us.
+    drop(std::net::TcpListener::bind("255.255.255.255:0"));
+
     let poll = Poll::new().unwrap();
 
     // Create the listener

--- a/tests/double_register.rs
+++ b/tests/double_register.rs
@@ -1,14 +1,17 @@
 //! A smoke test for windows compatibility
 
-#[test]
-#[cfg(any(target_os = "linux", target_os = "windows"))]
-pub fn test_double_register() {
-    use mio::net::TcpListener;
-    use mio::*;
+#![cfg(any(target_os = "linux", target_os = "windows"))]
 
-    // FIXME: see issue #1046.
-    // Let stdandard library call WSAStartup for us.
-    drop(std::net::TcpListener::bind("255.255.255.255:0"));
+use mio::net::TcpListener;
+use mio::*;
+
+mod util;
+
+use util::init;
+
+#[test]
+pub fn test_double_register() {
+    init();
 
     let poll = Poll::new().unwrap();
 

--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -1,8 +1,14 @@
 use mio::*;
 use std::time::Duration;
 
+mod util;
+
+use util::init;
+
 #[test]
 fn test_poll_closes_fd() {
+    init();
+
     for _ in 0..2000 {
         let mut poll = Poll::new().unwrap();
         let mut events = Events::with_capacity(4);
@@ -16,6 +22,8 @@ fn test_poll_closes_fd() {
 
 #[test]
 fn test_drop_cancels_interest_and_shuts_down() {
+    init();
+
     use mio::net::TcpStream;
     use std::io;
     use std::io::Read;

--- a/tests/registering.rs
+++ b/tests/registering.rs
@@ -11,7 +11,7 @@ use mio::{Events, Interests, Poll, Registry, Token};
 
 mod util;
 
-use util::localhost;
+use util::{init, localhost};
 
 const SERVER: Token = Token(0);
 const CLIENT: Token = Token(1);
@@ -68,7 +68,7 @@ impl TestHandler {
 
 #[test]
 pub fn test_register_deregister() {
-    drop(env_logger::try_init());
+    init();
 
     debug!("Starting TEST_REGISTER_DEREGISTER");
     let mut poll = Poll::new().unwrap();
@@ -144,6 +144,8 @@ pub fn test_reregister_different_without_poll() {
 #[test]
 #[cfg(debug_assertions)] // Check is only present when debug assertions are enabled.
 fn test_tcp_register_multiple_event_loops() {
+    init();
+
     let addr = localhost();
     let listener = TcpListener::bind(addr).unwrap();
 
@@ -207,6 +209,8 @@ fn test_tcp_register_multiple_event_loops() {
 #[test]
 #[cfg(debug_assertions)] // Check is only present when debug assertions are enabled.
 fn test_udp_register_multiple_event_loops() {
+    init();
+
     let addr = localhost();
     let socket = UdpSocket::bind(addr).unwrap();
 

--- a/tests/registering.rs
+++ b/tests/registering.rs
@@ -114,6 +114,8 @@ pub fn test_register_deregister() {
 
 #[test]
 pub fn test_reregister_different_without_poll() {
+    init();
+
     let mut events = Events::with_capacity(1024);
     let mut poll = Poll::new().unwrap();
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -4,8 +4,14 @@ use mio::net::TcpListener;
 use mio::{Events, Interests, Poll, Token};
 use std::time::Duration;
 
+mod util;
+
+use util::init;
+
 #[test]
 fn run_once_with_nothing() {
+    init();
+
     let mut events = Events::with_capacity(1024);
     let mut poll = Poll::new().unwrap();
     poll.poll(&mut events, Some(Duration::from_millis(100)))
@@ -14,6 +20,8 @@ fn run_once_with_nothing() {
 
 #[test]
 fn add_then_drop() {
+    init();
+
     let mut events = Events::with_capacity(1024);
     let l = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
     let mut poll = Poll::new().unwrap();

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -461,7 +461,7 @@ fn connection_reset_by_peer() {
     let client = unsafe {
         #[cfg(windows)]
         {
-            TcpStream::from_raw_fd(client.into_raw_fd())
+            TcpStream::from_raw_socket(client.into_raw_socket())
         }
         #[cfg(unix)]
         {

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -8,6 +8,7 @@ use std::{net, thread};
 
 use bytes::{Buf, Bytes, BytesMut};
 use log::{debug, info};
+#[cfg(unix)]
 use net2::TcpStreamExt;
 use slab::Slab;
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -1,16 +1,11 @@
 use std::io::{self, Cursor, Read, Write};
 use std::net::Shutdown;
-#[cfg(unix)]
-use std::os::unix::io::{FromRawFd, IntoRawFd};
-#[cfg(windows)]
-use std::os::windows::io::{FromRawSocket, IntoRawSocket};
 use std::sync::mpsc::channel;
 use std::time::Duration;
 use std::{net, thread};
 
 use bytes::{Buf, Bytes, BytesMut};
 use log::{debug, info};
-use net2::{self, TcpStreamExt};
 use slab::Slab;
 
 use mio::net::{TcpListener, TcpStream};
@@ -441,6 +436,7 @@ fn multiple_writes_immediate_success() {
     t.join().unwrap();
 }
 
+/* FIXME: requires net2 to use linger.
 #[test]
 fn connection_reset_by_peer() {
     let mut poll = Poll::new().unwrap();
@@ -458,16 +454,7 @@ fn connection_reset_by_peer() {
     client.connect(&addr).unwrap();
 
     // Convert to Mio stream
-    let client = unsafe {
-        #[cfg(windows)]
-        {
-            TcpStream::from_raw_socket(client.into_raw_socket())
-        }
-        #[cfg(unix)]
-        {
-            TcpStream::from_raw_fd(client.into_raw_fd())
-        }
-    };
+    let client = TcpStream::from_stream(client).unwrap();
 
     // Register server
     poll.registry()
@@ -526,6 +513,7 @@ fn connection_reset_by_peer() {
         }
     }
 }
+*/
 
 #[test]
 fn connect_error() {

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -17,7 +17,7 @@ use mio::{Events, Interests, Poll, Registry, Token};
 
 mod util;
 
-use util::{localhost, TryRead, TryWrite};
+use util::{init, localhost, TryRead, TryWrite};
 
 const LISTEN: Token = Token(0);
 const CLIENT: Token = Token(1);
@@ -25,6 +25,8 @@ const SERVER: Token = Token(2);
 
 #[test]
 fn accept() {
+    init();
+
     struct H {
         hit: bool,
         listener: TcpListener,
@@ -69,6 +71,8 @@ fn accept() {
 
 #[test]
 fn connect() {
+    init();
+
     struct H {
         hit: u32,
         shutdown: bool,
@@ -137,6 +141,8 @@ fn connect() {
 
 #[test]
 fn read() {
+    init();
+
     const N: usize = 16 * 1024 * 1024;
     struct H {
         amt: usize,
@@ -194,6 +200,8 @@ fn read() {
 
 #[test]
 fn peek() {
+    init();
+
     const N: usize = 16 * 1024 * 1024;
     struct H {
         amt: usize,
@@ -257,6 +265,8 @@ fn peek() {
 
 #[test]
 fn write() {
+    init();
+
     const N: usize = 16 * 1024 * 1024;
     struct H {
         amt: usize,
@@ -314,6 +324,8 @@ fn write() {
 
 #[test]
 fn connect_then_close() {
+    init();
+
     struct H {
         listener: TcpListener,
         shutdown: bool,
@@ -355,6 +367,8 @@ fn connect_then_close() {
 
 #[test]
 fn listen_then_close() {
+    init();
+
     let mut poll = Poll::new().unwrap();
     let l = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
 
@@ -381,6 +395,8 @@ fn assert_sync<T: Sync>() {}
 
 #[test]
 fn test_tcp_sockets_are_send() {
+    init();
+
     assert_send::<TcpListener>();
     assert_send::<TcpStream>();
     assert_sync::<TcpListener>();
@@ -389,6 +405,8 @@ fn test_tcp_sockets_are_send() {
 
 #[test]
 fn bind_twice_bad() {
+    init();
+
     let l1 = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = l1.local_addr().unwrap();
     assert!(TcpListener::bind(addr).is_err());
@@ -396,6 +414,8 @@ fn bind_twice_bad() {
 
 #[test]
 fn multiple_writes_immediate_success() {
+    init();
+
     const N: usize = 16;
     let l = net::TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = l.local_addr().unwrap();
@@ -443,6 +463,8 @@ fn multiple_writes_immediate_success() {
 #[test]
 #[cfg(unix)]
 fn connection_reset_by_peer() {
+    init();
+
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(16);
     let mut buf = [0u8; 16];
@@ -521,6 +543,8 @@ fn connection_reset_by_peer() {
 
 #[test]
 fn connect_error() {
+    init();
+
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(16);
 
@@ -555,6 +579,8 @@ fn connect_error() {
 
 #[test]
 fn write_error() {
+    init();
+
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(16);
     let (tx, rx) = channel();
@@ -649,6 +675,8 @@ macro_rules! wait {
 
 #[test]
 fn test_write_shutdown() {
+    init();
+
     let mut poll = Poll::new().unwrap();
 
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
@@ -690,6 +718,8 @@ struct MyHandler {
 
 #[test]
 fn local_addr_ready() {
+    init();
+
     let addr = "127.0.0.1:0".parse().unwrap();
     let server = TcpListener::bind(addr).unwrap();
     let addr = server.local_addr().unwrap();
@@ -1013,6 +1043,8 @@ impl Echo {
 
 #[test]
 pub fn test_echo_server() {
+    init();
+
     debug!("Starting TEST_ECHO_SERVER");
     let mut poll = Poll::new().unwrap();
 
@@ -1063,7 +1095,7 @@ pub fn test_echo_server() {
 
 #[test]
 fn write_then_drop() {
-    drop(env_logger::try_init());
+    init();
 
     let a = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = a.local_addr().unwrap();
@@ -1121,7 +1153,7 @@ fn write_then_drop() {
 
 #[test]
 fn write_then_deregister() {
-    drop(env_logger::try_init());
+    init();
 
     let a = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = a.local_addr().unwrap();

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -11,7 +11,7 @@ use mio::{Events, Interests, Poll, Registry, Token};
 
 mod util;
 
-use util::localhost;
+use util::{init, localhost};
 
 const LISTENER: Token = Token(0);
 const SENDER: Token = Token(1);
@@ -132,6 +132,8 @@ fn connected_sockets() -> (UdpSocket, UdpSocket) {
 
 #[test]
 pub fn test_udp_socket() {
+    init();
+
     let addr = localhost();
     let any = localhost();
 
@@ -143,6 +145,8 @@ pub fn test_udp_socket() {
 
 #[test]
 pub fn test_udp_socket_send_recv() {
+    init();
+
     let (tx, rx) = connected_sockets();
 
     test_send_recv_udp(tx, rx, true);
@@ -150,6 +154,8 @@ pub fn test_udp_socket_send_recv() {
 
 #[test]
 pub fn test_udp_socket_discard() {
+    init();
+
     let addr = localhost();
     let any = localhost();
     let outside = localhost();
@@ -249,7 +255,8 @@ impl UdpHandler {
 )]
 #[test]
 pub fn test_multicast() {
-    drop(env_logger::try_init());
+    init();
+
     debug!("Starting TEST_UDP_CONNECTIONLESS");
     let mut poll = Poll::new().unwrap();
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 
 use std::io::{self, Read, Write};
+use std::sync::Once;
 use std::time::Duration;
 
 use bytes::{Buf, BufMut};
@@ -123,4 +124,16 @@ pub fn expect_no_events(poll: &mut Poll, events: &mut Events) {
     poll.poll(events, Some(Duration::from_millis(50)))
         .expect("unable to poll");
     assert!(events.is_empty(), "received events, but didn't expect any");
+}
+
+pub fn init() {
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| {
+        drop(env_logger::try_init());
+
+        // FIXME: see issue #1046.
+        // Let stdandard library call WSAStartup for us.
+        drop(std::net::TcpListener::bind("255.255.255.255:0"));
+    })
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -131,9 +131,5 @@ pub fn init() {
 
     INIT.call_once(|| {
         drop(env_logger::try_init());
-
-        // FIXME: see issue #1046.
-        // Let stdandard library call WSAStartup for us.
-        drop(std::net::TcpListener::bind("255.255.255.255:0"));
     })
 }


### PR DESCRIPTION
This initial comment only remove net2 from `TcpStream::connect`, on Unix platforms (expect for iOS, macOS and Solaris) this reduces the number of system calls from three to two.

@carllerche this does increase the complexity a bit, do we still want to continue down this route?

Closes #841.
Closes #1045.