### PR TITLE
Update Bytes to v0.5 (unreleased)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,9 @@ ntapi  = "0.3"
 lazy_static = "1.3.0"
 
 [dev-dependencies]
-bytes      = "0.4.12"
+# Bytes v0.4 still depends on winapi v0.2, but Bytes v0.5 is released yet. So
+# for testing we'll use the git version.
+bytes      = { version = "0.5.0", git = "https://github.com/tokio-rs/bytes", rev = "79e4b2847f27137faaf149d116a352cbeae47fd1" }
 env_logger = { version = "0.6.1", default-features = false }
 slab       = "0.4.2"
 tempdir    = "0.3.7"

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -3,7 +3,7 @@ use std::net::IpAddr;
 use std::str;
 use std::time;
 
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use log::{debug, info};
 
 use mio::net::UdpSocket;


### PR DESCRIPTION
As bytes v0.5 is not yet released we'll use the git version (using a fixed commit to reduce breakage).