### PR TITLE
Add unit tests for sock_addr and path_offset functions

### DIFF
--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -1,4 +1,4 @@
-use super::socket_addr;
+use super::{path_offset, socket_addr};
 use crate::event::Source;
 use crate::sys::unix::net::new_socket;
 use crate::sys::unix::UnixStream;
@@ -220,7 +220,8 @@ impl SocketAddr {
     }
 
     fn address(&self) -> AddressKind<'_> {
-        let len = self.socklen as usize - self.path_offset();
+        let offset = path_offset(&self.sockaddr);
+        let len = self.socklen as usize - offset;
         let path = unsafe { &*(&self.sockaddr.sun_path as *const [libc::c_char] as *const [u8]) };
 
         // macOS seems to return a len of 16 and a zeroed sun_path for unnamed addresses
@@ -234,16 +235,6 @@ impl SocketAddr {
         } else {
             AddressKind::Pathname(OsStr::from_bytes(&path[..len - 1]).as_ref())
         }
-    }
-
-    // On Linux, this funtion equates to the same value as
-    // `size_of::<sa_family_t>()`, but some other implementations include
-    // other fields before `sun_path`, so the expression more portably
-    // describes the size of the address structure.
-    fn path_offset(&self) -> usize {
-        let base = &self.sockaddr as *const _ as usize;
-        let path = &self.sockaddr.sun_path as *const _ as usize;
-        path - base
     }
 }
 

--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -50,12 +50,7 @@ pub fn socket_addr(path: &Path) -> io::Result<(libc::sockaddr_un, libc::socklen_
         *dst = *src as libc::c_char;
     }
 
-    // View `SocketAddr::path_offset` documentation for why this is necessary.
-    let offset = {
-        let base = &sockaddr as *const _ as usize;
-        let path = &sockaddr.sun_path as *const _ as usize;
-        path - base
-    };
+    let offset = path_offset(&sockaddr);
     let mut socklen = offset + bytes.len();
 
     match bytes.get(0) {
@@ -66,6 +61,18 @@ pub fn socket_addr(path: &Path) -> io::Result<(libc::sockaddr_un, libc::socklen_
     }
 
     Ok((sockaddr, socklen as libc::socklen_t))
+}
+
+/// Get the `sun_path` field offset of `sockaddr_un` for the target OS.
+///
+/// On Linux, this funtion equates to the same value as
+/// `size_of::<sa_family_t>()`, but some other implementations include
+/// other fields before `sun_path`, so the expression more portably
+/// describes the size of the address structure.
+pub fn path_offset(sockaddr: &libc::sockaddr_un) -> usize {
+    let base = sockaddr as *const _ as usize;
+    let path = &sockaddr.sun_path as *const _ as usize;
+    path - base
 }
 
 fn pair_descriptors(mut fds: [RawFd; 2], flags: i32) -> io::Result<()> {
@@ -87,4 +94,44 @@ fn pair_descriptors(mut fds: [RawFd; 2], flags: i32) -> io::Result<()> {
         syscall!(fcntl(fds[1], libc::F_SETFD, libc::FD_CLOEXEC))?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{path_offset, socket_addr};
+    use std::path::Path;
+    use std::str;
+
+    // Assert `socklen` equals 16 (on Linux):
+    //   - 13 bytes for path length
+    //   - `path_offset` bytes for the `sun_path` offset (2 on Linux)
+    //   - 1 for the null terminator
+    #[test]
+    fn pathname_address() {
+        const PATH: &str = "./foo/bar.txt";
+        const PATH_LEN: usize = 13;
+
+        // Pathname addresses do have a null terminator, so `socklen` is
+        // expected to be `PATH_LEN` + `offset` + 1.
+        let path = Path::new(PATH);
+        let (sockaddr, actual) = socket_addr(path).unwrap();
+        let offset = path_offset(&sockaddr);
+        let expected = PATH_LEN + offset + 1;
+        assert_eq!(expected as libc::socklen_t, actual)
+    }
+
+    #[test]
+    fn abstract_address() {
+        const PATH: &[u8] = &[0, 116, 111, 107, 105, 111];
+        const PATH_LEN: usize = 6;
+
+        // Abstract addresses do not have a null terminator, so `socklen` is
+        // expected to be `PATH_LEN` + `offset`.
+        let abstract_path = str::from_utf8(PATH).unwrap();
+        let path = Path::new(abstract_path);
+        let (sockaddr, actual) = socket_addr(path).unwrap();
+        let offset = path_offset(&sockaddr);
+        let expected = PATH_LEN + offset;
+        assert_eq!(expected as libc::socklen_t, actual)
+    }
 }

--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -102,10 +102,6 @@ mod tests {
     use std::path::Path;
     use std::str;
 
-    // Assert `socklen` equals 16 (on Linux):
-    //   - 13 bytes for path length
-    //   - `path_offset` bytes for the `sun_path` offset (2 on Linux)
-    //   - 1 for the null terminator
     #[test]
     fn pathname_address() {
         const PATH: &str = "./foo/bar.txt";


### PR DESCRIPTION
## Motivation

The `sock_addr` function dispatches to a fair amount of `libc` calls and has
some additional complexity that is really only explained by man pages. It does
not have any unit tests and was incorrectly calculating `addrlen`.

## Solution

A new `path_offset` function has been separated out from `sock_addr` that
returns values dependent on the platform. It is a single function that can be
unit tested and now also used within the `sys::unix::uds` module.

Basic unit tests have also been added that check correct values for pathname
socket addresses and abstract socket addresses.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
