### PR TITLE
Add no_inline doc attribute to Events

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ mod waker;
 pub mod event;
 pub mod net;
 
+#[doc(no_inline)]
 pub use event::Events;
 pub use interests::Interests;
 pub use poll::{Poll, Registry};

--- a/tests/uds.rs
+++ b/tests/uds.rs
@@ -531,7 +531,7 @@ fn noop_listener(
     let handle = thread::spawn(move || {
         let dir = assert_ok!(TempDir::new("uds"));
         let path = dir.path().join("foo");
-        let listener = assert_ok!(net::UnixListener::bind(path.clone()));
+        let listener = assert_ok!(net::UnixListener::bind(path));
         let local_address = assert_ok!(listener.local_addr());
         assert_ok!(sender.send(local_address));
 


### PR DESCRIPTION
 This makes it clear that its a re-export from the event module.