### PR TITLE
fix for issue #1073, deregistering not working on windows. 

### DIFF
--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -383,6 +383,17 @@ impl super::SocketState for TcpListener {
         let mut internal = self.internal.lock().unwrap();
         match &mut *internal {
             Some(internal) => {
+                // action of setting a None state it's a sign of deregistering a socket, so
+                // existing socket must be marked for deletion so it won't be used by selector
+                // for subsequent updates (atm it will be removed during first selector poll update)
+                if sock_state.is_none() {
+                    if internal.sock_state.is_some() {
+                        let sock_state = internal.sock_state.as_ref();
+                        let mut sock_internal = sock_state.unwrap().lock().unwrap();
+                        sock_internal.mark_delete();
+                    }
+                }
+
                 internal.sock_state = sock_state;
             }
             None => {}

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -167,6 +167,17 @@ impl super::SocketState for UdpSocket {
         let mut internal = self.internal.lock().unwrap();
         match &mut *internal {
             Some(internal) => {
+                // action of setting a None state it's a sign of deregistering a socket, so
+                // existing socket must be marked for deletion so it won't be used by selector
+                // for subsequent updates (atm it will be removed during first selector poll update)
+                if sock_state.is_none() {
+                    if internal.sock_state.is_some() {
+                        let sock_state = internal.sock_state.as_ref();
+                        let mut sock_internal = sock_state.unwrap().lock().unwrap();
+                        sock_internal.mark_delete();
+                    }
+                }
+
                 internal.sock_state = sock_state;
             }
             None => {}

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -17,7 +17,10 @@ use mio::{Events, Interests, Poll, Registry, Token};
 
 mod util;
 
-use util::{any_local_address, assert_send, assert_sync, init, TryRead, TryWrite};
+use util::{
+    any_local_address, assert_send, assert_sync, expect_no_events, init, init_with_poll, TryRead,
+    TryWrite,
+};
 
 const LISTEN: Token = Token(0);
 const CLIENT: Token = Token(1);
@@ -1186,5 +1189,43 @@ fn write_then_deregister() {
 
     let mut buf = [0; 10];
     assert_eq!(s.read(&mut buf).unwrap(), 4);
+    assert_eq!(&buf[0..4], &[1, 2, 3, 4]);
+}
+
+#[test]
+fn tcp_no_events_after_deregister() {
+    let (mut poll, mut events) = init_with_poll();
+
+    let listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
+    let addr = listener.local_addr().unwrap();
+    let mut stream = TcpStream::connect(addr).unwrap();
+
+    poll.registry()
+        .register(&listener, Token(1), Interests::READABLE)
+        .unwrap();
+    poll.registry()
+        .register(&stream, Token(3), Interests::READABLE)
+        .unwrap();
+
+    // Wait a moment for stream to connect before trying accept
+    thread::sleep(Duration::from_millis(100));
+
+    let mut stream2 = listener.accept().unwrap().0;
+    poll.registry()
+        .register(&stream2, Token(2), Interests::WRITABLE)
+        .unwrap();
+
+    stream2.write_all(&[1, 2, 3, 4]).unwrap();
+
+    poll.registry().deregister(&listener).unwrap();
+    poll.registry().deregister(&stream).unwrap();
+    poll.registry().deregister(&stream2).unwrap();
+
+    // note: without deregister, poll would have retrieved 3 events:
+    // listener-READABLE, stream2-WRITABLE, stream-READABLE
+    expect_no_events(&mut poll, &mut events);
+
+    let mut buf = [0; 10];
+    assert_eq!(stream.read(&mut buf).unwrap(), 4);
     assert_eq!(&buf[0..4], &[1, 2, 3, 4]);
 }

--- a/tests/tcp_listener.rs
+++ b/tests/tcp_listener.rs
@@ -165,7 +165,6 @@ fn reregister() {
 }
 
 #[test]
-#[cfg_attr(windows, ignore = "deregister doesn't work, see #1073")]
 fn deregister() {
     let (mut poll, mut events) = init_with_poll();
 

--- a/tests/tcp_listener.rs
+++ b/tests/tcp_listener.rs
@@ -165,7 +165,7 @@ fn reregister() {
 }
 
 #[test]
-fn deregister() {
+fn no_events_after_deregister() {
     let (mut poll, mut events) = init_with_poll();
 
     let listener = TcpListener::bind(any_local_address()).unwrap();

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -539,7 +539,6 @@ fn no_events_after_deregister() {
         .deregister(&stream)
         .expect("unable to deregister TCP stream");
 
-    // note: without deregistering at this point poll would retrieve Interests::WRITABLE
     expect_no_events(&mut poll, &mut events);
 
     // We do expect to be connected.
@@ -554,7 +553,6 @@ fn no_events_after_deregister() {
     assert_eq!(n, DATA1.len());
     stream.flush().unwrap();
 
-    // note: without deregistering at this point poll would retrieve Interests::READABLE
     expect_no_events(&mut poll, &mut events);
 
     drop(stream);

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -545,8 +545,7 @@ fn udp_socket_reregister() {
 }
 
 #[test]
-#[cfg_attr(windows, ignore = "fails on Windows, see #1080")]
-fn udp_socket_deregister() {
+fn udp_socket_no_events_after_deregister() {
     let (mut poll, mut events) = init_with_poll();
 
     let socket = UdpSocket::bind(any_local_address()).unwrap();


### PR DESCRIPTION
When deregistering a socket make sure it is marked for deletion so it won't be used in poll updates.

Signed-off-by: Daniel Tacalau <dst4096@gmail.com>