### PR TITLE
Unlink bound path on uds drop

### DIFF
--- a/src/net/uds/datagram.rs
+++ b/src/net/uds/datagram.rs
@@ -26,6 +26,11 @@ impl UnixDatagram {
     }
 
     /// Creates a Unix datagram socket bound to the given path.
+    ///
+    /// On success, this creates a socket file at the bound path as a side effect.
+    /// The [`unlink`] method can be used to prevent leaking this file.
+    ///
+    /// [`unlink`]: #method.unlink
     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixDatagram> {
         let sys = sys::UnixDatagram::bind(path.as_ref())?;
         Ok(UnixDatagram::new(sys))
@@ -116,6 +121,14 @@ impl UnixDatagram {
     /// (see the documentation of `Shutdown`).
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
         self.sys.shutdown(how)
+    }
+
+    /// Consumes the socket, unlinking the bound socket file, if there is one.
+    ///
+    /// Note that a socket file is only removed once all references to it are
+    /// closed.
+    pub fn unlink(self) {
+        self.sys.unlink()
     }
 }
 

--- a/src/net/uds/listener.rs
+++ b/src/net/uds/listener.rs
@@ -27,6 +27,11 @@ impl UnixListener {
     }
 
     /// Creates a new `UnixListener` bound to the specified socket.
+    ///
+    /// On success, this creates a socket file at the bound path as a side effect.
+    /// The [`unlink`] method can be used to prevent leaking this file.
+    ///
+    /// [`unlink`]: #method.unlink
     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
         let sys = sys::UnixListener::bind(path.as_ref())?;
         Ok(UnixListener::new(sys))
@@ -59,6 +64,14 @@ impl UnixListener {
     /// Returns the value of the `SO_ERROR` option.
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         self.sys.take_error()
+    }
+
+    /// Consumes the socket, unlinking the bound socket file, if there is one.
+    ///
+    /// Note that a socket file is only removed once all references to it are
+    /// closed.
+    pub fn unlink(self) {
+        self.sys.unlink()
     }
 }
 

--- a/tests/uds.rs
+++ b/tests/uds.rs
@@ -107,6 +107,30 @@ fn is_send_and_sync() {
 }
 
 #[test]
+fn datagram_unlink() {
+    let path = "bar";
+
+    let datagram = assert_ok!(UnixDatagram::bind(path));
+    assert_err!(UnixDatagram::bind(path));
+    datagram.unlink();
+
+    let datagram = assert_ok!(UnixDatagram::bind(path));
+    datagram.unlink();
+}
+
+#[test]
+fn listener_unlink() {
+    let path = "baz";
+
+    let listener = assert_ok!(UnixListener::bind(path));
+    assert_err!(UnixListener::bind(path));
+    listener.unlink();
+
+    let listener = assert_ok!(UnixListener::bind(path));
+    listener.unlink();
+}
+
+#[test]
 fn register() {
     let (mut poll, mut events) = init_with_poll();
 


### PR DESCRIPTION
This allows a user to reuse a bound path after the uds was dropped
without having to do any cleanup.