### PR TITLE
Expose platform details in extended Debug impl for Event

### DIFF
--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -172,6 +172,7 @@ pub mod event {
     }
 
     pub fn debug_details(f: &mut fmt::Formatter<'_>, event: &Event) -> fmt::Result {
+        #[allow(clippy::trivially_copy_pass_by_ref)]
         fn check_events(got: &u32, want: &libc::c_int) -> bool {
             (*got as libc::c_int & want) != 0
         }

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -470,6 +470,7 @@ pub mod event {
             libc::EVFILT_VM,
         );
 
+        #[allow(clippy::trivially_copy_pass_by_ref)]
         fn check_flag(got: &Flags, want: &Flags) -> bool {
             (got & want) != 0
         }
@@ -500,6 +501,7 @@ pub mod event {
             libc::EV_NODATA,
         );
 
+        #[allow(clippy::trivially_copy_pass_by_ref)]
         fn check_fflag(got: &u32, want: &u32) -> bool {
             (got & want) != 0
         }

--- a/src/sys/windows/afd.rs
+++ b/src/sys/windows/afd.rs
@@ -214,7 +214,7 @@ pub const POLL_LOCAL_CLOSE: u32 = 0b000_100_000;
 // Not used as it indicated in each event where a connection is connected, not
 // just the first time a connection is established.
 // Also see https://github.com/piscisaureus/wepoll/commit/8b7b340610f88af3d83f40fb728e7b850b090ece.
-//pub const POLL_CONNECT: u32 = 0b001_000_000;
+pub const POLL_CONNECT: u32 = 0b001_000_000;
 pub const POLL_ACCEPT: u32 = 0b010_000_000;
 pub const POLL_CONNECT_FAIL: u32 = 0b100_000_000;
 

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -51,6 +51,7 @@ pub fn is_lio(_: &Event) -> bool {
 }
 
 pub fn debug_details(f: &mut fmt::Formatter<'_>, event: &Event) -> fmt::Result {
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     fn check_flags(got: &u32, want: &u32) -> bool {
         (got & want) != 0
     }

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -1,9 +1,10 @@
+use std::fmt;
+
 use miow::iocp::CompletionStatus;
 
 use super::afd;
 use crate::Token;
 
-#[derive(Debug)]
 pub struct Event {
     pub flags: u32,
     pub data: u64,
@@ -47,6 +48,30 @@ pub fn is_aio(_: &Event) -> bool {
 pub fn is_lio(_: &Event) -> bool {
     // Not supported.
     false
+}
+
+pub fn debug_details(f: &mut fmt::Formatter<'_>, event: &Event) -> fmt::Result {
+    fn check_flags(got: &u32, want: &u32) -> bool {
+        (got & want) != 0
+    }
+    debug_detail!(
+        FlagsDetails(u32),
+        check_flags,
+        afd::POLL_RECEIVE,
+        afd::POLL_RECEIVE_EXPEDITED,
+        afd::POLL_SEND,
+        afd::POLL_DISCONNECT,
+        afd::POLL_ABORT,
+        afd::POLL_LOCAL_CLOSE,
+        afd::POLL_CONNECT,
+        afd::POLL_ACCEPT,
+        afd::POLL_CONNECT_FAIL,
+    );
+
+    f.debug_struct("event")
+        .field("flags", &FlagsDetails(event.flags))
+        .field("data", &event.data)
+        .finish()
 }
 
 pub struct Events {

--- a/tests/unix_listener.rs
+++ b/tests/unix_listener.rs
@@ -72,7 +72,7 @@ fn unix_listener_try_clone_same_poll() {
 
     listener1.accept().unwrap();
 
-    let handle_2 = open_connections(path.clone(), 1, barrier.clone());
+    let handle_2 = open_connections(path, 1, barrier.clone());
     expect_events(
         &mut poll,
         &mut events,
@@ -129,7 +129,7 @@ fn unix_listener_try_clone_different_poll() {
 
     listener1.accept().unwrap();
 
-    let handle_2 = open_connections(path.clone(), 1, barrier.clone());
+    let handle_2 = open_connections(path, 1, barrier.clone());
     expect_events(
         &mut poll1,
         &mut events,
@@ -209,7 +209,7 @@ fn unix_listener_reregister() {
         .register(&listener, TOKEN_1, Interests::WRITABLE)
         .unwrap();
 
-    let handle = open_connections(path.clone(), 1, barrier.clone());
+    let handle = open_connections(path, 1, barrier.clone());
     expect_no_events(&mut poll, &mut events);
 
     poll.registry()
@@ -237,7 +237,7 @@ fn unix_listener_deregister() {
         .register(&listener, TOKEN_1, Interests::READABLE)
         .unwrap();
 
-    let handle = open_connections(path.clone(), 1, barrier.clone());
+    let handle = open_connections(path, 1, barrier.clone());
 
     poll.registry().deregister(&listener).unwrap();
     expect_no_events(&mut poll, &mut events);
@@ -265,7 +265,7 @@ where
         .unwrap();
     expect_no_events(&mut poll, &mut events);
 
-    let handle = open_connections(path.clone(), 1, barrier.clone());
+    let handle = open_connections(path, 1, barrier.clone());
     expect_events(
         &mut poll,
         &mut events,


### PR DESCRIPTION
This adds a new virtual field named "details" and exposes the selector
specific event structure. Below is some example output.

On kqueue(2), receiving a readable event for a UdpSocket with Token(0).

```
Event {
    token: Token(
        0,
    ),
    readable: true,
    writable: false,
    error: false,
    read_closed: false,
    write_closed: false,
    priority: false,
    aio: false,
    lio: false,
    details: kevent {
        ident: 3,
        filter: EVFILT_READ,
        flags: EV_ADD|EV_CLEAR|EV_RECEIPT,
        fflags: (empty),
        data: 2,
        udata: 0x0000000000000000,
    },
}
```

On epoll(2), also receiving a readable event for a UdpSocket with Token(0).

```
Event {
    token: Token(
        0,
    ),
    readable: true,
    writable: false,
    error: false,
    read_closed: false,
    write_closed: false,
    priority: false,
    aio: false,
    lio: false,
    details: epoll_event {
        events: EPOLLIN,
        u64: 0,
    },
}
```

On Windows, receiving an event that a TcpListener can accept a
connection with Token(0).

```
Event {
    token: Token(
        0,
    ),
    readable: true,
    writable: false,
    error: false,
    read_closed: false,
    write_closed: false,
    priority: false,
    aio: false,
    lio: false,
    details: event {
        flags: POLL_ACCEPT,
        data: 0,
    },
}
```

Some of this work was done in #1091 and #1125 by @dtacalau. I had a hard time rebasing the last pr on master and created this pr.

Closes #1125