### PR TITLE
Fix issue #1126. Make sure to reregister on successful accept.

### DIFF
--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -365,6 +365,7 @@ impl TcpListener {
 
     pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
         try_io!(self, accept).and_then(|(inner, addr)| {
+            self.io_blocked_reregister()?;
             inner.set_nonblocking(true).map(|()| {
                 (
                     TcpStream {

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -365,7 +365,8 @@ impl TcpListener {
 
     pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
         try_io!(self, accept).and_then(|(inner, addr)| {
-            self.io_blocked_reregister()?;
+            // intentionally ignore result of reregister and return the stream no matter what
+            let _ = self.io_blocked_reregister();
             inner.set_nonblocking(true).map(|()| {
                 (
                     TcpStream {


### PR DESCRIPTION
Reregister on every successful operation. Re-enabled some tests which were previously failing on windows. Added a new test with subsequent poll which fails w/o reregistering.