### PR TITLE
Wrap kqueue::Events so that it can be Send and Sync

### DIFF
--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -327,8 +327,10 @@ impl DerefMut for Events {
     }
 }
 
+// `Events` cannot derive `Send` because of the `udata: *mut ::c_void` field
+// in `libc::kevent`. However, `Events`'s public API treats the `udata` field as
+// a `uintptr_t` which is `Send`.
 unsafe impl Send for Events {}
-unsafe impl Sync for Events {}
 
 pub mod event {
     use crate::sys::Event;

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -2,6 +2,7 @@ use crate::{Interests, Token};
 
 use log::error;
 use std::mem::MaybeUninit;
+use std::ops::{Deref, DerefMut};
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -304,7 +305,30 @@ impl Drop for Selector {
 }
 
 pub type Event = libc::kevent;
-pub type Events = Vec<Event>;
+pub struct Events(Vec<libc::kevent>);
+
+impl Events {
+    pub fn with_capacity(capacity: usize) -> Events {
+        Events(Vec::with_capacity(capacity))
+    }
+}
+
+impl Deref for Events {
+    type Target = Vec<libc::kevent>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Events {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+unsafe impl Send for Events {}
+unsafe impl Sync for Events {}
 
 pub mod event {
     use crate::sys::Event;

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -327,10 +327,13 @@ impl DerefMut for Events {
     }
 }
 
-// `Events` cannot derive `Send` because of the `udata: *mut ::c_void` field
-// in `libc::kevent`. However, `Events`'s public API treats the `udata` field as
-// a `uintptr_t` which is `Send`.
+// `Events` cannot derive `Send` or `Sync` because of the
+// `udata: *mut ::c_void` field in `libc::kevent`. However, `Events`'s public
+// API treats the `udata` field as a `uintptr_t` which is `Send`. `Sync` is
+// safe because with a `events: &Events` value, the only access to the `udata`
+// field is through `fn token(event: &Event)` which cannot mutate the field.
 unsafe impl Send for Events {}
+unsafe impl Sync for Events {}
 
 pub mod event {
     use crate::sys::Event;

--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -14,6 +14,7 @@ use util::{any_local_address, assert_send, assert_sync, init};
 #[test]
 fn is_send_and_sync() {
     assert_send::<Events>();
+    assert_sync::<Events>();
 
     assert_sync::<Poll>();
     assert_send::<Poll>();

--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -13,6 +13,9 @@ use util::{any_local_address, assert_send, assert_sync, init};
 
 #[test]
 fn is_send_and_sync() {
+    assert_sync::<Events>();
+    assert_send::<Events>();
+
     assert_sync::<Poll>();
     assert_send::<Poll>();
 

--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -13,7 +13,6 @@ use util::{any_local_address, assert_send, assert_sync, init};
 
 #[test]
 fn is_send_and_sync() {
-    assert_sync::<Events>();
     assert_send::<Events>();
 
     assert_sync::<Poll>();


### PR DESCRIPTION
## Motivation

Both `Poll` and `Registry` are `Send` and `Sync`. `Events` is passed as an
argument to `Poll::poll`, and is intended to be created once--at the same time
as `Poll`--and reused on each call. It would be expected that `Events` is
therefore `Send` and `Sync` but that is currently not the case in kqueue.

#983 changed the "events" type (`KeventList` -> `Events`) to have a named field,
but also [dropped](https://github.com/tokio-rs/mio/pull/983/files#diff-1b9651542d08c6eca04e6025b1c6fd53L330) the `Send` and `Sync` impls.

For epoll events this has been okay because these marker traits can be derived
from the fields within `epoll_event`, but `kevent` has a `*mut T` field making
this not possible.

## Solution

`kqueue::Events` is now a smart pointer wrapping a `Vec<libc::kevent>` and impls
`Send` and `Sync`. `Deref` and `DerefMut` traits have also been implemented
which reduce changes in the rest of `sys`.

Assertions for `Events` have been added to the `assert_send`/`assert_sync` test
as well.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>