### PR TITLE
Drop support for LIO

### DIFF
--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -162,17 +162,6 @@ impl Event {
         sys::event::is_aio(&self.inner)
     }
 
-    /// Returns true if the event contains LIO readiness.
-    ///
-    /// # Notes
-    ///
-    /// Method is available on all platforms, but only FreeBSD supports LIO. On
-    /// FreeBSD this method checks the `EVFILT_LIO` flag.
-    #[inline]
-    pub fn is_lio(&self) -> bool {
-        sys::event::is_lio(&self.inner)
-    }
-
     /// Create a reference to an `Event` from a platform specific event.
     pub(crate) fn from_sys_event_ref(sys_event: &sys::Event) -> &Event {
         unsafe {
@@ -194,7 +183,6 @@ impl fmt::Debug for Event {
             .field("read_hup", &self.is_read_hup())
             .field("priority", &self.is_priority())
             .field("aio", &self.is_aio())
-            .field("lio", &self.is_lio())
             .finish()
     }
 }

--- a/src/interests.rs
+++ b/src/interests.rs
@@ -40,8 +40,6 @@ const WRITABLE: u8 = 0b0_010;
     allow(dead_code)
 )]
 const AIO: u8 = 0b0_100;
-#[cfg_attr(not(target_os = "freebsd"), allow(dead_code))]
-const LIO: u8 = 0b1_000;
 
 impl Interests {
     /// Returns a `Interests` set representing readable interests.
@@ -59,10 +57,6 @@ impl Interests {
     ))]
     pub const AIO: Interests = Interests(unsafe { NonZeroU8::new_unchecked(AIO) });
 
-    /// Returns a `Interests` set representing LIO completion interests.
-    #[cfg(target_os = "freebsd")]
-    pub const LIO: Interests = Interests(unsafe { NonZeroU8::new_unchecked(LIO) });
-
     /// Returns true if the value includes readable readiness.
     pub fn is_readable(self) -> bool {
         (self.0.get() & READABLE) != 0
@@ -76,11 +70,6 @@ impl Interests {
     /// Returns true if `Interests` contains AIO readiness
     pub fn is_aio(self) -> bool {
         (self.0.get() & AIO) != 0
-    }
-
-    /// Returns true if `Interests` contains LIO readiness
-    pub fn is_lio(self) -> bool {
-        (self.0.get() & LIO) != 0
     }
 }
 
@@ -129,16 +118,6 @@ impl fmt::Debug for Interests {
                     write!(fmt, " | ")?
                 }
                 write!(fmt, "AIO")?;
-                one = true
-            }
-        }
-        #[cfg(any(target_os = "freebsd"))]
-        {
-            if self.is_lio() {
-                if one {
-                    write!(fmt, " | ")?
-                }
-                write!(fmt, "LIO")?;
                 one = true
             }
         }

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -147,11 +147,6 @@ pub mod event {
         // Not supported in the kernel, only in libc.
         false
     }
-
-    pub fn is_lio(_: &Event) -> bool {
-        // Not supported.
-        false
-    }
 }
 
 #[test]

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -378,18 +378,6 @@ pub mod event {
             false
         }
     }
-
-    #[allow(unused_variables)] // `event` is only used on FreeBSD.
-    pub fn is_lio(event: &Event) -> bool {
-        #[cfg(target_os = "freebsd")]
-        {
-            event.filter == libc::EVFILT_LIO
-        }
-        #[cfg(not(target_os = "freebsd"))]
-        {
-            false
-        }
-    }
 }
 
 #[test]

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -49,11 +49,6 @@ pub fn is_aio(_: &Event) -> bool {
     false
 }
 
-pub fn is_lio(_: &Event) -> bool {
-    // Not supported.
-    false
-}
-
 pub struct Events {
     /// Raw I/O event completions are filled in here by the call to `get_many`
     /// on the completion port above. These are then processed to run callbacks

--- a/tests/interests.rs
+++ b/tests/interests.rs
@@ -7,7 +7,6 @@ fn is_tests() {
     assert!(!Interests::WRITABLE.is_readable());
     assert!(Interests::WRITABLE.is_writable());
     assert!(!Interests::WRITABLE.is_aio());
-    assert!(!Interests::WRITABLE.is_lio());
 }
 
 #[test]
@@ -33,9 +32,5 @@ fn fmt_debug() {
     ))]
     {
         assert_eq!(format!("{:?}", Interests::AIO), "AIO");
-    }
-    #[cfg(any(target_os = "freebsd"))]
-    {
-        assert_eq!(format!("{:?}", Interests::LIO), "LIO");
     }
 }


### PR DESCRIPTION
list directed I/O (LIO) was only sort of supported on FreeBSD. The
kqueue manual doesn't mention it and we didn't have tests for it making
it all round poorly supported.

For v0.7, in an effort to reduce the API, LIO is removed. It can be
added back later (with proper support and testing).

Closes #1036.