### PR TITLE
Silence warnings on newer Rustc versions

### DIFF
--- a/benches/bench_poll.rs
+++ b/benches/bench_poll.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(deprecated)]
 
 extern crate mio;
 extern crate test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc(html_root_url = "https://docs.rs/mio/0.6.19")]
 // Mio targets old versions of the Rust compiler. In order to do this, uses
 // deprecated APIs.
-#![allow(deprecated)]
+#![allow(deprecated, bare_trait_objects)]
 #![deny(missing_docs, missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -181,7 +181,6 @@ mod ports {
 
 pub fn sleep_ms(ms: u64) {
     use std::thread;
-    use std::time::Duration;
     thread::sleep(Duration::from_millis(ms));
 }
 

--- a/test/test_tcp_shutdown.rs
+++ b/test/test_tcp_shutdown.rs
@@ -210,7 +210,7 @@ fn test_graceful_shutdown() {
 #[test]
 fn test_abrupt_shutdown() {
     use net2::TcpStreamExt;
-    use std::io::{self, Read, Write};
+    use std::io::Read;
 
     let mut poll = TestPoll::new();
     let mut buf = [0; 1024];
@@ -224,7 +224,7 @@ fn test_abrupt_shutdown() {
                   Ready::readable() | Ready::writable(),
                   PollOpt::edge());
 
-    let (mut socket, _) = assert_ok!(listener.accept());
+    let (socket, _) = assert_ok!(listener.accept());
     assert_ok!(socket.set_linger(Some(Duration::from_millis(0))));
     // assert_ok!(socket.set_linger(None));
 


### PR DESCRIPTION
This is a minimal commit to silence warnings on newer compiler versions,
while we're still supporting old compilers in v0.6. This does not
include any function changes.

For #1095.