### PR TITLE
Fix UnixStream::pair and UnixDatagram::pair on all platforms

### DIFF
--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::io::RawFd;
 use std::path::Path;
 use std::{io, mem};
 
@@ -73,27 +72,6 @@ pub fn path_offset(sockaddr: &libc::sockaddr_un) -> usize {
     let base = sockaddr as *const _ as usize;
     let path = &sockaddr.sun_path as *const _ as usize;
     path - base
-}
-
-fn pair_descriptors(fds: &mut [RawFd; 2], flags: i32) -> io::Result<()> {
-    #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "solaris")))]
-    let flags = flags | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
-
-    syscall!(socketpair(libc::AF_UNIX, flags, 0, fds.as_mut_ptr()))?;
-
-    // Darwin and Solaris don't have SOCK_NONBLOCK or SOCK_CLOEXEC.
-    //
-    // For platforms that don't support flags in `socket`, the flags must be
-    // set through `fcntl`. The `F_SETFL` command sets the `O_NONBLOCK` bit.
-    // The `F_SETFD` command sets the `FD_CLOEXEC` bit.
-    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "solaris"))]
-    {
-        syscall!(fcntl(fds[0], libc::F_SETFL, libc::O_NONBLOCK))?;
-        syscall!(fcntl(fds[0], libc::F_SETFD, libc::FD_CLOEXEC))?;
-        syscall!(fcntl(fds[1], libc::F_SETFL, libc::O_NONBLOCK))?;
-        syscall!(fcntl(fds[1], libc::F_SETFD, libc::FD_CLOEXEC))?;
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/sys/unix/uds/stream.rs
+++ b/src/sys/unix/uds/stream.rs
@@ -1,4 +1,4 @@
-use super::{pair_descriptors, socket_addr, SocketAddr};
+use super::{socket_addr, SocketAddr};
 use crate::event::Source;
 use crate::sys::unix::net::new_socket;
 use crate::sys::unix::SourceFd;
@@ -47,33 +47,30 @@ impl UnixStream {
     pub(crate) fn pair() -> io::Result<(UnixStream, UnixStream)> {
         let mut fds = [-1; 2];
         let flags = libc::SOCK_STREAM;
-
         #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "solaris")))]
-        let pair = {
-            pair_descriptors(&mut fds, flags)?;
-            unsafe {
-                (
-                    UnixStream::from_raw_fd(fds[0]),
-                    UnixStream::from_raw_fd(fds[1]),
-                )
-            }
+        let flags = flags | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
+
+        syscall!(socketpair(libc::AF_UNIX, flags, 0, fds.as_mut_ptr()))?;
+        let pair = unsafe {
+            (
+                UnixStream::from_raw_fd(fds[0]),
+                UnixStream::from_raw_fd(fds[1]),
+            )
         };
 
         // Darwin and Solaris do not have SOCK_NONBLOCK or SOCK_CLOEXEC.
         //
         // In order to set those flags, additional `fcntl` sys calls must be
-        // made in `pair_descriptors` that are fallible. If a `fnctl` fails
-        // after the sockets have been created, the file descriptors will
-        // leak. Creating `s1` and `s2` below ensure that if there is an
-        // error, the file descriptors are closed.
+        // performed. If a `fnctl` fails after the sockets have been created,
+        // the file descriptors will leak. Creating `pair` above ensures that
+        // if there is an error, the file descriptors are closed.
         #[cfg(any(target_os = "ios", target_os = "macos", target_os = "solaris"))]
-        let pair = {
-            let s1 = unsafe { UnixStream::from_raw_fd(fds[0]) };
-            let s2 = unsafe { UnixStream::from_raw_fd(fds[1]) };
-            pair_descriptors(&mut fds, flags)?;
-            (s1, s2)
-        };
-
+        {
+            syscall!(fcntl(fds[0], libc::F_SETFL, libc::O_NONBLOCK))?;
+            syscall!(fcntl(fds[0], libc::F_SETFD, libc::FD_CLOEXEC))?;
+            syscall!(fcntl(fds[1], libc::F_SETFL, libc::O_NONBLOCK))?;
+            syscall!(fcntl(fds[1], libc::F_SETFD, libc::FD_CLOEXEC))?;
+        }
         Ok(pair)
     }
 

--- a/tests/uds.rs
+++ b/tests/uds.rs
@@ -149,11 +149,13 @@ fn stream_pair() {
     );
 
     let mut buf = [0; DEFAULT_BUF_SIZE];
+    assert_would_block(s1.read(&mut buf));
     let wrote = assert_ok!(s1.write(&DATA1));
     assert_eq!(wrote, DATA1_LEN);
     assert_ok!(s1.flush());
 
     let read = assert_ok!(s2.read(&mut buf));
+    assert_would_block(s2.read(&mut buf));
     assert_eq!(read, DATA1_LEN);
     assert_eq!(&buf[..read], DATA1);
     assert_eq!(read, wrote, "unequal reads and writes");
@@ -187,10 +189,12 @@ fn datagram_pair() {
     );
 
     let mut buf = [0; DEFAULT_BUF_SIZE];
+    assert_would_block(s1.recv(&mut buf));
     let wrote = assert_ok!(s1.send(&DATA1));
     assert_eq!(wrote, DATA1_LEN);
 
     let read = assert_ok!(s2.recv(&mut buf));
+    assert_would_block(s2.recv(&mut buf));
     assert_eq!(read, DATA1_LEN);
     assert_eq!(&buf[..read], DATA1);
     assert_eq!(read, wrote, "unequal reads and writes");

--- a/tests/uds.rs
+++ b/tests/uds.rs
@@ -154,6 +154,11 @@ fn stream_pair() {
     assert_eq!(wrote, DATA1_LEN);
     assert_ok!(s1.flush());
 
+    expect_events(
+        &mut poll,
+        &mut events,
+        vec![ExpectEvent::new(Token(1), Interests::READABLE)],
+    );
     let read = assert_ok!(s2.read(&mut buf));
     assert_would_block(s2.read(&mut buf));
     assert_eq!(read, DATA1_LEN);
@@ -164,6 +169,11 @@ fn stream_pair() {
     assert_eq!(wrote, DATA2_LEN);
     assert_ok!(s2.flush());
 
+    expect_events(
+        &mut poll,
+        &mut events,
+        vec![ExpectEvent::new(Token(0), Interests::READABLE)],
+    );
     let read = assert_ok!(s1.read(&mut buf));
     assert_eq!(read, DATA2_LEN);
     assert_eq!(&buf[..read], DATA2);
@@ -193,6 +203,11 @@ fn datagram_pair() {
     let wrote = assert_ok!(s1.send(&DATA1));
     assert_eq!(wrote, DATA1_LEN);
 
+    expect_events(
+        &mut poll,
+        &mut events,
+        vec![ExpectEvent::new(Token(1), Interests::READABLE)],
+    );
     let read = assert_ok!(s2.recv(&mut buf));
     assert_would_block(s2.recv(&mut buf));
     assert_eq!(read, DATA1_LEN);
@@ -202,6 +217,11 @@ fn datagram_pair() {
     let wrote = assert_ok!(s2.send(&DATA2));
     assert_eq!(wrote, DATA2_LEN);
 
+    expect_events(
+        &mut poll,
+        &mut events,
+        vec![ExpectEvent::new(Token(0), Interests::READABLE)],
+    );
     let read = assert_ok!(s1.recv(&mut buf));
     assert_eq!(read, DATA2_LEN);
     assert_eq!(&buf[..read], DATA2);


### PR DESCRIPTION
#1141 Addressed an issue with `UnixStream::pair` and `UnixDatagram::pair`
where the file descriptor array passed in to `pair_descriptors` was copied in
instead of passed by reference. Even if `pair_descriptors` succeded, the file
descriptor array used to create the socket pairs was the original array
initialized to `[-1; 2]`.

The issue still remains for target platforms where additional `fcntl` sys
calls must be made. The sockets are created before the call to
`pair_descriptors`, but a successful return does not actually affect the
sockets.

Ultimately, both of the `pair` methods and `pair_descriptors` function were
incorrect. I feel `pair_descriptors` role in trying to reduce code duplication
while being generic over `UnixStream` and `UnixDatagram` adds some uncessary
complexity without actually resulting in less code.

### Solution

The `pair` methods are now separate and no longer dispatch to a generic
function. The sockets are created after the required sys call. The `fcntl`
calls are made after socket creation to allow for cleanup.

Tests have been added for these specific methods.

A final PR separate from this will expand all UDS tests so that it is more
heavily tested.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
