### PR TITLE
Remove poll interruptible

### DIFF
--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -81,10 +81,6 @@ impl Events {
         self.events.is_empty()
     }
 
-    pub fn len(&self) -> usize {
-        self.events.len()
-    }
-
     pub fn capacity(&self) -> usize {
         self.events.capacity()
     }


### PR DESCRIPTION
And return errors directly in `Poll::poll`.