### PR TITLE
Add from_std methods to TCP/Unix Stream/Listener

### DIFF
--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -5,6 +5,7 @@ use crate::{event, sys, Interests, Registry, Token};
 
 use std::fmt;
 use std::io;
+use std::net;
 use std::net::SocketAddr;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -41,6 +42,20 @@ pub struct TcpListener {
 }
 
 impl TcpListener {
+    /// Creates a new `TcpListener` from a standard `net::TcpListener`.
+    ///
+    /// This function is intended to be used to wrap a TCP listener from the
+    /// standard library in the Mio equivalent. The conversion assumes nothing
+    /// about the underlying listener.
+    pub fn from_std(listener: net::TcpListener) -> Self {
+        let sys = sys::TcpListener::from_std(listener);
+        Self {
+            sys,
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
+    }
+
     /// Convenience method to bind a new TCP listener to the specified address
     /// to receive new connections.
     ///

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -44,20 +44,6 @@ pub struct TcpListener {
 }
 
 impl TcpListener {
-    /// Creates a new `TcpListener` from a standard `net::TcpListener`.
-    ///
-    /// This function is intended to be used to wrap a TCP listener from the
-    /// standard library in the Mio equivalent. The conversion assumes nothing
-    /// about the underlying listener.
-    pub fn from_std(listener: net::TcpListener) -> Self {
-        let sys = sys::TcpListener::from_std(listener);
-        Self {
-            sys,
-            #[cfg(debug_assertions)]
-            selector_id: SelectorId::new(),
-        }
-    }
-
     /// Convenience method to bind a new TCP listener to the specified address
     /// to receive new connections.
     ///
@@ -73,6 +59,21 @@ impl TcpListener {
             #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         })
+    }
+
+    /// Creates a new `TcpListener` from a standard `net::TcpListener`.
+    ///
+    /// This function is intended to be used to wrap a TCP listener from the
+    /// standard library in the Mio equivalent. The conversion assumes nothing
+    /// about the underlying listener; ; it is left up to the user to set it
+    /// in non-blocking mode.
+    pub fn from_std(listener: net::TcpListener) -> TcpListener {
+        let sys = sys::TcpListener::from_std(listener);
+        TcpListener {
+            sys,
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
     }
 
     /// Accepts a new `TcpStream`.

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -9,6 +9,8 @@ use std::net;
 use std::net::SocketAddr;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+#[cfg(windows)]
+use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
 
 /// A structure representing a socket server
 ///
@@ -181,5 +183,30 @@ impl FromRawFd for TcpListener {
             #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         }
+    }
+}
+
+#[cfg(windows)]
+impl AsRawSocket for TcpListener {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.sys.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl FromRawSocket for TcpListener {
+    unsafe fn from_raw_socket(socket: RawSocket) -> TcpListener {
+        TcpListener {
+            sys: FromRawSocket::from_raw_socket(socket),
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
+    }
+}
+
+#[cfg(windows)]
+impl IntoRawSocket for TcpListener {
+    fn into_raw_socket(self) -> RawSocket {
+        self.sys.into_raw_socket()
     }
 }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -4,6 +4,8 @@ use std::net;
 use std::net::SocketAddr;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+#[cfg(windows)]
+use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
 
 #[cfg(debug_assertions)]
 use crate::poll::SelectorId;
@@ -295,5 +297,30 @@ impl FromRawFd for TcpStream {
             #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         }
+    }
+}
+
+#[cfg(windows)]
+impl AsRawSocket for TcpStream {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.sys.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl FromRawSocket for TcpStream {
+    unsafe fn from_raw_socket(socket: RawSocket) -> TcpStream {
+        TcpStream {
+            sys: FromRawSocket::from_raw_socket(socket),
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
+    }
+}
+
+#[cfg(windows)]
+impl IntoRawSocket for TcpStream {
+    fn into_raw_socket(self) -> RawSocket {
+        self.sys.into_raw_socket()
     }
 }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -58,24 +58,6 @@ impl TcpStream {
         }
     }
 
-    /// Creates a new `TcpStream` from a standard `net::TcpStream`.
-    ///
-    /// This function is intended to be used to wrap a TCP stream from the
-    /// standard library in the Mio equivalent. The conversion assumes nothing
-    /// about the underlying stream.
-    ///
-    /// Note: The TCP stream here will not have `connect` called on it, so it
-    /// should already be connected via some other means (be it manually, or
-    /// the standard library).
-    pub fn from_std(stream: net::TcpStream) -> Self {
-        let sys = sys::TcpStream::from_std(stream);
-        Self {
-            sys,
-            #[cfg(debug_assertions)]
-            selector_id: SelectorId::new(),
-        }
-    }
-
     /// Create a new TCP stream and issue a non-blocking connect to the
     /// specified address.
     pub fn connect(addr: SocketAddr) -> io::Result<TcpStream> {
@@ -84,6 +66,27 @@ impl TcpStream {
             #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         })
+    }
+
+    /// Creates a new `TcpStream` from a standard `net::TcpStream`.
+    ///
+    /// This function is intended to be used to wrap a TCP stream from the
+    /// standard library in the Mio equivalent. The conversion assumes nothing
+    /// about the underlying stream; it is left up to the user to set it in
+    /// non-blocking mode.
+    ///
+    /// # Note
+    ///
+    /// The TCP stream here will not have `connect` called on it, so it
+    /// should already be connected via some other means (be it manually, or
+    /// the standard library).
+    pub fn from_std(stream: net::TcpStream) -> TcpStream {
+        let sys = sys::TcpStream::from_std(stream);
+        TcpStream {
+            sys,
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
     }
 
     /// Returns the socket address of the remote peer of this TCP connection.

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
+use std::net;
 use std::net::SocketAddr;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -49,6 +50,24 @@ use std::net::Shutdown;
 impl TcpStream {
     pub(crate) fn new(sys: sys::TcpStream) -> TcpStream {
         TcpStream {
+            sys,
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
+    }
+
+    /// Creates a new `TcpStream` from a standard `net::TcpStream`.
+    ///
+    /// This function is intended to be used to wrap a TCP stream from the
+    /// standard library in the Mio equivalent. The conversion assumes nothing
+    /// about the underlying stream.
+    ///
+    /// Note: The TCP stream here will not have `connect` called on it, so it
+    /// should already be connected via some other means (be it manually, or
+    /// the standard library).
+    pub fn from_std(stream: net::TcpStream) -> Self {
+        let sys = sys::TcpStream::from_std(stream);
+        Self {
             sys,
             #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -17,6 +17,8 @@ use std::net;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+#[cfg(windows)]
+use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
 
 /// A User Datagram Protocol socket.
 ///
@@ -569,5 +571,30 @@ impl FromRawFd for UdpSocket {
             #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         }
+    }
+}
+
+#[cfg(windows)]
+impl AsRawSocket for UdpSocket {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.sys.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl FromRawSocket for UdpSocket {
+    unsafe fn from_raw_socket(socket: RawSocket) -> UdpSocket {
+        UdpSocket {
+            sys: FromRawSocket::from_raw_socket(socket),
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
+    }
+}
+
+#[cfg(windows)]
+impl IntoRawSocket for UdpSocket {
+    fn into_raw_socket(self) -> RawSocket {
+        self.sys.into_raw_socket()
     }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -95,20 +95,6 @@ pub struct UdpSocket {
 }
 
 impl UdpSocket {
-    /// Creates a new `UdpSocket` from a standard `net::UdpSocket`.
-    ///
-    /// This function is intended to be used to wrap a UDP socket from the
-    /// standard library in the Mio equivalent. The conversion assumes nothing
-    /// about the underlying socket.
-    pub fn from_std(socket: net::UdpSocket) -> Self {
-        let sys = sys::UdpSocket::from_std(socket);
-        Self {
-            sys,
-            #[cfg(debug_assertions)]
-            selector_id: SelectorId::new(),
-        }
-    }
-
     /// Creates a UDP socket from the given address.
     ///
     /// # Examples
@@ -139,6 +125,21 @@ impl UdpSocket {
             #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),
         })
+    }
+
+    /// Creates a new `UdpSocket` from a standard `net::UdpSocket`.
+    ///
+    /// This function is intended to be used to wrap a UDP socket from the
+    /// standard library in the Mio equivalent. The conversion assumes nothing
+    /// about the underlying socket; it is left up to the user to set it in
+    /// non-blocking mode.
+    pub fn from_std(socket: net::UdpSocket) -> UdpSocket {
+        let sys = sys::UdpSocket::from_std(socket);
+        UdpSocket {
+            sys,
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
     }
 
     /// Returns the socket address that this socket was created from.

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -13,6 +13,7 @@ use crate::{event, sys, Interests, Registry, Token};
 
 use std::fmt;
 use std::io;
+use std::net;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -92,6 +93,20 @@ pub struct UdpSocket {
 }
 
 impl UdpSocket {
+    /// Creates a new `UdpSocket` from a standard `net::UdpSocket`.
+    ///
+    /// This function is intended to be used to wrap a UDP socket from the
+    /// standard library in the Mio equivalent. The conversion assumes nothing
+    /// about the underlying socket.
+    pub fn from_std(socket: net::UdpSocket) -> Self {
+        let sys = sys::UdpSocket::from_std(socket);
+        Self {
+            sys,
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
+    }
+
     /// Creates a UDP socket from the given address.
     ///
     /// # Examples

--- a/src/net/uds/datagram.rs
+++ b/src/net/uds/datagram.rs
@@ -6,6 +6,7 @@ use crate::{sys, Interests, Registry, Token};
 use std::io;
 use std::net::Shutdown;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::os::unix::net;
 use std::path::Path;
 
 /// A Unix datagram socket.
@@ -19,6 +20,20 @@ pub struct UnixDatagram {
 impl UnixDatagram {
     fn new(sys: sys::UnixDatagram) -> UnixDatagram {
         UnixDatagram {
+            sys,
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
+    }
+
+    /// Creates a new `UnixDatagram` from a standard `net::UnixDatagram`.
+    ///
+    /// This function is intended to be used to wrap a Unix datagram from the
+    /// standard library in the Mio equivalent. The conversion assumes nothing
+    /// about the underlying datagram.
+    pub fn from_std(datagram: net::UnixDatagram) -> Self {
+        let sys = sys::UnixDatagram::from_std(datagram);
+        Self {
             sys,
             #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),

--- a/src/net/uds/datagram.rs
+++ b/src/net/uds/datagram.rs
@@ -26,24 +26,25 @@ impl UnixDatagram {
         }
     }
 
-    /// Creates a new `UnixDatagram` from a standard `net::UnixDatagram`.
-    ///
-    /// This function is intended to be used to wrap a Unix datagram from the
-    /// standard library in the Mio equivalent. The conversion assumes nothing
-    /// about the underlying datagram.
-    pub fn from_std(datagram: net::UnixDatagram) -> Self {
-        let sys = sys::UnixDatagram::from_std(datagram);
-        Self {
-            sys,
-            #[cfg(debug_assertions)]
-            selector_id: SelectorId::new(),
-        }
-    }
-
     /// Creates a Unix datagram socket bound to the given path.
     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixDatagram> {
         let sys = sys::UnixDatagram::bind(path.as_ref())?;
         Ok(UnixDatagram::new(sys))
+    }
+
+    /// Creates a new `UnixDatagram` from a standard `net::UnixDatagram`.
+    ///
+    /// This function is intended to be used to wrap a Unix datagram from the
+    /// standard library in the Mio equivalent. The conversion assumes nothing
+    /// about the underlying datagram; ; it is left up to the user to set it
+    /// in non-blocking mode.
+    pub fn from_std(datagram: net::UnixDatagram) -> UnixDatagram {
+        let sys = sys::UnixDatagram::from_std(datagram);
+        UnixDatagram {
+            sys,
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
     }
 
     /// Connects the socket to the specified address.

--- a/src/net/uds/listener.rs
+++ b/src/net/uds/listener.rs
@@ -7,6 +7,7 @@ use crate::{sys, Interests, Registry, Token};
 
 use std::io;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::os::unix::net;
 use std::path::Path;
 
 /// A non-blocking Unix domain socket server.
@@ -20,6 +21,20 @@ pub struct UnixListener {
 impl UnixListener {
     fn new(sys: sys::UnixListener) -> UnixListener {
         UnixListener {
+            sys,
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
+    }
+
+    /// Creates a new `UnixListener` from a standard `net::UnixListener`.
+    ///
+    /// This function is intended to be used to wrap a Unix listener from the
+    /// standard library in the Mio equivalent. The conversion assumes nothing
+    /// about the underlying listener.
+    pub fn from_std(listener: net::UnixListener) -> Self {
+        let sys = sys::UnixListener::from_std(listener);
+        Self {
             sys,
             #[cfg(debug_assertions)]
             selector_id: SelectorId::new(),

--- a/src/net/uds/listener.rs
+++ b/src/net/uds/listener.rs
@@ -27,24 +27,25 @@ impl UnixListener {
         }
     }
 
-    /// Creates a new `UnixListener` from a standard `net::UnixListener`.
-    ///
-    /// This function is intended to be used to wrap a Unix listener from the
-    /// standard library in the Mio equivalent. The conversion assumes nothing
-    /// about the underlying listener.
-    pub fn from_std(listener: net::UnixListener) -> Self {
-        let sys = sys::UnixListener::from_std(listener);
-        Self {
-            sys,
-            #[cfg(debug_assertions)]
-            selector_id: SelectorId::new(),
-        }
-    }
-
     /// Creates a new `UnixListener` bound to the specified socket.
     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
         let sys = sys::UnixListener::bind(path.as_ref())?;
         Ok(UnixListener::new(sys))
+    }
+
+    /// Creates a new `UnixListener` from a standard `net::UnixListener`.
+    ///
+    /// This function is intended to be used to wrap a Unix listener from the
+    /// standard library in the Mio equivalent. The conversion assumes nothing
+    /// about the underlying listener; it is left up to the user to set it in
+    /// non-blocking mode.
+    pub fn from_std(listener: net::UnixListener) -> UnixListener {
+        let sys = sys::UnixListener::from_std(listener);
+        UnixListener {
+            sys,
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
     }
 
     /// Accepts a new incoming connection to this listener.

--- a/src/net/uds/stream.rs
+++ b/src/net/uds/stream.rs
@@ -26,28 +26,31 @@ impl UnixStream {
         }
     }
 
-    /// Creates a new `UnixStream` from a standard `net::UnixStream`.
-    ///
-    /// This function is intended to be used to wrap a Unix stream from the
-    /// standard library in the Mio equivalent. The conversion assumes nothing
-    /// about the underlying stream.
-    ///
-    /// Note: The Unix stream here will not have `connect` called on it, so it
-    /// should already be connected via some other means (be it manually, or
-    /// the standard library).
-    pub fn from_std(stream: net::UnixStream) -> Self {
-        let sys = sys::UnixStream::from_std(stream);
-        Self {
-            sys,
-            #[cfg(debug_assertions)]
-            selector_id: SelectorId::new(),
-        }
-    }
-
     /// Connects to the socket named by `path`.
     pub fn connect<P: AsRef<Path>>(p: P) -> io::Result<UnixStream> {
         let sys = sys::UnixStream::connect(p.as_ref())?;
         Ok(UnixStream::new(sys))
+    }
+
+    /// Creates a new `UnixStream` from a standard `net::UnixStream`.
+    ///
+    /// This function is intended to be used to wrap a Unix stream from the
+    /// standard library in the Mio equivalent. The conversion assumes nothing
+    /// about the underlying stream; it is left up to the user to set it in
+    /// non-blocking mode.
+    ///
+    /// # Note
+    ///
+    /// The Unix stream here will not have `connect` called on it, so it
+    /// should already be connected via some other means (be it manually, or
+    /// the standard library).
+    pub fn from_std(stream: net::UnixStream) -> UnixStream {
+        let sys = sys::UnixStream::from_std(stream);
+        UnixStream {
+            sys,
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
     }
 
     /// Creates an unnamed pair of connected sockets.

--- a/src/sys/unix/tcp/listener.rs
+++ b/src/sys/unix/tcp/listener.rs
@@ -13,12 +13,6 @@ pub struct TcpListener {
 }
 
 impl TcpListener {
-    pub(crate) fn from_std(inner: net::TcpListener) -> Self {
-        let raw_fd = inner.into_raw_fd();
-        let inner = unsafe { FromRawFd::from_raw_fd(raw_fd) };
-        Self { inner }
-    }
-
     pub fn bind(addr: SocketAddr) -> io::Result<TcpListener> {
         new_ip_socket(addr, libc::SOCK_STREAM).and_then(|socket| {
             // Set SO_REUSEADDR (mirrors what libstd does).
@@ -44,6 +38,10 @@ impl TcpListener {
                 inner: unsafe { net::TcpListener::from_raw_fd(socket) },
             })
         })
+    }
+
+    pub fn from_std(inner: net::TcpListener) -> TcpListener {
+        TcpListener { inner }
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {

--- a/src/sys/unix/tcp/listener.rs
+++ b/src/sys/unix/tcp/listener.rs
@@ -13,6 +13,12 @@ pub struct TcpListener {
 }
 
 impl TcpListener {
+    pub(crate) fn from_std(inner: net::TcpListener) -> Self {
+        let raw_fd = inner.into_raw_fd();
+        let inner = unsafe { FromRawFd::from_raw_fd(raw_fd) };
+        Self { inner }
+    }
+
     pub fn bind(addr: SocketAddr) -> io::Result<TcpListener> {
         new_ip_socket(addr, libc::SOCK_STREAM).and_then(|socket| {
             // Set SO_REUSEADDR (mirrors what libstd does).

--- a/src/sys/unix/tcp/stream.rs
+++ b/src/sys/unix/tcp/stream.rs
@@ -16,12 +16,6 @@ impl TcpStream {
         TcpStream { inner }
     }
 
-    pub(crate) fn from_std(inner: net::TcpStream) -> Self {
-        let raw_fd = inner.into_raw_fd();
-        let inner = unsafe { FromRawFd::from_raw_fd(raw_fd) };
-        Self { inner }
-    }
-
     pub fn connect(addr: SocketAddr) -> io::Result<TcpStream> {
         new_ip_socket(addr, libc::SOCK_STREAM)
             .and_then(|socket| {
@@ -43,6 +37,10 @@ impl TcpStream {
             .map(|socket| TcpStream {
                 inner: unsafe { net::TcpStream::from_raw_fd(socket) },
             })
+    }
+
+    pub fn from_std(inner: net::TcpStream) -> TcpStream {
+        TcpStream { inner }
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {

--- a/src/sys/unix/tcp/stream.rs
+++ b/src/sys/unix/tcp/stream.rs
@@ -16,6 +16,12 @@ impl TcpStream {
         TcpStream { inner }
     }
 
+    pub(crate) fn from_std(inner: net::TcpStream) -> Self {
+        let raw_fd = inner.into_raw_fd();
+        let inner = unsafe { FromRawFd::from_raw_fd(raw_fd) };
+        Self { inner }
+    }
+
     pub fn connect(addr: SocketAddr) -> io::Result<TcpStream> {
         new_ip_socket(addr, libc::SOCK_STREAM)
             .and_then(|socket| {

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -11,6 +11,12 @@ pub struct UdpSocket {
 }
 
 impl UdpSocket {
+    pub(crate) fn from_std(io: net::UdpSocket) -> Self {
+        let raw_fd = io.into_raw_fd();
+        let io = unsafe { FromRawFd::from_raw_fd(raw_fd) };
+        Self { io }
+    }
+
     pub fn bind(addr: SocketAddr) -> io::Result<UdpSocket> {
         // Gives a warning for non Apple platforms.
         #[allow(clippy::let_and_return)]

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -11,12 +11,6 @@ pub struct UdpSocket {
 }
 
 impl UdpSocket {
-    pub(crate) fn from_std(io: net::UdpSocket) -> Self {
-        let raw_fd = io.into_raw_fd();
-        let io = unsafe { FromRawFd::from_raw_fd(raw_fd) };
-        Self { io }
-    }
-
     pub fn bind(addr: SocketAddr) -> io::Result<UdpSocket> {
         // Gives a warning for non Apple platforms.
         #[allow(clippy::let_and_return)]
@@ -48,6 +42,10 @@ impl UdpSocket {
                     io: unsafe { net::UdpSocket::from_raw_fd(socket) },
                 })
         })
+    }
+
+    pub fn from_std(io: net::UdpSocket) -> UdpSocket {
+        UdpSocket { io }
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {

--- a/src/sys/unix/uds/datagram.rs
+++ b/src/sys/unix/uds/datagram.rs
@@ -20,6 +20,12 @@ impl UnixDatagram {
         UnixDatagram { inner }
     }
 
+    pub(crate) fn from_std(inner: net::UnixDatagram) -> Self {
+        let raw_fd = inner.into_raw_fd();
+        let inner = unsafe { FromRawFd::from_raw_fd(raw_fd) };
+        UnixDatagram { inner }
+    }
+
     pub(crate) fn bind(path: &Path) -> io::Result<UnixDatagram> {
         let socket = new_socket(libc::AF_UNIX, libc::SOCK_DGRAM)?;
         let (sockaddr, socklen) = socket_addr(path)?;

--- a/src/sys/unix/uds/datagram.rs
+++ b/src/sys/unix/uds/datagram.rs
@@ -20,12 +20,6 @@ impl UnixDatagram {
         UnixDatagram { inner }
     }
 
-    pub(crate) fn from_std(inner: net::UnixDatagram) -> Self {
-        let raw_fd = inner.into_raw_fd();
-        let inner = unsafe { FromRawFd::from_raw_fd(raw_fd) };
-        UnixDatagram { inner }
-    }
-
     pub(crate) fn bind(path: &Path) -> io::Result<UnixDatagram> {
         let socket = new_socket(libc::AF_UNIX, libc::SOCK_DGRAM)?;
         let (sockaddr, socklen) = socket_addr(path)?;
@@ -33,6 +27,10 @@ impl UnixDatagram {
 
         syscall!(bind(socket, sockaddr, socklen))?;
         Ok(unsafe { UnixDatagram::from_raw_fd(socket) })
+    }
+
+    pub fn from_std(inner: net::UnixDatagram) -> UnixDatagram {
+        UnixDatagram { inner }
     }
 
     pub(crate) fn connect<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -41,6 +41,12 @@ impl UnixListener {
         UnixListener { inner }
     }
 
+    pub(crate) fn from_std(inner: net::UnixListener) -> Self {
+        let raw_fd = inner.into_raw_fd();
+        let inner = unsafe { FromRawFd::from_raw_fd(raw_fd) };
+        Self { inner }
+    }
+
     pub(crate) fn accept(&self) -> io::Result<(UnixStream, SocketAddr)> {
         let sockaddr = mem::MaybeUninit::<libc::sockaddr_un>::zeroed();
 

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -41,12 +41,6 @@ impl UnixListener {
         UnixListener { inner }
     }
 
-    pub(crate) fn from_std(inner: net::UnixListener) -> Self {
-        let raw_fd = inner.into_raw_fd();
-        let inner = unsafe { FromRawFd::from_raw_fd(raw_fd) };
-        Self { inner }
-    }
-
     pub(crate) fn accept(&self) -> io::Result<(UnixStream, SocketAddr)> {
         let sockaddr = mem::MaybeUninit::<libc::sockaddr_un>::zeroed();
 
@@ -116,6 +110,10 @@ impl UnixListener {
                 err
             })
             .map(|_| unsafe { UnixListener::from_raw_fd(socket) })
+    }
+
+    pub fn from_std(inner: net::UnixListener) -> UnixListener {
+        UnixListener { inner }
     }
 
     pub(crate) fn try_clone(&self) -> io::Result<UnixListener> {

--- a/src/sys/unix/uds/stream.rs
+++ b/src/sys/unix/uds/stream.rs
@@ -20,6 +20,12 @@ impl UnixStream {
         UnixStream { inner }
     }
 
+    pub(crate) fn from_std(inner: net::UnixStream) -> Self {
+        let raw_fd = inner.into_raw_fd();
+        let inner = unsafe { FromRawFd::from_raw_fd(raw_fd) };
+        Self { inner }
+    }
+
     pub(crate) fn connect(path: &Path) -> io::Result<UnixStream> {
         let socket = new_socket(libc::AF_UNIX, libc::SOCK_STREAM)?;
         let (sockaddr, socklen) = socket_addr(path)?;

--- a/src/sys/unix/uds/stream.rs
+++ b/src/sys/unix/uds/stream.rs
@@ -20,12 +20,6 @@ impl UnixStream {
         UnixStream { inner }
     }
 
-    pub(crate) fn from_std(inner: net::UnixStream) -> Self {
-        let raw_fd = inner.into_raw_fd();
-        let inner = unsafe { FromRawFd::from_raw_fd(raw_fd) };
-        Self { inner }
-    }
-
     pub(crate) fn connect(path: &Path) -> io::Result<UnixStream> {
         let socket = new_socket(libc::AF_UNIX, libc::SOCK_STREAM)?;
         let (sockaddr, socklen) = socket_addr(path)?;
@@ -44,6 +38,10 @@ impl UnixStream {
         }
 
         Ok(unsafe { UnixStream::from_raw_fd(socket) })
+    }
+
+    pub fn from_std(inner: net::UnixStream) -> UnixStream {
+        UnixStream { inner }
     }
 
     pub(crate) fn pair() -> io::Result<(UnixStream, UnixStream)> {

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -67,15 +67,6 @@ macro_rules! wouldblock {
 }
 
 impl TcpStream {
-    pub(crate) fn from_std(inner: net::TcpStream) -> Self {
-        let raw_socket = inner.into_raw_socket();
-        let inner = unsafe { FromRawSocket::from_raw_socket(raw_socket) };
-        Self {
-            internal: Arc::new(Mutex::new(None)),
-            inner,
-        }
-    }
-
     pub fn connect(addr: SocketAddr) -> io::Result<TcpStream> {
         init();
         new_socket(addr, SOCK_STREAM)
@@ -113,6 +104,13 @@ impl TcpStream {
                 internal: Arc::new(Mutex::new(None)),
                 inner: unsafe { net::TcpStream::from_raw_socket(socket as StdSocket) },
             })
+    }
+
+    pub fn from_std(inner: net::TcpStream) -> TcpStream {
+        TcpStream {
+            internal: Arc::new(Mutex::new(None)),
+            inner,
+        }
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
@@ -333,15 +331,6 @@ impl AsRawSocket for TcpStream {
 }
 
 impl TcpListener {
-    pub(crate) fn from_std(inner: net::TcpListener) -> Self {
-        let raw_socket = inner.into_raw_socket();
-        let inner = unsafe { FromRawSocket::from_raw_socket(raw_socket) };
-        Self {
-            internal: Arc::new(Mutex::new(None)),
-            inner,
-        }
-    }
-
     pub fn bind(addr: SocketAddr) -> io::Result<TcpListener> {
         init();
         new_socket(addr, SOCK_STREAM).and_then(|socket| {
@@ -363,6 +352,13 @@ impl TcpListener {
                 inner: unsafe { net::TcpListener::from_raw_socket(socket as StdSocket) },
             })
         })
+    }
+
+    pub fn from_std(inner: net::TcpListener) -> TcpListener {
+        TcpListener {
+            internal: Arc::new(Mutex::new(None)),
+            inner,
+        }
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -63,7 +63,7 @@ impl TcpStream {
 
     pub fn from_std(inner: net::TcpStream) -> TcpStream {
         TcpStream {
-            internal: Arc::new(Mutex::new(None)),
+            internal: Box::new(Mutex::new(None)),
             inner,
         }
     }
@@ -325,7 +325,7 @@ impl TcpListener {
 
     pub fn from_std(inner: net::TcpListener) -> TcpListener {
         TcpListener {
-            internal: Arc::new(Mutex::new(None)),
+            internal: Box::new(Mutex::new(None)),
             inner,
         }
     }

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -67,6 +67,15 @@ macro_rules! wouldblock {
 }
 
 impl TcpStream {
+    pub(crate) fn from_std(inner: net::TcpStream) -> Self {
+        let raw_socket = inner.into_raw_socket();
+        let inner = unsafe { FromRawSocket::from_raw_socket(raw_socket) };
+        Self {
+            internal: Arc::new(Mutex::new(None)),
+            inner,
+        }
+    }
+
     pub fn connect(addr: SocketAddr) -> io::Result<TcpStream> {
         init();
         new_socket(addr, SOCK_STREAM)
@@ -324,6 +333,15 @@ impl AsRawSocket for TcpStream {
 }
 
 impl TcpListener {
+    pub(crate) fn from_std(inner: net::TcpListener) -> Self {
+        let raw_socket = inner.into_raw_socket();
+        let inner = unsafe { FromRawSocket::from_raw_socket(raw_socket) };
+        Self {
+            internal: Arc::new(Mutex::new(None)),
+            inner,
+        }
+    }
+
     pub fn bind(addr: SocketAddr) -> io::Result<TcpListener> {
         init();
         new_socket(addr, SOCK_STREAM).and_then(|socket| {

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -41,15 +41,6 @@ macro_rules! wouldblock {
 }
 
 impl UdpSocket {
-    pub(crate) fn from_std(io: net::UdpSocket) -> Self {
-        let raw_socket = io.into_raw_socket();
-        let io = unsafe { FromRawSocket::from_raw_socket(raw_socket) };
-        Self {
-            internal: Arc::new(Mutex::new(None)),
-            io,
-        }
-    }
-
     pub fn bind(addr: SocketAddr) -> io::Result<UdpSocket> {
         init();
         new_socket(addr, SOCK_DGRAM).and_then(|socket| {
@@ -70,6 +61,13 @@ impl UdpSocket {
                 io: unsafe { net::UdpSocket::from_raw_socket(socket as StdSocket) },
             })
         })
+    }
+
+    pub fn from_std(io: net::UdpSocket) -> UdpSocket {
+        UdpSocket {
+            internal: Arc::new(Mutex::new(None)),
+            io,
+        }
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -41,6 +41,15 @@ macro_rules! wouldblock {
 }
 
 impl UdpSocket {
+    pub(crate) fn from_std(io: net::UdpSocket) -> Self {
+        let raw_socket = io.into_raw_socket();
+        let io = unsafe { FromRawSocket::from_raw_socket(raw_socket) };
+        Self {
+            internal: Arc::new(Mutex::new(None)),
+            io,
+        }
+    }
+
     pub fn bind(addr: SocketAddr) -> io::Result<UdpSocket> {
         init();
         new_socket(addr, SOCK_DGRAM).and_then(|socket| {

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -38,10 +38,10 @@ impl UdpSocket {
         })
     }
 
-    pub fn from_std(io: net::UdpSocket) -> UdpSocket {
+    pub fn from_std(inner: net::UdpSocket) -> UdpSocket {
         UdpSocket {
-            internal: Arc::new(Mutex::new(None)),
-            io,
+            internal: Box::new(Mutex::new(None)),
+            inner,
         }
     }
 

--- a/tests/tcp_listener.rs
+++ b/tests/tcp_listener.rs
@@ -72,6 +72,12 @@ fn smoke_test_tcp_listener(addr: SocketAddr) {
     thread_handle.join().expect("unable to join thread");
 }
 
+// #[test]
+// fn tcp_listener_from_std() {
+//     let listener = assert_ok!(std::net::TcpListener::bind(any_local_address()));
+//     assert_ok!(TcpListener::from_std(listener));
+// }
+
 #[test]
 fn set_get_ttl() {
     init();

--- a/tests/tcp_listener.rs
+++ b/tests/tcp_listener.rs
@@ -26,12 +26,12 @@ fn is_send_and_sync() {
 
 #[test]
 fn tcp_listener() {
-    smoke_test_tcp_listener(any_local_address(), |addr| TcpListener::bind(addr));
+    smoke_test_tcp_listener(any_local_address(), TcpListener::bind);
 }
 
 #[test]
 fn tcp_listener_ipv6() {
-    smoke_test_tcp_listener(any_local_ipv6_address(), |addr| TcpListener::bind(addr));
+    smoke_test_tcp_listener(any_local_ipv6_address(), TcpListener::bind);
 }
 
 #[test]

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -120,6 +120,14 @@ fn smoke_test_tcp_stream(addr: SocketAddr) {
     thread_handle.join().expect("unable to join thread");
 }
 
+// #[test]
+// fn tcp_stream_from_std() {
+//     let (handle, sockaddr) = echo_listener(any_local_address(), 1);
+//     let stream = assert_ok!(std::net::TcpStream::connect(sockaddr));
+//     assert_ok!(TcpStream::from_std(stream));
+//     assert_ok!(handle.join())
+// }
+
 #[test]
 fn try_clone() {
     let (mut poll, mut events) = init_with_poll();

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -8,7 +8,7 @@ use std::thread;
 use std::time::Duration;
 
 use mio::net::TcpStream;
-use mio::{Interests, Token};
+use mio::{Events, Interests, Poll, Token};
 
 #[macro_use]
 mod util;
@@ -36,21 +36,47 @@ fn is_send_and_sync() {
 #[test]
 #[cfg_attr(windows, ignore = "fails on Windows, see #1078")]
 fn tcp_stream_ipv4() {
-    smoke_test_tcp_stream(any_local_address());
+    let (poll, events) = init_with_poll();
+    let (handle, addr) = echo_listener(any_local_address(), 1);
+    let stream = TcpStream::connect(addr).unwrap();
+
+    smoke_test_tcp_stream(stream, poll, events, addr);
+    handle.join().expect("unable to join thread");
 }
 
 #[test]
 #[cfg_attr(windows, ignore = "fails on Windows, see #1078")]
 fn tcp_stream_ipv6() {
-    smoke_test_tcp_stream(any_local_ipv6_address());
+    let (poll, events) = init_with_poll();
+    let (handle, addr) = echo_listener(any_local_ipv6_address(), 1);
+    let stream = TcpStream::connect(addr).unwrap();
+
+    smoke_test_tcp_stream(stream, poll, events, addr);
+    handle.join().expect("unable to join thread");
 }
 
-fn smoke_test_tcp_stream(addr: SocketAddr) {
-    let (mut poll, mut events) = init_with_poll();
+#[test]
+#[cfg_attr(windows, ignore = "fails on Windows, see #1078")]
+fn tcp_stream_std() {
+    let (poll, events) = init_with_poll();
+    let (handle, addr) = echo_listener(any_local_address(), 1);
+    let stream = net::TcpStream::connect(addr).unwrap();
 
-    let (thread_handle, addr) = echo_listener(addr, 1);
-    let mut stream = TcpStream::connect(addr).unwrap();
+    // `std::net::TcpStream`s are blocking by default, so make sure it is in
+    // non-blocking mode before wrapping in a Mio equivalent.
+    assert_ok!(stream.set_nonblocking(true));
+    let stream = TcpStream::from_std(stream);
 
+    smoke_test_tcp_stream(stream, poll, events, addr);
+    handle.join().expect("unable to join thread");
+}
+
+fn smoke_test_tcp_stream(
+    mut stream: TcpStream,
+    mut poll: Poll,
+    mut events: Events,
+    addr: SocketAddr,
+) {
     poll.registry()
         .register(&stream, ID1, Interests::WRITABLE.add(Interests::READABLE))
         .expect("unable to register TCP stream");
@@ -116,17 +142,7 @@ fn smoke_test_tcp_stream(addr: SocketAddr) {
 
     // Close the connection to allow the listener to shutdown.
     drop(stream);
-
-    thread_handle.join().expect("unable to join thread");
 }
-
-// #[test]
-// fn tcp_stream_from_std() {
-//     let (handle, sockaddr) = echo_listener(any_local_address(), 1);
-//     let stream = assert_ok!(std::net::TcpStream::connect(sockaddr));
-//     assert_ok!(TcpStream::from_std(stream));
-//     assert_ok!(handle.join())
-// }
 
 #[test]
 fn try_clone() {

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -36,13 +36,13 @@ fn is_send_and_sync() {
 #[test]
 #[cfg_attr(windows, ignore = "fails on Windows, see #1078")]
 fn tcp_stream_ipv4() {
-    smoke_test_tcp_stream(any_local_address(), |addr| TcpStream::connect(addr));
+    smoke_test_tcp_stream(any_local_address(), TcpStream::connect);
 }
 
 #[test]
 #[cfg_attr(windows, ignore = "fails on Windows, see #1078")]
 fn tcp_stream_ipv6() {
-    smoke_test_tcp_stream(any_local_ipv6_address(), |addr| TcpStream::connect(addr));
+    smoke_test_tcp_stream(any_local_ipv6_address(), TcpStream::connect);
 }
 
 #[test]

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -49,6 +49,21 @@ fn unconnected_udp_socket_ipv6() {
     smoke_test_unconnected_udp_socket(socket1, socket2);
 }
 
+#[test]
+fn unconnected_udp_socket_std() {
+    let socket1 = net::UdpSocket::bind(any_local_address()).unwrap();
+    let socket2 = net::UdpSocket::bind(any_local_address()).unwrap();
+
+    // `std::net::UdpSocket`s are blocking by default, so make sure they are
+    // in non-blocking mode before wrapping in a Mio equivalent.
+    assert_ok!(socket1.set_nonblocking(true));
+    assert_ok!(socket2.set_nonblocking(true));
+
+    let socket1 = UdpSocket::from_std(socket1);
+    let socket2 = UdpSocket::from_std(socket2);
+    smoke_test_unconnected_udp_socket(socket1, socket2);
+}
+
 fn smoke_test_unconnected_udp_socket(socket1: UdpSocket, socket2: UdpSocket) {
     let (mut poll, mut events) = init_with_poll();
 

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -173,6 +173,28 @@ fn connected_udp_socket_ipv6() {
     smoke_test_connected_udp_socket(socket1, socket2);
 }
 
+#[test]
+fn connected_udp_socket_std() {
+    let socket1 = net::UdpSocket::bind(any_local_address()).unwrap();
+    let address1 = socket1.local_addr().unwrap();
+
+    let socket2 = net::UdpSocket::bind(any_local_address()).unwrap();
+    let address2 = socket2.local_addr().unwrap();
+
+    socket1.connect(address2).unwrap();
+    socket2.connect(address1).unwrap();
+
+    // `std::net::UdpSocket`s are blocking by default, so make sure they are
+    // in non-blocking mode before wrapping in a Mio equivalent.
+    assert_ok!(socket1.set_nonblocking(true));
+    assert_ok!(socket2.set_nonblocking(true));
+
+    let socket1 = UdpSocket::from_std(socket1);
+    let socket2 = UdpSocket::from_std(socket2);
+
+    smoke_test_connected_udp_socket(socket1, socket2);
+}
+
 fn smoke_test_connected_udp_socket(socket1: UdpSocket, socket2: UdpSocket) {
     let (mut poll, mut events) = init_with_poll();
 

--- a/tests/uds.rs
+++ b/tests/uds.rs
@@ -32,6 +32,7 @@ const LOCAL_CLONE: Token = Token(1);
 
 #[test]
 fn uds_stream() {
+    #[allow(clippy::redundant_closure)]
     smoke_test(|path| UnixStream::connect(path));
 }
 

--- a/tests/uds.rs
+++ b/tests/uds.rs
@@ -5,11 +5,12 @@ mod util;
 use log::warn;
 use mio::net::{UnixDatagram, UnixListener, UnixStream};
 use mio::unix::SocketAddr;
-use mio::{Events, Interests, Poll, Token};
+use mio::{Interests, Token};
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::Shutdown;
 use std::os::unix::net;
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::path::Path;
+use std::sync::mpsc::{channel, Receiver};
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
@@ -31,38 +32,31 @@ const LOCAL_CLONE: Token = Token(1);
 
 #[test]
 fn uds_stream() {
-    let (poll, events) = init_with_poll();
-
-    let (sync_sender, sync_receiver) = channel();
-    let (handle, remote_addr) = echo_remote(1, sync_receiver);
-
-    let path = remote_addr.as_pathname().expect("not a pathname");
-    let local = assert_ok!(UnixStream::connect(path));
-
-    smoke_test(local, poll, events, sync_sender);
-    assert_ok!(handle.join());
+    smoke_test(|path| UnixStream::connect(path));
 }
 
 #[test]
 fn uds_stream_std() {
-    let (poll, events) = init_with_poll();
+    smoke_test(|path| {
+        let local = assert_ok!(net::UnixStream::connect(path));
+        // `std::os::unix::net::UnixStream`s are blocking by default, so make sure
+        // it is in non-blocking mode before wrapping in a Mio equivalent.
+        assert_ok!(local.set_nonblocking(true));
+        Ok(UnixStream::from_std(local))
+    })
+}
+
+fn smoke_test<F>(make_stream: F)
+where
+    F: FnOnce(&Path) -> io::Result<UnixStream>,
+{
+    let (mut poll, mut events) = init_with_poll();
 
     let (sync_sender, sync_receiver) = channel();
     let (handle, remote_addr) = echo_remote(1, sync_receiver);
 
     let path = remote_addr.as_pathname().expect("not a pathname");
-    let local = assert_ok!(net::UnixStream::connect(path));
-
-    // `std::os::unix::net::UnixStream`s are blocking by default, so make sure
-    // it is in non-blocking mode before wrapping in a Mio equivalent.
-    assert_ok!(local.set_nonblocking(true));
-    let local = UnixStream::from_std(local);
-
-    smoke_test(local, poll, events, sync_sender);
-    assert_ok!(handle.join());
-}
-
-fn smoke_test(mut local: UnixStream, mut poll: Poll, mut events: Events, sync_sender: Sender<()>) {
+    let mut local = assert_ok!(make_stream(path));
     assert_ok!(sync_sender.send(()));
 
     assert_ok!(poll.registry().register(
@@ -120,6 +114,7 @@ fn smoke_test(mut local: UnixStream, mut poll: Poll, mut events: Events, sync_se
 
     // Close the connection to allow the remote to shutdown
     drop(local);
+    assert_ok!(handle.join());
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

#1029 removed the `from_std` methods on the TCP (Unix) Stream (Listener)
resources. These methods are still needed in upstream libraries where creating
wrapped resources from standard types is needed.

Tokio: [TcpListener::from_std](https://github.com/tokio-rs/tokio/blob/master/tokio/src/net/tcp/listener.rs#L195-L199)

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
