### PR TITLE
Move most of the crate documentation to README

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,109 +5,19 @@
 // Disallow warnings in examples.
 #![doc(test(attr(deny(warnings))))]
 
-//! A fast, low-level IO library for Rust focusing on non-blocking APIs, event
-//! notification, and other useful utilities for building high performance IO
-//! apps.
-//!
-//! # Features
-//!
-//! * Non-blocking TCP, UDP
-//! * I/O event queue backed by epoll, kqueue, and IOCP
-//! * Zero allocations at runtime
-//! * Platform specific extensions
-//!
-//! # Non-goals
-//!
-//! The following are specifically omitted from Mio and are left to the user or
-//! higher-level libraries.
-//!
-//! * File operations
-//! * Thread pools / multi-threaded event loop
-//! * Timers
-//!
-//! # Platforms
-//!
-//! Currently supported platforms:
-//!
-//! * Android
-//! * DragonFly BSD
-//! * FreeBSD
-//! * Linux
-//! * NetBSD
-//! * OpenBSD
-//! * Solaris
-//! * Windows
-//! * iOS
-//! * macOS
-//!
-//! Mio can handle interfacing with each of the event systems of the
-//! aforementioned platforms. The details of their implementation are further
-//! discussed in [`Poll`].
+//! Mio is a fast, low-level I/O library for Rust focusing on non-blocking APIs
+//! and event notification for building high performance I/O apps with as little
+//! overhead as possible over the OS abstractions.
 //!
 //! # Usage
 //!
 //! Using Mio starts by creating a [`Poll`], which reads events from the OS and
-//! puts them into [`Events`]. You can handle IO events from the OS with it.
+//! puts them into [`Events`]. You can handle I/O events from the OS with it.
 //!
 //! For more detail, see [`Poll`].
 //!
 //! [`Poll`]: struct.Poll.html
 //! [`Events`]: struct.Events.html
-//!
-//! # Example
-//!
-//! ```
-//! # use std::error::Error;
-//! # fn main() -> Result<(), Box<dyn Error>> {
-//! use mio::*;
-//! use mio::net::{TcpListener, TcpStream};
-//!
-//! // Setup some tokens to allow us to identify which event is
-//! // for which socket.
-//! const SERVER: Token = Token(0);
-//! const CLIENT: Token = Token(1);
-//!
-//! let addr = "127.0.0.1:13265".parse()?;
-//!
-//! // Setup the server socket
-//! let server = TcpListener::bind(addr)?;
-//!
-//! // Create a poll instance
-//! let mut poll = Poll::new()?;
-//!
-//! // Start listening for incoming connections
-//! poll.registry().register(&server, SERVER, Interests::READABLE)?;
-//!
-//! // Setup the client socket
-//! let sock = TcpStream::connect(addr)?;
-//!
-//! // Register the socket
-//! poll.registry().register(&sock, CLIENT, Interests::READABLE)?;
-//!
-//! // Create storage for events
-//! let mut events = Events::with_capacity(1024);
-//!
-//! loop {
-//!     poll.poll(&mut events, None)?;
-//!
-//!     for event in events.iter() {
-//!         match event.token() {
-//!             SERVER => {
-//!                 // Accept and drop the socket immediately, this will close
-//!                 // the socket and notify the client of the EOF.
-//!                 let _ = server.accept();
-//!             }
-//!             CLIENT => {
-//!                 // The server just shuts down the socket, let's just exit
-//!                 // from our event loop.
-//!                 return Ok(());
-//!             }
-//!             _ => unreachable!(),
-//!         }
-//!     }
-//! }
-//! # }
-//! ```
 
 mod interests;
 mod poll;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,22 @@
 //!
 //! [`Poll`]: struct.Poll.html
 //! [`Events`]: struct.Events.html
+//!
+//! ## Examples
+//!
+//! Examples can found in the `examples` directory of the source code, or [on
+//! GitHub].
+//!
+//! [on GitHub]: https://github.com/tokio-rs/mio/tree/master/examples
+//!
+//! ## Guide
+//!
+//! A getting started guide is available in the
+#![cfg_attr(feature = "guide", doc = "[`guide`](crate::guide) module.")]
+#![cfg_attr(
+    not(feature = "guide"),
+    doc = "`guide` (only available when the `guide` feature is enabled)."
+)]
 
 mod interests;
 mod poll;


### PR DESCRIPTION
Thing like the features, non-goals and platforms are moved to the README
in an effort to reduce the scrolling when opening the API documentation.
Furthermore once you decide on using Mio most of these thing don't
really add any value anymore. So instead these things are moved to the
README of the repository where people (most likely) will land when first
encountering Mio on GitHub or crates.io.

The example is also moved to the README as the README was missing one
and most types now have examples in there documentation, including Poll.