### PR TITLE
Reverted reregistering on partial read/write for TcpStream. 

### DIFF
--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -35,19 +35,6 @@ macro_rules! try_io {
         }
         result
     }};
-    ($self: ident.$method: ident ( $($arg: expr),* $(,)* ), $reregister_check: expr)  => {{
-        let result = (&$self.inner).$method($($arg),*);
-        let should_reregister = match &result {
-            // See if we need reregister interest to emulate edge-triggers.
-            Ok(ok) => $reregister_check(ok),
-            Err(err) if err.kind() == io::ErrorKind::WouldBlock => true,
-            Err(_) => false,
-        };
-        if should_reregister {
-            $self.io_blocked_reregister()?;
-        }
-        result
-    }};
 }
 
 mod afd;

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -342,8 +342,6 @@ impl TcpListener {
 
     pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
         try_io!(self, accept).and_then(|(inner, addr)| {
-            // intentionally ignore result of reregister and return the stream no matter what
-            let _ = self.io_blocked_reregister();
             inner.set_nonblocking(true).map(|()| {
                 (
                     TcpStream {

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -195,27 +195,21 @@ impl<'a> super::SocketState for &'a TcpStream {
 
 impl<'a> Read for &'a TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        try_io!(self.read(buf), |bytes_read: &usize| *bytes_read
-            <= buf.len())
+        try_io!(self, read, buf)
     }
 
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-        try_io!(self.read_vectored(bufs), |bytes_read: &usize| *bytes_read
-            <= bufs.iter().map(|b| b.len()).sum())
+        try_io!(self, read_vectored, bufs)
     }
 }
 
 impl<'a> Write for &'a TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        try_io!(self.write(buf), |bytes_written: &usize| *bytes_written
-            <= buf.len())
+        try_io!(self, write, buf)
     }
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        try_io!(
-            self.write_vectored(bufs),
-            |bytes_written: &usize| *bytes_written <= bufs.iter().map(|b| b.len()).sum()
-        )
+        try_io!(self, write_vectored, bufs)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/tests/tcp_listener.rs
+++ b/tests/tcp_listener.rs
@@ -372,6 +372,8 @@ fn tcp_listener_two_streams() {
         assert_eq!(stream.local_addr().unwrap(), address);
     }
 
+    assert_would_block(listener.accept());
+
     let thread_handle2 = start_connections(address, 1, barrier.clone());
 
     expect_events(

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -98,6 +98,8 @@ where
 
     assert!(stream.take_error().unwrap().is_none());
 
+    assert_would_block(stream.read(&mut buf));
+
     let bufs = [IoSlice::new(&DATA1), IoSlice::new(&DATA2)];
     let n = stream
         .write_vectored(&bufs)


### PR DESCRIPTION
Mio guarantee is that, after you get a WouldBlock, you will receive a readiness notification, so, you always have to perform the operation you care about, receive would block, then wait for the readiness event.

A WouldBlock read doing reregister is enough to fix the TcpStream test failing on Windows. More details in this issue https://github.com/tokio-rs/mio/issues/1131#issuecomment-559179472

Signed-off-by: Daniel Tacalau <dst4096@gmail.com>