### PR TITLE
Check EV_EOF in Event::is_hup on kqueue platforms

### DIFF
--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -79,7 +79,7 @@ impl Event {
     /// | [OS selector] | Flag(s) checked |
     /// |---------------|-----------------|
     /// | [epoll]       | `EPOLLHUP`      |
-    /// | [kqueue]      | Not supported   |
+    /// | [kqueue]      | `EV_EOF`        |
     ///
     /// [OS selector]: ../struct.Poll.html#implementation-notes
     /// [epoll]: http://man7.org/linux/man-pages/man7/epoll.7.html

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -341,9 +341,8 @@ pub mod event {
             (event.flags & libc::EV_EOF) != 0 && event.fflags != 0
     }
 
-    pub fn is_hup(_: &Event) -> bool {
-        // Not supported.
-        false
+    pub fn is_hup(event: &Event) -> bool {
+        event.filter == libc::EVFILT_WRITE && (event.flags & libc::EV_EOF) != 0
     }
 
     pub fn is_read_hup(event: &Event) -> bool {


### PR DESCRIPTION
This matches checking for `EPOLLHUP` done on `epoll(2)` platforms for Unix pipes. I don't know if this needs a tests, but I got one in another crate.