### PR TITLE
fixed issue #1080, re-enable failing udp tests on windows

### DIFF
--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -228,6 +228,14 @@ impl UdpSocket {
     /// Receives data from the socket. On success, returns the number of bytes
     /// read and the address from whence the data came.
     ///
+    /// # Notes
+    ///
+    /// On Windows, if the data is larger than the buffer specified, the buffer
+    /// is filled with the first part of the data, and recv_from returns the error
+    /// WSAEMSGSIZE(10040). The excess data is lost.
+    /// Make sure to always use a sufficiently large buffer to hold the
+    /// maximum UDP packet size, which can be up to 64 kilobytes in size.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -255,6 +263,14 @@ impl UdpSocket {
     /// Receives data from the socket, without removing it from the input queue.
     /// On success, returns the number of bytes read and the address from whence
     /// the data came.
+    ///
+    /// # Notes
+    ///
+    /// On Windows, if the data is larger than the buffer specified, the buffer
+    /// is filled with the first part of the data, and peek_from returns the error
+    /// WSAEMSGSIZE(10040). The excess data is lost.
+    /// Make sure to always use a sufficiently large buffer to hold the
+    /// maximum UDP packet size, which can be up to 64 kilobytes in size.
     ///
     /// # Examples
     ///
@@ -288,12 +304,28 @@ impl UdpSocket {
 
     /// Receives data from the socket previously bound with connect(). On success, returns
     /// the number of bytes read.
+    ///
+    /// # Notes
+    ///
+    /// On Windows, if the data is larger than the buffer specified, the buffer
+    /// is filled with the first part of the data, and recv returns the error
+    /// WSAEMSGSIZE(10040). The excess data is lost.
+    /// Make sure to always use a sufficiently large buffer to hold the
+    /// maximum UDP packet size, which can be up to 64 kilobytes in size.
     pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.sys.recv(buf)
     }
 
     /// Receives data from the socket, without removing it from the input queue.
     /// On success, returns the number of bytes read.
+    ///
+    /// # Notes
+    ///
+    /// On Windows, if the data is larger than the buffer specified, the buffer
+    /// is filled with the first part of the data, and peek returns the error
+    /// WSAEMSGSIZE(10040). The excess data is lost.
+    /// Make sure to always use a sufficiently large buffer to hold the
+    /// maximum UDP packet size, which can be up to 64 kilobytes in size.
     pub fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.sys.peek(buf)
     }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -234,7 +234,7 @@ impl UdpSocket {
     /// is filled with the first part of the data, and recv_from returns the error
     /// WSAEMSGSIZE(10040). The excess data is lost.
     /// Make sure to always use a sufficiently large buffer to hold the
-    /// maximum UDP packet size, which can be up to 64 kilobytes in size.
+    /// maximum UDP packet size, which can be up to 65536 bytes in size.
     ///
     /// # Examples
     ///
@@ -270,7 +270,7 @@ impl UdpSocket {
     /// is filled with the first part of the data, and peek_from returns the error
     /// WSAEMSGSIZE(10040). The excess data is lost.
     /// Make sure to always use a sufficiently large buffer to hold the
-    /// maximum UDP packet size, which can be up to 64 kilobytes in size.
+    /// maximum UDP packet size, which can be up to 65536 bytes in size.
     ///
     /// # Examples
     ///
@@ -311,7 +311,7 @@ impl UdpSocket {
     /// is filled with the first part of the data, and recv returns the error
     /// WSAEMSGSIZE(10040). The excess data is lost.
     /// Make sure to always use a sufficiently large buffer to hold the
-    /// maximum UDP packet size, which can be up to 64 kilobytes in size.
+    /// maximum UDP packet size, which can be up to 65536 bytes in size.
     pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.sys.recv(buf)
     }
@@ -325,7 +325,7 @@ impl UdpSocket {
     /// is filled with the first part of the data, and peek returns the error
     /// WSAEMSGSIZE(10040). The excess data is lost.
     /// Make sure to always use a sufficiently large buffer to hold the
-    /// maximum UDP packet size, which can be up to 64 kilobytes in size.
+    /// maximum UDP packet size, which can be up to 65536 bytes in size.
     pub fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.sys.peek(buf)
     }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -172,8 +172,8 @@ pub fn assert_error<T, E: fmt::Display>(result: Result<T, E>, expected_msg: &str
         Err(err) => assert!(
             err.to_string().contains(expected_msg),
             "wanted: {}, got: {}",
+            expected_msg,
             err,
-            expected_msg
         ),
     }
 }


### PR DESCRIPTION
Fixes issues #1080 & #1131.

Couple of fixes two re-enable two udp tests which were failing on windows.
Added two new tests to check ET for UDP sockets, tests rely on a WouldBlock recv(_from) to reregister the socket and reset the interests.
Added  a note in the read/peek(_from) docs that on Windows reading with a too small a buffer will return an error. 

No need to emulate edge-triggers for UDP sockets by doing reregister on partial reads/write.