### PR TITLE
Fix socket_addr() to not drop chars in path

### DIFF
--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -242,7 +242,7 @@ impl SocketAddr {
     // describes the size of the address structure.
     fn path_offset(&self) -> usize {
         let base = &self.sockaddr as *const _ as usize;
-        let path = &self.sockaddr as *const _ as usize;
+        let path = &self.sockaddr.sun_path as *const _ as usize;
         path - base
     }
 }

--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -53,7 +53,7 @@ pub fn socket_addr(path: &Path) -> io::Result<(libc::sockaddr_un, libc::socklen_
     // View `SocketAddr::path_offset` documentation for why this is necessary.
     let offset = {
         let base = &sockaddr as *const _ as usize;
-        let path = &sockaddr as *const _ as usize;
+        let path = &sockaddr.sun_path as *const _ as usize;
         path - base
     };
     let mut socklen = offset + bytes.len();


### PR DESCRIPTION
Fixes #1101 