### PR TITLE
Split Event::is_hup into is_hup and is_read_hup and refer to OS selector docs

### DIFF
--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -71,9 +71,8 @@ impl Event {
     ///
     /// Because of the above be cautions when using this in cross-platform
     /// applications, Mio makes no attempt at normalising this indicator and
-    /// only provides a convenience method to read it. We advice looking at the
-    /// documentation provided for the selectors (see below) when using this
-    /// indicator.
+    /// only provides a convenience method to read it. Refer to the selector
+    /// documentation (below) when using this indicator.
     ///
     /// The table below shows what flags are checked on what OS.
     ///

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -69,19 +69,11 @@ impl Event {
     /// Method is available on all platforms, but not all platforms (can) use
     /// this indicator.
     ///
-    /// When HUP events are received is different per platform. For example on
-    /// epoll platforms HUP will be received when a TCP socket reached EOF,
-    /// however on kqueue platforms a HUP event will be received when `shutdown`
-    /// is called on the connection (both when shutting down the reading
-    /// **and/or** writing side). Meaning that even though this function might
-    /// return true on one platform in a given situation, it might return false
-    /// on a different platform in the same situation. Furthermore even if true
-    /// was returned on both platforms it could simply mean something different
-    /// on the two platforms.
-    ///
     /// Because of the above be cautions when using this in cross-platform
     /// applications, Mio makes no attempt at normalising this indicator and
-    /// only provides a convenience method to read it.
+    /// only provides a convenience method to read it. We advice looking at the
+    /// documentation provided for the selectors (see below) when using this
+    /// indicator.
     ///
     /// The table below shows what flags are checked on what OS.
     ///

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -87,8 +87,8 @@ impl Event {
     ///
     /// | [OS selector] | Flag(s) checked |
     /// |---------------|-----------------|
-    /// | [epoll]       | `EPOLLHUP` and `EPOLLRDHUP` |
-    /// | [kqueue]      | `EV_EOF`        |
+    /// | [epoll]       | `EPOLLHUP`      |
+    /// | [kqueue]      | Not supported   |
     ///
     /// [OS selector]: ../struct.Poll.html#implementation-notes
     /// [epoll]: http://man7.org/linux/man-pages/man7/epoll.7.html
@@ -96,6 +96,34 @@ impl Event {
     #[inline]
     pub fn is_hup(&self) -> bool {
         sys::event::is_hup(&self.inner)
+    }
+
+    /// Returns true if the event contains read HUP readiness.
+    ///
+    /// # Notes
+    ///
+    /// Method is available on all platforms, but not all platforms (can) use
+    /// this indicator.
+    ///
+    /// Because of the above be cautions when using this in cross-platform
+    /// applications, Mio makes no attempt at normalising this indicator and
+    /// only provides a convenience method to read it. We advice looking at the
+    /// documentation provided for the selectors (see below) when using this
+    /// indicator.
+    ///
+    /// The table below shows what flags are checked on what OS.
+    ///
+    /// | [OS selector] | Flag(s) checked |
+    /// |---------------|-----------------|
+    /// | [epoll]       | `EPOLLRDHUP`    |
+    /// | [kqueue]      | `EV_EOF`        |
+    ///
+    /// [OS selector]: ../struct.Poll.html#implementation-notes
+    /// [epoll]: http://man7.org/linux/man-pages/man7/epoll.7.html
+    /// [kqueue]: https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
+    #[inline]
+    pub fn is_read_hup(&self) -> bool {
+        sys::event::is_read_hup(&self.inner)
     }
 
     /// Returns true if the event contains priority readiness.
@@ -176,6 +204,7 @@ impl fmt::Debug for Event {
             .field("writable", &self.is_writable())
             .field("error", &self.is_error())
             .field("hup", &self.is_hup())
+            .field("read_hup", &self.is_read_hup())
             .field("priority", &self.is_priority())
             .field("aio", &self.is_aio())
             .field("lio", &self.is_lio())

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -44,8 +44,8 @@ impl Event {
     ///
     /// # Notes
     ///
-    /// Method is available on all platforms, but not all platforms (can) use
-    /// this indicator.
+    /// Method is available on all platforms, but not all platforms trigger the
+    /// error event.
     ///
     /// The table below shows what flags are checked on what OS.
     ///
@@ -66,8 +66,8 @@ impl Event {
     ///
     /// # Notes
     ///
-    /// Method is available on all platforms, but not all platforms (can) use
-    /// this indicator.
+    /// Method is available on all platforms, but not all platforms trigger the
+    /// HUP event.
     ///
     /// Because of the above be cautions when using this in cross-platform
     /// applications, Mio makes no attempt at normalising this indicator and
@@ -94,8 +94,8 @@ impl Event {
     ///
     /// # Notes
     ///
-    /// Method is available on all platforms, but not all platforms (can) use
-    /// this indicator.
+    /// Method is available on all platforms, but not all platforms trigger the
+    /// read HUP event.
     ///
     /// Because of the above be cautions when using this in cross-platform
     /// applications, Mio makes no attempt at normalising this indicator and
@@ -122,8 +122,8 @@ impl Event {
     ///
     /// # Notes
     ///
-    /// Method is available on all platforms, but not all platforms (can) use
-    /// this indicator.
+    /// Method is available on all platforms, but not all platforms trigger the
+    /// priority event.
     ///
     /// The table below shows what flags are checked on what OS.
     ///
@@ -144,8 +144,7 @@ impl Event {
     ///
     /// # Notes
     ///
-    /// Method is available on all platforms, but not all platforms (can) use
-    /// this indicator.
+    /// Method is available on all platforms, but not all platforms support AIO.
     ///
     /// The table below shows what flags are checked on what OS.
     ///
@@ -168,11 +167,8 @@ impl Event {
     ///
     /// # Notes
     ///
-    /// Method is available on all platforms, but not all platforms (can) use
-    /// this indicator.
-    ///
-    /// This is currently only supported on FreeBSD and checks the `EVFILT_LIO`
-    /// flag.
+    /// Method is available on all platforms, but only FreeBSD supports LIO. On
+    /// FreeBSD this method checks the `EVFILT_LIO` flag.
     #[inline]
     pub fn is_lio(&self) -> bool {
         sys::event::is_lio(&self.inner)

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -46,6 +46,17 @@ impl Event {
     ///
     /// Method is available on all platforms, but not all platforms (can) use
     /// this indicator.
+    ///
+    /// The table below shows what flags are checked on what OS.
+    ///
+    /// | [OS selector] | Flag(s) checked |
+    /// |---------------|-----------------|
+    /// | [epoll]       | `EPOLLERR`      |
+    /// | [kqueue]      | `EV_ERROR` and `EV_EOF` with `fflags` set to `0`. |
+    ///
+    /// [OS selector]: ../struct.Poll.html#implementation-notes
+    /// [epoll]: http://man7.org/linux/man-pages/man7/epoll.7.html
+    /// [kqueue]: https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
     #[inline]
     pub fn is_error(&self) -> bool {
         sys::event::is_error(&self.inner)
@@ -71,6 +82,17 @@ impl Event {
     /// Because of the above be cautions when using this in cross-platform
     /// applications, Mio makes no attempt at normalising this indicator and
     /// only provides a convenience method to read it.
+    ///
+    /// The table below shows what flags are checked on what OS.
+    ///
+    /// | [OS selector] | Flag(s) checked |
+    /// |---------------|-----------------|
+    /// | [epoll]       | `EPOLLHUP` and `EPOLLRDHUP` |
+    /// | [kqueue]      | `EV_EOF`        |
+    ///
+    /// [OS selector]: ../struct.Poll.html#implementation-notes
+    /// [epoll]: http://man7.org/linux/man-pages/man7/epoll.7.html
+    /// [kqueue]: https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
     #[inline]
     pub fn is_hup(&self) -> bool {
         sys::event::is_hup(&self.inner)
@@ -82,6 +104,17 @@ impl Event {
     ///
     /// Method is available on all platforms, but not all platforms (can) use
     /// this indicator.
+    ///
+    /// The table below shows what flags are checked on what OS.
+    ///
+    /// | [OS selector] | Flag(s) checked |
+    /// |---------------|-----------------|
+    /// | [epoll]       | `EPOLLPRI`      |
+    /// | [kqueue]      | *Not supported* |
+    ///
+    /// [OS selector]: ../struct.Poll.html#implementation-notes
+    /// [epoll]: http://man7.org/linux/man-pages/man7/epoll.7.html
+    /// [kqueue]: https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
     #[inline]
     pub fn is_priority(&self) -> bool {
         sys::event::is_priority(&self.inner)
@@ -93,6 +126,19 @@ impl Event {
     ///
     /// Method is available on all platforms, but not all platforms (can) use
     /// this indicator.
+    ///
+    /// The table below shows what flags are checked on what OS.
+    ///
+    /// | [OS selector] | Flag(s) checked |
+    /// |---------------|-----------------|
+    /// | [epoll]       | *Not supported* |
+    /// | [kqueue]<sup>1</sup> | `EVFILT_AIO` |
+    ///
+    /// 1: Only supported on DragonFly BSD, FreeBSD, iOS and macOS.
+    ///
+    /// [OS selector]: ../struct.Poll.html#implementation-notes
+    /// [epoll]: http://man7.org/linux/man-pages/man7/epoll.7.html
+    /// [kqueue]: https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
     #[inline]
     pub fn is_aio(&self) -> bool {
         sys::event::is_aio(&self.inner)
@@ -104,6 +150,9 @@ impl Event {
     ///
     /// Method is available on all platforms, but not all platforms (can) use
     /// this indicator.
+    ///
+    /// This is currently only supported on FreeBSD and checks the `EVFILT_LIO`
+    /// flag.
     #[inline]
     pub fn is_lio(&self) -> bool {
         sys::event::is_lio(&self.inner)

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -133,7 +133,10 @@ pub mod event {
 
     pub fn is_hup(event: &Event) -> bool {
         (event.events as libc::c_int & libc::EPOLLHUP) != 0
-            || (event.events as libc::c_int & libc::EPOLLRDHUP) != 0
+    }
+
+    pub fn is_read_hup(event: &Event) -> bool {
+        (event.events as libc::c_int & libc::EPOLLRDHUP) != 0
     }
 
     pub fn is_priority(event: &Event) -> bool {

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -349,7 +349,7 @@ pub mod event {
     }
 
     pub fn is_read_hup(event: &Event) -> bool {
-        (event.flags & libc::EV_EOF) != 0
+        event.filter == libc::EVFILT_READ && (event.flags & libc::EV_EOF) != 0
     }
 
     pub fn is_priority(_: &Event) -> bool {

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -343,7 +343,12 @@ pub mod event {
             (event.flags & libc::EV_EOF) != 0 && event.fflags != 0
     }
 
-    pub fn is_hup(event: &Event) -> bool {
+    pub fn is_hup(_: &Event) -> bool {
+        // Not supported.
+        false
+    }
+
+    pub fn is_read_hup(event: &Event) -> bool {
         (event.flags & libc::EV_EOF) != 0
     }
 

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -35,6 +35,11 @@ pub fn is_hup(event: &Event) -> bool {
     (event.flags & (afd::AFD_POLL_ABORT | afd::AFD_POLL_CONNECT_FAIL)) != 0
 }
 
+pub fn is_read_hup(_: &Event) -> bool {
+    // Not supported.
+    false
+}
+
 pub fn is_priority(event: &Event) -> bool {
     (event.flags & afd::AFD_POLL_RECEIVE_EXPEDITED) != 0
 }

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -27,7 +27,7 @@ use crate::{poll, sys, Registry, Token};
 /// filter, see [implementation notes of `Poll`] to see what platforms support
 /// kqueue. On Linux it uses [eventfd].
 ///
-/// [implementation notes of `Poll`]: ../index.html#implementation-notes
+/// [implementation notes of `Poll`]: struct.Poll.html#implementation-notes
 /// [eventfd]: http://man7.org/linux/man-pages/man2/eventfd.2.html
 ///
 /// # Examples

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -625,7 +625,7 @@ macro_rules! wait {
                 ))]
                 {
                     if $expect_hup {
-                        assert!(event.is_hup());
+                        assert!(event.is_read_hup());
                     }
                 }
 


### PR DESCRIPTION
This doesn't mention Windows, I think the Windows rewrite should be merged first.

Updates #941.
Closes #1040.