### PR TITLE
windows: use the default IOCP concurrency value.

### DIFF
--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -55,7 +55,7 @@ impl Selector {
         // offset by 1 to avoid choosing 0 as the id of a selector
         let id = NEXT_ID.fetch_add(1, Ordering::Relaxed) + 1;
 
-        CompletionPort::new(1).map(|cp| {
+        CompletionPort::new(0).map(|cp| {
             Selector {
                 inner: Arc::new(SelectorInner {
                     id: id,


### PR DESCRIPTION
IOCP is initialized with the max number of threads that can be
"associated" with the IOCP handle. A thread becomes associated with IOCP
when it is woken after selecting. It remains associated with IOCP until
the thread sleeps for any reason (blocking I/O, yield, page fault,
sleep, ...).

Currently, the value is set to 1. However, this was picked mostly
because I had no idea what it meant to be "associated" with IOCP and 1
sounded good. It turns out that 0 is lets windows pick a default value
(number of cores). This makes much more sense than 1.

ref: https://docs.microsoft.com/en-us/windows/win32/fileio/i-o-completion-ports#threads-and-concurrency