### PR TITLE
chore: prepare v0.6.21 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.6.21 (November 27, 2019)
+
+### Fixed
+- remove `=` dependency on `cfg-if`.
+
 # 0.6.20 (November 21, 2019)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ name          = "mio"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create git tag
-version       = "0.6.20"
+version       = "0.6.21"
 license       = "MIT"
 authors       = ["Carl Lerche <me@carllerche.com>"]
 description   = "Lightweight non-blocking IO"
-documentation = "https://docs.rs/mio/0.6.20/mio/"
+documentation = "https://docs.rs/mio/0.6.21/mio/"
 homepage      = "https://github.com/carllerche/mio"
 repository    = "https://github.com/carllerche/mio"
 readme        = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/mio/0.6.20")]
+#![doc(html_root_url = "https://docs.rs/mio/0.6.21")]
 // Mio targets old versions of the Rust compiler. In order to do this, uses
 // deprecated APIs.
 #![allow(bare_trait_objects, deprecated, unknown_lints)]


### PR DESCRIPTION
Removes the hard `=` from the cfg-if dependency.