### PR TITLE
Add Events::len inspector to retrieve number of events

### DIFF
--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -105,6 +105,18 @@ impl Events {
         self.inner.capacity()
     }
 
+    /// Returns the number of `Event` values that `self` holds.
+    ///
+    /// ```
+    /// use mio::Events;
+    ///
+    /// let events = Events::with_capacity(1024);
+    /// assert_eq!(0, events.len());
+    /// ```
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
     /// Returns `true` if `self` contains no `Event` values.
     ///
     /// # Examples

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -80,6 +80,10 @@ impl Events {
         self.events.capacity()
     }
 
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
     pub fn get(&self, idx: usize) -> Option<&Event> {
         self.events.get(idx)
     }


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/mio/issues/1158.