### PR TITLE
Use FD_CLOEXEC in call to fcntl over

### DIFF
--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -55,19 +55,21 @@ pub fn pipe() -> ::io::Result<(Io, Io)> {
             Some(pipe2_fn) => {
                 let flags = libc::O_NONBLOCK | libc::O_CLOEXEC;
                 cvt(pipe2_fn(pipes.as_mut_ptr(), flags))?;
+                Ok((Io::from_raw_fd(pipes[0]), Io::from_raw_fd(pipes[1])))
             }
             None => {
                 cvt(libc::pipe(pipes.as_mut_ptr()))?;
+                // Ensure the pipe are closed if any of the system calls below
+                // fail.
+                let r = Io::from_raw_fd(pipes[0]);
+                let w = Io::from_raw_fd(pipes[1]);
                 cvt(libc::fcntl(pipes[0], libc::F_SETFD, libc::FD_CLOEXEC))?;
                 cvt(libc::fcntl(pipes[1], libc::F_SETFD, libc::FD_CLOEXEC))?;
                 cvt(libc::fcntl(pipes[0], libc::F_SETFL, libc::O_NONBLOCK))?;
                 cvt(libc::fcntl(pipes[1], libc::F_SETFL, libc::O_NONBLOCK))?;
+                Ok((r, w))
             }
         }
-    }
-
-    unsafe {
-        Ok((Io::from_raw_fd(pipes[0]), Io::from_raw_fd(pipes[1])))
     }
 }
 


### PR DESCRIPTION
O_CLOEXEC is not accepted in fnctl, but no OS complains about it.

Closes #1092 

/cc @reiver-dev