### PR TITLE
Add a test for polling with zero duration

### DIFF
--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -1,7 +1,8 @@
 use mio::net::{TcpListener, TcpStream};
 use mio::*;
+use std::net;
 use std::sync::{Arc, Barrier};
-use std::thread;
+use std::thread::{self, sleep};
 use std::time::Duration;
 
 mod util;
@@ -40,6 +41,41 @@ fn add_then_drop() {
     drop(l);
     poll.poll(&mut events, Some(Duration::from_millis(100)))
         .unwrap();
+}
+
+#[test]
+fn zero_duration_polls_events() {
+    init();
+
+    let mut poll = Poll::new().unwrap();
+    let mut events = Events::with_capacity(16);
+
+    let listener = net::TcpListener::bind(any_local_address()).unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let streams: Vec<TcpStream> = (0..3)
+        .map(|n| {
+            let stream = TcpStream::connect(addr).unwrap();
+            poll.registry()
+                .register(&stream, Token(n), Interests::WRITABLE)
+                .unwrap();
+            stream
+        })
+        .collect();
+
+    // Ensure the TcpStreams have some time to connection and for the events to
+    // show up.
+    sleep(Duration::from_millis(10));
+
+    // Even when passing a zero duration timeout we still want do the system
+    // call.
+    poll.poll(&mut events, Some(Duration::from_nanos(0)))
+        .unwrap();
+    assert!(!events.is_empty());
+
+    // Both need to live until here.
+    drop(streams);
+    drop(listener);
 }
 
 #[test]


### PR DESCRIPTION
This ensures that the relevant system call is made even if the passed
duration is zero.

Also see https://github.com/tokio-rs/mio/pull/1055#discussion_r315237581

/cc @PerfectLaugh 