### PR TITLE
Remove the transparent attribute on Event and Interests

### DIFF
--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -12,7 +12,6 @@ use std::fmt;
 /// [`Poll::poll`]: crate::Poll::poll
 /// [`Poll`]: crate::Poll
 /// [`Token`]: crate::Token
-#[repr(transparent)]
 pub struct Event {
     inner: sys::Event,
 }

--- a/src/interests.rs
+++ b/src/interests.rs
@@ -14,7 +14,6 @@ use std::{fmt, ops};
 /// [readable]: Interests::READABLE
 /// [`poll`]: crate::Poll::poll
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
-#[repr(transparent)]
 pub struct Interests(NonZeroU8);
 
 // These must be unique.


### PR DESCRIPTION
For Event is was needed to safety create a pointer to the internal
system event, but this is no longer used.

For Interests it was never needed.

Closes #1122