### PR TITLE
Fix uds::pair_descriptors() to actually take an output argument as intended

### DIFF
--- a/src/sys/unix/uds/datagram.rs
+++ b/src/sys/unix/uds/datagram.rs
@@ -38,12 +38,12 @@ impl UnixDatagram {
     }
 
     pub(crate) fn pair() -> io::Result<(UnixDatagram, UnixDatagram)> {
-        let fds = [-1; 2];
+        let mut fds = [-1; 2];
         let flags = libc::SOCK_DGRAM;
 
         #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "solaris")))]
         let pair = {
-            pair_descriptors(fds, flags)?;
+            pair_descriptors(&mut fds, flags)?;
             unsafe {
                 (
                     UnixDatagram::from_raw_fd(fds[0]),
@@ -63,7 +63,7 @@ impl UnixDatagram {
         let pair = {
             let s1 = unsafe { UnixDatagram::from_raw_fd(fds[0]) };
             let s2 = unsafe { UnixDatagram::from_raw_fd(fds[1]) };
-            pair_descriptors(fds, flags)?;
+            pair_descriptors(&mut fds, flags)?;
             (s1, s2)
         };
 

--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -75,7 +75,7 @@ pub fn path_offset(sockaddr: &libc::sockaddr_un) -> usize {
     path - base
 }
 
-fn pair_descriptors(mut fds: [RawFd; 2], flags: i32) -> io::Result<()> {
+fn pair_descriptors(fds: &mut [RawFd; 2], flags: i32) -> io::Result<()> {
     #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "solaris")))]
     let flags = flags | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
 

--- a/src/sys/unix/uds/stream.rs
+++ b/src/sys/unix/uds/stream.rs
@@ -45,12 +45,12 @@ impl UnixStream {
     }
 
     pub(crate) fn pair() -> io::Result<(UnixStream, UnixStream)> {
-        let fds = [-1; 2];
+        let mut fds = [-1; 2];
         let flags = libc::SOCK_STREAM;
 
         #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "solaris")))]
         let pair = {
-            pair_descriptors(fds, flags)?;
+            pair_descriptors(&mut fds, flags)?;
             unsafe {
                 (
                     UnixStream::from_raw_fd(fds[0]),
@@ -70,7 +70,7 @@ impl UnixStream {
         let pair = {
             let s1 = unsafe { UnixStream::from_raw_fd(fds[0]) };
             let s2 = unsafe { UnixStream::from_raw_fd(fds[1]) };
-            pair_descriptors(fds, flags)?;
+            pair_descriptors(&mut fds, flags)?;
             (s1, s2)
         };
 


### PR DESCRIPTION
This took me a while to figure out.  The original symptom I saw was that
registering `UnixStream::pair()` streams fails with "Bad file descriptor". 
Digging deeper, I realized all operations on the streams result in EBADF. 
Reading the code, it suddenly dawned on me:
`mio::sys::unix::uds::pair_descriptors` is used with the intention of `fds`
being an output argument. However, `fds` is declared as a mutable array, not a
reference to a mutable array. So what currently happens in the code path of
`Unix{Datagram,Stream}::pair` is that we initialize `fds` to [-1; 2], copy
that into `pair_descriptors()` and return it later as two streams or
datagrams.  Always set to -1 because the modifications to `fds` by
`pair_descriptors` gets lost.

The fix is to change `fds` to a mutable reference, and update the call sites
to declare the array mutable.

This is tested and works, I can finally use `UnixStream::pair` in my mio poll
loop.

However, this patch uncovers another bug that should be fixed separately:

`Unix{Datagram,Stream}::pair` in `src/sys/unix/uds/{datagram,stream}.rs` both
have a special case for Darwin and Solaris.  Quoting the code below:

```rust
   // Darwin and Solaris do not have SOCK_NONBLOCK or SOCK_CLOEXEC.
   //
   // In order to set those flags, additional `fcntl` sys calls must be
   // made in `pair_descriptors` that are fallible. If a `fnctl` fails
   // after the sockets have been created, the file descriptors will
   // leak. Creating `s1` and `s2` below ensure that if there is an
   // error, the file descriptors are closed.
   #[cfg(any(target_os = "ios", target_os = "macos", target_os = "solaris"))]
   let pair = {
       let s1 = unsafe { UnixStream::from_raw_fd(fds[0]) };
       let s2 = unsafe { UnixStream::from_raw_fd(fds[1]) };
       pair_descriptors(&mut fds, flags)?;
       (s1, s2)
   };
```

The comment is very careful to explain the situation, but the code below of it
is hopelessly wrong.  from_raw_fd takes a copy of fd. so both streams again
get initialized with a -1 fd, and the result of pair_descriptors is
essentially discarded.

To sum up: with this path, `Unix{Datagram,Stream}::pair()` works correctly on
everything other then ios, macos and solaris.

I'd like to leave fixing of those other platforms to the person that wrong
this elaborate comment above.