### PR TITLE
 Add Interests::and 

### DIFF
--- a/src/interests.rs
+++ b/src/interests.rs
@@ -71,11 +71,12 @@ impl Interests {
     /// ```
     /// use mio::Interests;
     ///
-    /// const INTERESTS: Interests = Interests::READABLE.and(Interests::WRITABLE);
+    /// const INTERESTS: Interests = Interests::READABLE.add(Interests::WRITABLE);
     /// # fn silent_dead_code_warning(_: Interests) { }
     /// # silent_dead_code_warning(INTERESTS)
     /// ```
-    pub const fn and(self, other: Interests) -> Interests {
+    #[allow(clippy::should_implement_trait)]
+    pub const fn add(self, other: Interests) -> Interests {
         Interests(unsafe { NonZeroU8::new_unchecked(self.0.get() | other.0.get()) })
     }
 

--- a/src/interests.rs
+++ b/src/interests.rs
@@ -63,6 +63,22 @@ impl Interests {
     #[cfg(target_os = "freebsd")]
     pub const LIO: Interests = Interests(unsafe { NonZeroU8::new_unchecked(LIO) });
 
+    /// Add together two `Interests`.
+    ///
+    /// This does the same thing as the `BitOr` implementation, but is a
+    /// constant function.
+    ///
+    /// ```
+    /// use mio::Interests;
+    ///
+    /// const INTERESTS: Interests = Interests::READABLE.and(Interests::WRITABLE);
+    /// # fn silent_dead_code_warning(_: Interests) { }
+    /// # silent_dead_code_warning(INTERESTS)
+    /// ```
+    pub const fn and(self, other: Interests) -> Interests {
+        Interests(unsafe { NonZeroU8::new_unchecked(self.0.get() | other.0.get()) })
+    }
+
     /// Returns true if the value includes readable readiness.
     pub fn is_readable(self) -> bool {
         (self.0.get() & READABLE) != 0

--- a/src/interests.rs
+++ b/src/interests.rs
@@ -80,22 +80,22 @@ impl Interests {
     }
 
     /// Returns true if the value includes readable readiness.
-    pub fn is_readable(self) -> bool {
+    pub const fn is_readable(self) -> bool {
         (self.0.get() & READABLE) != 0
     }
 
     /// Returns true if the value includes writable readiness.
-    pub fn is_writable(self) -> bool {
+    pub const fn is_writable(self) -> bool {
         (self.0.get() & WRITABLE) != 0
     }
 
     /// Returns true if `Interests` contains AIO readiness
-    pub fn is_aio(self) -> bool {
+    pub const fn is_aio(self) -> bool {
         (self.0.get() & AIO) != 0
     }
 
     /// Returns true if `Interests` contains LIO readiness
-    pub fn is_lio(self) -> bool {
+    pub const fn is_lio(self) -> bool {
         (self.0.get() & LIO) != 0
     }
 }


### PR DESCRIPTION
This allows adding two interests together, much like the BitOr
implementation, but is a constant function.

I'm not 100% sure on the name, as people might conflict it with `BitAnd`, however `or` didn't make sense either.