### PR TITLE
Fix issues pointed out by Clippy

### DIFF
--- a/src/sys/unix/uds/datagram.rs
+++ b/src/sys/unix/uds/datagram.rs
@@ -4,6 +4,7 @@ use crate::sys::unix::net::new_socket;
 use crate::unix::SourceFd;
 use crate::{Interests, Registry, Token};
 
+use std::cmp::Ordering;
 use std::io;
 use std::net::Shutdown;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -99,12 +100,10 @@ impl UnixDatagram {
                 sockaddr,
                 socklen,
             );
-            if count > 0 {
-                Ok(1)
-            } else if count == 0 {
-                Ok(0)
-            } else {
-                Err(io::Error::last_os_error())
+            match count.cmp(&0) {
+                Ordering::Greater => Ok(1),
+                Ordering::Equal => Ok(0),
+                Ordering::Less => Err(io::Error::last_os_error()),
             }
         })?;
         Ok((count as usize, socketaddr))

--- a/tests/uds.rs
+++ b/tests/uds.rs
@@ -438,7 +438,7 @@ fn echo_remote(
     let handle = thread::spawn(move || {
         let dir = assert_ok!(TempDir::new("uds"));
         let path = dir.path().join("foo");
-        let remote = assert_ok!(UnixListener::bind(path.clone()));
+        let remote = assert_ok!(UnixListener::bind(path));
         let local_address = assert_ok!(remote.local_addr());
         assert_ok!(addr_sender.send(local_address));
 


### PR DESCRIPTION
This makes clippy happy again. Unneeded clone and an exhaustive match of
a return value.