### PR TITLE
Fix fcntl calls and ensure fds are closed on error

### DIFF
--- a/src/sys/unix/net.rs
+++ b/src/sys/unix/net.rs
@@ -13,26 +13,38 @@ pub fn new_ip_socket(addr: SocketAddr, socket_type: libc::c_int) -> io::Result<l
 
 /// Create a new non-blocking socket.
 pub fn new_socket(domain: libc::c_int, socket_type: libc::c_int) -> io::Result<libc::c_int> {
-    #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "solaris")))]
-    {
-        let socket_type = socket_type | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
-        syscall!(socket(domain, socket_type, 0))
-    }
+    #[cfg(any(
+        target_os = "android",
+        target_os = "bitrig",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    let socket_type = socket_type | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
 
+    // Gives a warning for platforms without SOCK_NONBLOCK.
+    #[allow(clippy::let_and_return)]
+    let socket = syscall!(socket(domain, socket_type, 0));
+
+    // Darwin doesn't have SOCK_NONBLOCK or SOCK_CLOEXEC. Not sure about
+    // Solaris, couldn't find anything online.
     #[cfg(any(target_os = "ios", target_os = "macos", target_os = "solaris"))]
-    {
-        let socket = syscall!(socket(domain, socket_type, 0))?;
-        if let Err(e) = (|| {
-            syscall!(fcntl(socket, libc::F_SETFL, libc::O_NONBLOCK))?;
-            syscall!(fcntl(socket, libc::F_SETFD, libc::FD_CLOEXEC))
-        })() {
-            // If either of the `fcntl` calls failed, ensure the socket is
-            // closed and return the error.
-            syscall!(close(socket))?;
-            return Err(e);
-        }
-        Ok(socket)
-    }
+    let socket = socket.and_then(|socket| {
+        // For platforms that don't support flags in socket, we need to
+        // set the flags ourselves.
+        syscall!(fcntl(socket, libc::F_SETFL, libc::O_NONBLOCK,))
+            .and_then(|_| syscall!(fcntl(socket, libc::F_SETFD, libc::FD_CLOEXEC,)).map(|_| socket))
+            .map_err(|e| {
+                // If either of the `fcntl` calls failed, ensure the socket is
+                // closed and return the error.
+                let _ = syscall!(close(socket));
+                e
+            })
+    });
+
+    socket
 }
 
 pub fn socket_addr(addr: &SocketAddr) -> (*const libc::sockaddr, libc::socklen_t) {

--- a/src/sys/unix/uds/datagram.rs
+++ b/src/sys/unix/uds/datagram.rs
@@ -37,14 +37,31 @@ impl UnixDatagram {
         let fds = [-1; 2];
         let flags = libc::SOCK_DGRAM;
 
-        pair_descriptors(fds, flags)?;
+        #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "solaris")))]
+        {
+            pair_descriptors(fds, flags)?;
+            Ok(unsafe {
+                (
+                    UnixDatagram::from_raw_fd(fds[0]),
+                    UnixDatagram::from_raw_fd(fds[1]),
+                )
+            })
+        }
 
-        Ok(unsafe {
-            (
-                UnixDatagram::from_raw_fd(fds[0]),
-                UnixDatagram::from_raw_fd(fds[1]),
-            )
-        })
+        // Darwin and Solaris do not have SOCK_NONBLOCK or SOCK_CLOEXEC.
+        //
+        // In order to set those flags, additional `fcntl` sys calls must be
+        // made in `pair_descriptors` that are fallible. If a `fnctl` fails
+        // after the sockets have been created, the file descriptors will
+        // leak. Creating `s1` and `s2` below ensure that if there is an
+        // error, the file descriptors are closed.
+        #[cfg(any(target_os = "ios", target_os = "macos", target_os = "solaris"))]
+        {
+            let s1 = unsafe { UnixDatagram::from_raw_fd(fds[0]) };
+            let s2 = unsafe { UnixDatagram::from_raw_fd(fds[1]) };
+            pair_descriptors(fds, flags)?;
+            Ok((s1, s2))
+        }
     }
 
     pub(crate) fn unbound() -> io::Result<UnixDatagram> {

--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -70,21 +70,22 @@ pub fn socket_addr(path: &Path) -> io::Result<(libc::sockaddr_un, libc::socklen_
 
 fn pair_descriptors(mut fds: [RawFd; 2], flags: i32) -> io::Result<()> {
     #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "solaris")))]
-    let flags = flags | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
+    {
+        let flags = flags | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
+        syscall!(socketpair(libc::AF_UNIX, flags, 0, fds.as_mut_ptr()))?;
+        Ok(())
+    }
 
-    syscall!(socketpair(libc::AF_UNIX, flags, 0, fds.as_mut_ptr()))?;
-
-    // Darwin and Solaris don't have SOCK_NONBLOCK or SOCK_CLOEXEC.
-    //
     // For platforms that don't support flags in `socket`, the flags must be
     // set through `fcntl`. The `F_SETFL` command sets the `O_NONBLOCK` bit.
     // The `F_SETFD` command sets the `FD_CLOEXEC` bit.
     #[cfg(any(target_os = "ios", target_os = "macos", target_os = "solaris"))]
     {
+        syscall!(socketpair(libc::AF_UNIX, flags, 0, fds.as_mut_ptr()))?;
         syscall!(fcntl(fds[0], libc::F_SETFL, libc::O_NONBLOCK))?;
         syscall!(fcntl(fds[0], libc::F_SETFD, libc::FD_CLOEXEC))?;
         syscall!(fcntl(fds[1], libc::F_SETFL, libc::O_NONBLOCK))?;
         syscall!(fcntl(fds[1], libc::F_SETFD, libc::FD_CLOEXEC))?;
+        Ok(())
     }
-    Ok(())
 }

--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -81,6 +81,8 @@ fn pair_descriptors(mut fds: [RawFd; 2], flags: i32) -> io::Result<()> {
 
     syscall!(socketpair(libc::AF_UNIX, flags, 0, fds.as_mut_ptr()))?;
 
+    // Darwin and Solaris don't have SOCK_NONBLOCK or SOCK_CLOEXEC.
+    //
     // For platforms that don't support flags in `socket`, the flags must be
     // set through `fcntl`. The `F_SETFL` command sets the `O_NONBLOCK` bit.
     // The `F_SETFD` command sets the `FD_CLOEXEC` bit.
@@ -91,7 +93,6 @@ fn pair_descriptors(mut fds: [RawFd; 2], flags: i32) -> io::Result<()> {
         syscall!(fcntl(fds[1], libc::F_SETFL, libc::O_NONBLOCK))?;
         syscall!(fcntl(fds[1], libc::F_SETFD, libc::FD_CLOEXEC))?;
     }
-
     Ok(())
 }
 

--- a/src/sys/unix/uds/stream.rs
+++ b/src/sys/unix/uds/stream.rs
@@ -44,14 +44,31 @@ impl UnixStream {
         let fds = [-1; 2];
         let flags = libc::SOCK_STREAM;
 
-        pair_descriptors(fds, flags)?;
+        #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "solaris")))]
+        {
+            pair_descriptors(fds, flags)?;
+            Ok(unsafe {
+                (
+                    UnixStream::from_raw_fd(fds[0]),
+                    UnixStream::from_raw_fd(fds[1]),
+                )
+            })
+        }
 
-        Ok(unsafe {
-            (
-                UnixStream::from_raw_fd(fds[0]),
-                UnixStream::from_raw_fd(fds[1]),
-            )
-        })
+        // Darwin and Solaris do not have SOCK_NONBLOCK or SOCK_CLOEXEC.
+        //
+        // In order to set those flags, additional `fcntl` sys calls must be
+        // made in `pair_descriptors` that are fallible. If a `fnctl` fails
+        // after the sockets have been created, the file descriptors will
+        // leak. Creating `s1` and `s2` below ensure that if there is an
+        // error, the file descriptors are closed.
+        #[cfg(any(target_os = "ios", target_os = "macos", target_os = "solaris"))]
+        {
+            let s1 = unsafe { UnixStream::from_raw_fd(fds[0]) };
+            let s2 = unsafe { UnixStream::from_raw_fd(fds[1]) };
+            pair_descriptors(fds, flags)?;
+            Ok((s1, s2))
+        }
     }
 
     pub(crate) fn try_clone(&self) -> io::Result<UnixStream> {


### PR DESCRIPTION
## Motivation

The primary focus of this PR was to fix the `FD_CLOEXEC` flag not being set on
sockets. On platforms where the flag cannot be set on the `socket` sys call, it
is attempted to be set via the `F_SETFL` command in the `fcntl` sys call.

`FD_CLOEXEC` can only be set with the `F_SETFD` command in a separate `fcntl`
sys call.

This was recently fixed on `v0.6.x` via #1095.

In addition to the primary motivation, if `fcntl` sys calls fail they leave the
newly created sockets open which leads to file descriptor leaks.

## Solution

The `new_socket` function now has two separate `fctnl` sys calls to set the
`O_NONBLOCK` and `FD_CLOEXEC` flags.

The blocks of platform specific code where `fcntl` sys calls are required now
properly cleanup newly created sockets when there are errors.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
