### PR TITLE
Update UDP example

### DIFF
--- a/examples/tcp_server.rs
+++ b/examples/tcp_server.rs
@@ -21,7 +21,7 @@ fn main() -> io::Result<()> {
     let mut events = Events::with_capacity(128);
 
     // Setup the TCP server socket.
-    let addr = "127.0.0.1:13265".parse().unwrap();
+    let addr = "127.0.0.1:9000".parse().unwrap();
     let server = TcpListener::bind(addr)?;
 
     // Register the server with poll we can receive events for it.
@@ -34,7 +34,7 @@ fn main() -> io::Result<()> {
     let mut unique_token = Token(SERVER.0 + 1);
 
     println!("You can connect to the server using `nc`:");
-    println!(" $ nc 127.0.0.1 13265");
+    println!(" $ nc 127.0.0.1 9000");
     println!("You'll see our welcome message and anything you type we'll be printed here.");
 
     loop {

--- a/examples/udp_server.rs
+++ b/examples/udp_server.rs
@@ -1,58 +1,71 @@
-use mio::net::UdpSocket;
-use mio::{Events, Interests, Poll, Token};
 use std::io;
 
-const IN: Token = Token(0);
+use mio::net::UdpSocket;
+use mio::{Events, Interests, Poll, Token};
+
+// A token to allow us to identify which event is for the `UdpSocket`.
+const UDP_SOCKET: Token = Token(0);
 
 fn main() -> io::Result<()> {
-    // Set up a new socket on port 9000 to listen on.
-    let socket = UdpSocket::bind("0.0.0.0:9000".parse().unwrap())?;
-    // Initialize poller.
-    let mut poll = Poll::new()?;
-    // Register our socket with the token IN (defined above) and an interest
-    // in being `READABLE`.
-    poll.registry().register(&socket, IN, Interests::READABLE)?;
+    env_logger::init();
 
-    // Prepare a buffer for the number of events we can handle at a time.
-    // Someone might wat to echo really fast so lets give it some size.
-    let mut events = Events::with_capacity(1024);
-    // Initialize a buffer for the UDP datagram
-    let mut buf = [0; 65535];
-    // Main loop
+    // Create a poll instance.
+    let mut poll = Poll::new()?;
+    // Create storage for events. Since we will only register a single socket, a
+    // capacity of 1 will do.
+    let mut events = Events::with_capacity(1);
+
+    // Setup the UDP socket.
+    let addr = "127.0.0.1:9000".parse().unwrap();
+    let socket = UdpSocket::bind(addr)?;
+
+    // Register our socket with the token defined above and an interest in being
+    // `READABLE`.
+    poll.registry()
+        .register(&socket, UDP_SOCKET, Interests::READABLE)?;
+
+    println!("You can connect to the server using `nc`:");
+    println!(" $ nc -u 127.0.0.1 9000");
+    println!("Anything you type will be echoed back to you.");
+
+    // Initialize a buffer for the UDP packet. We use the maximum size of a UDP
+    // packet, which is the maximum value of 16 a bit integer.
+    let mut buf = [0; 1 << 16];
+
+    // Our event loop.
     loop {
-        // Poll if we have events waiting for us on the socket.
+        // Poll to check if we have events waiting for us.
         poll.poll(&mut events, None)?;
-        // If we do iterate throuigh them
+
+        // Process each event.
         for event in events.iter() {
             // Validate the token we registered our socket with,
             // in this example it will only ever be one but we
             // make sure it's valid none the less.
             match event.token() {
-                IN => loop {
-                    // In this loop we receive from the socket as long as we
-                    // can read data
+                UDP_SOCKET => loop {
+                    // In this loop we receive all packets queued for the socket.
                     match socket.recv_from(&mut buf) {
-                        Ok((n, from_addr)) => {
-                            // Send the data right back from where it came from.
-                            socket.send_to(&buf[..n], from_addr)?;
+                        Ok((packet_size, source_address)) => {
+                            // Echo the data.
+                            socket.send_to(&buf[..packet_size], source_address)?;
+                        }
+                        Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                            // If we get a `WouldBlock` error we know our socket
+                            // has no more packets queued, so we can return to
+                            // polling and wait for some more.
+                            break;
                         }
                         Err(e) => {
-                            // If we failed to receive data we have two cases
-                            if e.kind() == io::ErrorKind::WouldBlock {
-                                // If the reason was `WouldBlock` we know
-                                // our socket has no more data to give so
-                                // we can return to the poll to wait politely.
-                                break;
-                            } else {
-                                // If it was any other kind of error, something
-                                // went wrong and we terminate with an error.
-                                return Err(e);
-                            }
+                            // If it was any other kind of error, something went
+                            // wrong and we terminate with an error.
+                            return Err(e);
                         }
                     }
                 },
-                // We only have IN as a token, so this should never ever be hit
-                _ => unreachable!(),
+                // This should never happen as we only registered our
+                // `UdpSocket` using the `UDP_SOCKET` token.
+                _ => {}
             }
         }
     }

--- a/examples/udp_server.rs
+++ b/examples/udp_server.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+use log::warn;
 use mio::net::UdpSocket;
 use mio::{Events, Interests, Poll, Token};
 
@@ -63,9 +64,12 @@ fn main() -> io::Result<()> {
                         }
                     }
                 },
-                // This should never happen as we only registered our
-                // `UdpSocket` using the `UDP_SOCKET` token.
-                _ => {}
+                _ => {
+                    // This should never happen as we only registered our
+                    // `UdpSocket` using the `UDP_SOCKET` token, but if it ever
+                    // does we'll log it.
+                    warn!("Got event for unexpected token: {:?}", event);
+                }
             }
         }
     }


### PR DESCRIPTION
Changes the structure a bit to match the TCP server example. Enables
logging and prints how the server can be accessed, also matching the TCP
server example