### PR TITLE
Change event::Source to take &mut (instead of &self)

### DIFF
--- a/examples/udp_server.rs
+++ b/examples/udp_server.rs
@@ -18,12 +18,12 @@ fn main() -> io::Result<()> {
 
     // Setup the UDP socket.
     let addr = "127.0.0.1:9000".parse().unwrap();
-    let socket = UdpSocket::bind(addr)?;
+    let mut socket = UdpSocket::bind(addr)?;
 
     // Register our socket with the token defined above and an interest in being
     // `READABLE`.
     poll.registry()
-        .register(&socket, UDP_SOCKET, Interest::READABLE)?;
+        .register(&mut socket, UDP_SOCKET, Interest::READABLE)?;
 
     println!("You can connect to the server using `nc`:");
     println!(" $ nc -u 127.0.0.1 9000");

--- a/src/event/source.rs
+++ b/src/event/source.rs
@@ -1,7 +1,7 @@
 use crate::{Interest, Registry, Token};
 
 use std::io;
-use std::ops::Deref;
+use std::ops::DerefMut;
 
 /// An event source that may be registered with [`Registry`].
 ///
@@ -52,21 +52,21 @@ use std::ops::Deref;
 /// }
 ///
 /// impl Source for MySource {
-///     fn register(&self, registry: &Registry, token: Token, interests: Interest)
+///     fn register(&mut self, registry: &Registry, token: Token, interests: Interest)
 ///         -> io::Result<()>
 ///     {
 ///         // Delegate the `register` call to `socket`
 ///         self.socket.register(registry, token, interests)
 ///     }
 ///
-///     fn reregister(&self, registry: &Registry, token: Token, interests: Interest)
+///     fn reregister(&mut self, registry: &Registry, token: Token, interests: Interest)
 ///         -> io::Result<()>
 ///     {
 ///         // Delegate the `reregister` call to `socket`
 ///         self.socket.reregister(registry, token, interests)
 ///     }
 ///
-///     fn deregister(&self, registry: &Registry) -> io::Result<()> {
+///     fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
 ///         // Delegate the `deregister` call to `socket`
 ///         self.socket.deregister(registry)
 ///     }
@@ -80,7 +80,12 @@ pub trait Source {
     /// to another `Source` type.
     ///
     /// [`Registry::register`]: crate::Registry::register
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()>;
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()>;
 
     /// Re-register `self` with the given `Registry` instance.
     ///
@@ -89,7 +94,12 @@ pub trait Source {
     /// re-registration by either delegating the call to another `Source` type.
     ///
     /// [`Registry::reregister`]: crate::Registry::reregister
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()>;
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()>;
 
     /// Deregister `self` from the given `Registry` instance.
     ///
@@ -98,23 +108,33 @@ pub trait Source {
     /// deregistration by delegating the call to another `Source` type.
     ///
     /// [`Registry::deregister`]: crate::Registry::deregister
-    fn deregister(&self, registry: &Registry) -> io::Result<()>;
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()>;
 }
 
 impl<T, S> Source for T
 where
-    T: Deref<Target = S>,
+    T: DerefMut<Target = S>,
     S: Source + ?Sized,
 {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
-        self.deref().register(registry, token, interests)
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        self.deref_mut().register(registry, token, interests)
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
-        self.deref().reregister(registry, token, interests)
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        self.deref_mut().reregister(registry, token, interests)
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
-        self.deref().deregister(registry)
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        self.deref_mut().deregister(registry)
     }
 }

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -23,13 +23,13 @@ use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket}
 /// use mio::net::TcpListener;
 /// use std::time::Duration;
 ///
-/// let listener = TcpListener::bind("127.0.0.1:34255".parse()?)?;
+/// let mut listener = TcpListener::bind("127.0.0.1:34255".parse()?)?;
 ///
 /// let mut poll = Poll::new()?;
 /// let mut events = Events::with_capacity(128);
 ///
 /// // Register the socket with `Poll`
-/// poll.registry().register(&listener, Token(0), Interest::READABLE)?;
+/// poll.registry().register(&mut listener, Token(0), Interest::READABLE)?;
 ///
 /// poll.poll(&mut events, Some(Duration::from_millis(100)))?;
 ///
@@ -136,17 +136,27 @@ impl TcpListener {
 }
 
 impl event::Source for TcpListener {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         #[cfg(debug_assertions)]
         self.selector_id.associate_selector(registry)?;
         self.sys.register(registry, token, interests)
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         self.sys.reregister(registry, token, interests)
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         self.sys.deregister(registry)
     }
 }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -27,13 +27,13 @@ use crate::{event, sys, Interest, Registry, Token};
 /// use mio::net::TcpStream;
 /// use std::time::Duration;
 ///
-/// let stream = TcpStream::connect("127.0.0.1:34254".parse()?)?;
+/// let mut stream = TcpStream::connect("127.0.0.1:34254".parse()?)?;
 ///
 /// let mut poll = Poll::new()?;
 /// let mut events = Events::with_capacity(128);
 ///
 /// // Register the socket with `Poll`
-/// poll.registry().register(&stream, Token(0), Interest::WRITABLE)?;
+/// poll.registry().register(&mut stream, Token(0), Interest::WRITABLE)?;
 ///
 /// poll.poll(&mut events, Some(Duration::from_millis(100)))?;
 ///
@@ -252,17 +252,27 @@ impl<'a> Write for &'a TcpStream {
 }
 
 impl event::Source for TcpStream {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         #[cfg(debug_assertions)]
         self.selector_id.associate_selector(registry)?;
         self.sys.register(registry, token, interests)
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         self.sys.reregister(registry, token, interests)
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         self.sys.deregister(registry)
     }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -45,8 +45,8 @@ use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket}
 ///
 /// // This operation will fail if the address is in use, so we select different ports for each
 /// // socket.
-/// let sender_socket = UdpSocket::bind("127.0.0.1:0".parse()?)?;
-/// let echoer_socket = UdpSocket::bind("127.0.0.1:0".parse()?)?;
+/// let mut sender_socket = UdpSocket::bind("127.0.0.1:0".parse()?)?;
+/// let mut echoer_socket = UdpSocket::bind("127.0.0.1:0".parse()?)?;
 ///
 /// // If we do not use connect here, SENDER and ECHOER would need to call send_to and recv_from
 /// // respectively.
@@ -57,8 +57,8 @@ use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket}
 /// let mut poll = Poll::new()?;
 ///
 /// // We register our sockets here so that we can check if they are ready to be written/read.
-/// poll.registry().register(&sender_socket, SENDER, Interest::WRITABLE)?;
-/// poll.registry().register(&echoer_socket, ECHOER, Interest::READABLE)?;
+/// poll.registry().register(&mut sender_socket, SENDER, Interest::WRITABLE)?;
+/// poll.registry().register(&mut echoer_socket, ECHOER, Interest::READABLE)?;
 ///
 /// let msg_to_send = [9; 9];
 /// let mut buffer = [0; 9];
@@ -550,17 +550,27 @@ impl UdpSocket {
 }
 
 impl event::Source for UdpSocket {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         #[cfg(debug_assertions)]
         self.selector_id.associate_selector(registry)?;
         self.sys.register(registry, token, interests)
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         self.sys.reregister(registry, token, interests)
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         self.sys.deregister(registry)
     }
 }

--- a/src/net/uds/datagram.rs
+++ b/src/net/uds/datagram.rs
@@ -1,7 +1,6 @@
-use crate::event::Source;
 #[cfg(debug_assertions)]
 use crate::poll::SelectorId;
-use crate::{sys, Interest, Registry, Token};
+use crate::{event, sys, Interest, Registry, Token};
 
 use std::io;
 use std::net::Shutdown;
@@ -135,18 +134,28 @@ impl UnixDatagram {
     }
 }
 
-impl Source for UnixDatagram {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+impl event::Source for UnixDatagram {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         #[cfg(debug_assertions)]
         self.selector_id.associate_selector(registry)?;
         self.sys.register(registry, token, interests)
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         self.sys.reregister(registry, token, interests)
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         self.sys.deregister(registry)
     }
 }

--- a/src/net/uds/listener.rs
+++ b/src/net/uds/listener.rs
@@ -1,9 +1,8 @@
-use crate::event::Source;
 use crate::net::UnixStream;
 #[cfg(debug_assertions)]
 use crate::poll::SelectorId;
 use crate::unix::SocketAddr;
-use crate::{sys, Interest, Registry, Token};
+use crate::{event, sys, Interest, Registry, Token};
 
 use std::io;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -78,18 +77,28 @@ impl UnixListener {
     }
 }
 
-impl Source for UnixListener {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+impl event::Source for UnixListener {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         #[cfg(debug_assertions)]
         self.selector_id.associate_selector(registry)?;
         self.sys.register(registry, token, interests)
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         self.sys.reregister(registry, token, interests)
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         self.sys.deregister(registry)
     }
 }

--- a/src/net/uds/stream.rs
+++ b/src/net/uds/stream.rs
@@ -1,7 +1,6 @@
-use crate::event::Source;
 #[cfg(debug_assertions)]
 use crate::poll::SelectorId;
-use crate::{sys, Interest, Registry, Token};
+use crate::{event, sys, Interest, Registry, Token};
 
 use std::io::{self, IoSlice, IoSliceMut};
 use std::net::Shutdown;
@@ -99,18 +98,28 @@ impl UnixStream {
     }
 }
 
-impl Source for UnixStream {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+impl event::Source for UnixStream {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         #[cfg(debug_assertions)]
         self.selector_id.associate_selector(registry)?;
         self.sys.register(registry, token, interests)
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         self.sys.reregister(registry, token, interests)
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         self.sys.deregister(registry)
     }
 }

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -662,12 +662,12 @@ fn does_not_register_rw() {
     use crate::{Poll, Token};
 
     let kq = unsafe { libc::kqueue() };
-    let kqf = SourceFd(&kq);
+    let mut kqf = SourceFd(&kq);
     let poll = Poll::new().unwrap();
 
     // Registering kqueue fd will fail if write is requested (On anything but
     // some versions of macOS).
     poll.registry()
-        .register(&kqf, Token(1234), Interest::READABLE)
+        .register(&mut kqf, Token(1234), Interest::READABLE)
         .unwrap();
 }

--- a/src/sys/unix/sourcefd.rs
+++ b/src/sys/unix/sourcefd.rs
@@ -41,7 +41,7 @@ use std::os::unix::io::RawFd;
 ///
 /// // Register the listener
 /// poll.registry().register(
-///     &SourceFd(&listener.as_raw_fd()),
+///     &mut SourceFd(&listener.as_raw_fd()),
 ///     Token(0),
 ///     Interest::READABLE)?;
 /// #     Ok(())
@@ -63,19 +63,19 @@ use std::os::unix::io::RawFd;
 /// }
 ///
 /// impl event::Source for MyIo {
-///     fn register(&self, registry: &Registry, token: Token, interests: Interest)
+///     fn register(&mut self, registry: &Registry, token: Token, interests: Interest)
 ///         -> io::Result<()>
 ///     {
 ///         SourceFd(&self.fd).register(registry, token, interests)
 ///     }
 ///
-///     fn reregister(&self, registry: &Registry, token: Token, interests: Interest)
+///     fn reregister(&mut self, registry: &Registry, token: Token, interests: Interest)
 ///         -> io::Result<()>
 ///     {
 ///         SourceFd(&self.fd).reregister(registry, token, interests)
 ///     }
 ///
-///     fn deregister(&self, registry: &Registry) -> io::Result<()> {
+///     fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
 ///         SourceFd(&self.fd).deregister(registry)
 ///     }
 /// }
@@ -84,15 +84,25 @@ use std::os::unix::io::RawFd;
 pub struct SourceFd<'a>(pub &'a RawFd);
 
 impl<'a> event::Source for SourceFd<'a> {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         poll::selector(registry).register(*self.0, token, interests)
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         poll::selector(registry).reregister(*self.0, token, interests)
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         poll::selector(registry).deregister(*self.0)
     }
 }

--- a/src/sys/unix/tcp/listener.rs
+++ b/src/sys/unix/tcp/listener.rs
@@ -74,15 +74,25 @@ impl TcpListener {
 }
 
 impl event::Source for TcpListener {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).register(registry, token, interests)
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).reregister(registry, token, interests)
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).deregister(registry)
     }
 }

--- a/src/sys/unix/tcp/stream.rs
+++ b/src/sys/unix/tcp/stream.rs
@@ -109,15 +109,25 @@ impl<'a> Write for &'a TcpStream {
 }
 
 impl event::Source for TcpStream {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).register(registry, token, interests)
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).reregister(registry, token, interests)
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).deregister(registry)
     }
 }

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -146,15 +146,25 @@ impl UdpSocket {
 }
 
 impl event::Source for UdpSocket {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).register(registry, token, interests)
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).reregister(registry, token, interests)
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).deregister(registry)
     }
 }

--- a/src/sys/unix/uds/datagram.rs
+++ b/src/sys/unix/uds/datagram.rs
@@ -1,8 +1,7 @@
 use super::{socket_addr, SocketAddr};
-use crate::event::Source;
 use crate::sys::unix::net::new_socket;
 use crate::unix::SourceFd;
-use crate::{Interest, Registry, Token};
+use crate::{event, Interest, Registry, Token};
 
 use std::io;
 use std::net::Shutdown;
@@ -129,16 +128,26 @@ impl UnixDatagram {
     }
 }
 
-impl Source for UnixDatagram {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+impl event::Source for UnixDatagram {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).register(registry, token, interests)
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).reregister(registry, token, interests)
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).deregister(registry)
     }
 }

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -1,9 +1,8 @@
 use super::{path_offset, socket_addr};
-use crate::event::Source;
 use crate::sys::unix::net::new_socket;
 use crate::sys::unix::UnixStream;
 use crate::unix::SourceFd;
-use crate::{Interest, Registry, Token};
+use crate::{event, Interest, Registry, Token};
 
 use std::ffi::OsStr;
 use std::os::unix::ffi::OsStrExt;
@@ -133,16 +132,26 @@ impl UnixListener {
     }
 }
 
-impl Source for UnixListener {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+impl event::Source for UnixListener {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).register(registry, token, interests)
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).reregister(registry, token, interests)
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).deregister(registry)
     }
 }

--- a/src/sys/unix/uds/stream.rs
+++ b/src/sys/unix/uds/stream.rs
@@ -1,8 +1,7 @@
 use super::{socket_addr, SocketAddr};
-use crate::event::Source;
 use crate::sys::unix::net::new_socket;
 use crate::sys::unix::SourceFd;
-use crate::{Interest, Registry, Token};
+use crate::{event, Interest, Registry, Token};
 
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::Shutdown;
@@ -100,16 +99,26 @@ impl UnixStream {
     }
 }
 
-impl Source for UnixStream {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+impl event::Source for UnixStream {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).register(registry, token, interests)
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).reregister(registry, token, interests)
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         SourceFd(&self.as_raw_fd()).deregister(registry)
     }
 }

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -218,7 +218,12 @@ impl<'a> Write for &'a TcpStream {
 }
 
 impl event::Source for TcpStream {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         {
             let mut internal = self.internal.lock().unwrap();
             if internal.is_none() {
@@ -240,7 +245,12 @@ impl event::Source for TcpStream {
         result
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         let result = poll::selector(registry).reregister(self, token, interests);
         match result {
             Ok(_) => {
@@ -253,7 +263,7 @@ impl event::Source for TcpStream {
         result
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         let result = poll::selector(registry).deregister(self);
         match result {
             Ok(_) => {
@@ -410,7 +420,12 @@ impl super::SocketState for TcpListener {
 }
 
 impl event::Source for TcpListener {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         {
             let mut internal = self.internal.lock().unwrap();
             if internal.is_none() {
@@ -432,7 +447,12 @@ impl event::Source for TcpListener {
         result
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         let result = poll::selector(registry).reregister(self, token, interests);
         match result {
             Ok(_) => {
@@ -445,7 +465,7 @@ impl event::Source for TcpListener {
         result
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         let result = poll::selector(registry).deregister(self);
         match result {
             Ok(_) => {

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -194,7 +194,12 @@ impl super::SocketState for UdpSocket {
 }
 
 impl event::Source for UdpSocket {
-    fn register(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         {
             let mut internal = self.internal.lock().unwrap();
             if internal.is_none() {
@@ -216,7 +221,12 @@ impl event::Source for UdpSocket {
         result
     }
 
-    fn reregister(&self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         let result = poll::selector(registry).reregister(self, token, interests);
         match result {
             Ok(_) => {
@@ -229,7 +239,7 @@ impl event::Source for UdpSocket {
         result
     }
 
-    fn deregister(&self, registry: &Registry) -> io::Result<()> {
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         let result = poll::selector(registry).deregister(self);
         match result {
             Ok(_) => {

--- a/src/token.rs
+++ b/src/token.rs
@@ -44,10 +44,10 @@
 /// let mut poll = Poll::new()?;
 ///
 /// // Tcp listener
-/// let listener = TcpListener::bind("127.0.0.1:0".parse()?)?;
+/// let mut listener = TcpListener::bind("127.0.0.1:0".parse()?)?;
 ///
 /// // Register the listener
-/// poll.registry().register(&listener, LISTENER, Interest::READABLE)?;
+/// poll.registry().register(&mut listener, LISTENER, Interest::READABLE)?;
 ///
 /// // Spawn a thread that will connect a bunch of sockets then close them
 /// let addr = listener.local_addr()?;
@@ -79,7 +79,7 @@
 ///                 // encountered.
 ///                 loop {
 ///                     match listener.accept() {
-///                         Ok((socket, _)) => {
+///                         Ok((mut socket, _)) => {
 ///                             // Shutdown the server
 ///                             if next_socket_index == MAX_SOCKETS {
 ///                                 return Ok(());
@@ -90,7 +90,7 @@
 ///                             next_socket_index += 1;
 ///
 ///                             // Register the new socket w/ poll
-///                             poll.registry().register(&socket, token, Interest::READABLE)?;
+///                             poll.registry().register(&mut socket, token, Interest::READABLE)?;
 ///
 ///                             // Store the socket
 ///                             sockets.insert(token, socket);

--- a/tests/close_on_drop.rs
+++ b/tests/close_on_drop.rs
@@ -68,7 +68,7 @@ impl TestHandler {
             _ => panic!("received unknown token {:?}", tok),
         }
         poll.registry()
-            .reregister(&self.cli, CLIENT, Interest::READABLE)
+            .reregister(&mut self.cli, CLIENT, Interest::READABLE)
             .unwrap();
     }
 
@@ -78,7 +78,7 @@ impl TestHandler {
             CLIENT => {
                 debug!("client connected");
                 poll.registry()
-                    .reregister(&self.cli, CLIENT, Interest::READABLE)
+                    .reregister(&mut self.cli, CLIENT, Interest::READABLE)
                     .unwrap();
             }
             _ => panic!("received unknown token {:?}", tok),
@@ -93,18 +93,18 @@ pub fn close_on_drop() {
     let mut poll = Poll::new().unwrap();
 
     // == Create & setup server socket
-    let srv = TcpListener::bind(any_local_address()).unwrap();
+    let mut srv = TcpListener::bind(any_local_address()).unwrap();
     let addr = srv.local_addr().unwrap();
 
     poll.registry()
-        .register(&srv, SERVER, Interest::READABLE)
+        .register(&mut srv, SERVER, Interest::READABLE)
         .unwrap();
 
     // == Create & setup client socket
-    let sock = TcpStream::connect(addr).unwrap();
+    let mut sock = TcpStream::connect(addr).unwrap();
 
     poll.registry()
-        .register(&sock, CLIENT, Interest::WRITABLE)
+        .register(&mut sock, CLIENT, Interest::WRITABLE)
         .unwrap();
 
     // == Create storage for events

--- a/tests/event_source.rs
+++ b/tests/event_source.rs
@@ -1,6 +1,3 @@
-use std::rc::Rc;
-use std::sync::Arc;
-
 use mio::event;
 use mio::net::TcpStream;
 
@@ -10,8 +7,4 @@ fn assert_event_source_implemented_for() {
 
     assert_event_source::<Box<dyn event::Source>>();
     assert_event_source::<Box<TcpStream>>();
-    assert_event_source::<Arc<dyn event::Source>>();
-    assert_event_source::<Arc<TcpStream>>();
-    assert_event_source::<Rc<dyn event::Source>>();
-    assert_event_source::<Rc<TcpStream>>();
 }

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -27,7 +27,7 @@ fn issue_776() {
     let mut s = TcpStream::connect(addr).unwrap();
 
     poll.registry()
-        .register(&s, Token(1), Interest::READABLE | Interest::WRITABLE)
+        .register(&mut s, Token(1), Interest::READABLE | Interest::WRITABLE)
         .unwrap();
     let mut events = Events::with_capacity(16);
     'outer: loop {

--- a/tests/tcp_listener.rs
+++ b/tests/tcp_listener.rs
@@ -51,11 +51,11 @@ where
 {
     let (mut poll, mut events) = init_with_poll();
 
-    let listener = make_listener(addr).unwrap();
+    let mut listener = make_listener(addr).unwrap();
     let address = listener.local_addr().unwrap();
 
     poll.registry()
-        .register(&listener, ID1, Interest::READABLE)
+        .register(&mut listener, ID1, Interest::READABLE)
         .expect("unable to register TCP listener");
 
     let barrier = Arc::new(Barrier::new(2));
@@ -131,10 +131,10 @@ fn raw_fd() {
 fn registering() {
     let (mut poll, mut events) = init_with_poll();
 
-    let stream = TcpListener::bind(any_local_address()).unwrap();
+    let mut stream = TcpListener::bind(any_local_address()).unwrap();
 
     poll.registry()
-        .register(&stream, ID1, Interest::READABLE)
+        .register(&mut stream, ID1, Interest::READABLE)
         .expect("unable to register TCP listener");
 
     expect_no_events(&mut poll, &mut events);
@@ -146,14 +146,14 @@ fn registering() {
 fn reregister() {
     let (mut poll, mut events) = init_with_poll();
 
-    let listener = TcpListener::bind(any_local_address()).unwrap();
+    let mut listener = TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
     poll.registry()
-        .register(&listener, ID1, Interest::READABLE)
+        .register(&mut listener, ID1, Interest::READABLE)
         .unwrap();
     poll.registry()
-        .reregister(&listener, ID2, Interest::READABLE)
+        .reregister(&mut listener, ID2, Interest::READABLE)
         .unwrap();
 
     let barrier = Arc::new(Barrier::new(2));
@@ -182,17 +182,17 @@ fn reregister() {
 fn no_events_after_deregister() {
     let (mut poll, mut events) = init_with_poll();
 
-    let listener = TcpListener::bind(any_local_address()).unwrap();
+    let mut listener = TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
     poll.registry()
-        .register(&listener, ID1, Interest::READABLE)
+        .register(&mut listener, ID1, Interest::READABLE)
         .unwrap();
 
     let barrier = Arc::new(Barrier::new(2));
     let thread_handle = start_connections(address, 1, barrier.clone());
 
-    poll.registry().deregister(&listener).unwrap();
+    poll.registry().deregister(&mut listener).unwrap();
 
     expect_no_events(&mut poll, &mut events);
 
@@ -215,8 +215,8 @@ fn no_events_after_deregister() {
 fn try_clone_same_poll() {
     let (mut poll, mut events) = init_with_poll();
 
-    let listener1 = TcpListener::bind(any_local_address()).unwrap();
-    let listener2 = listener1.try_clone().expect("unable to clone TCP listener");
+    let mut listener1 = TcpListener::bind(any_local_address()).unwrap();
+    let mut listener2 = listener1.try_clone().expect("unable to clone TCP listener");
     #[cfg(unix)]
     assert_ne!(listener1.as_raw_fd(), listener2.as_raw_fd());
     let address = listener1.local_addr().unwrap();
@@ -226,10 +226,10 @@ fn try_clone_same_poll() {
     let thread_handle1 = start_connections(address, 1, barrier.clone());
 
     poll.registry()
-        .register(&listener1, ID1, Interest::READABLE)
+        .register(&mut listener1, ID1, Interest::READABLE)
         .unwrap();
     poll.registry()
-        .register(&listener2, ID2, Interest::READABLE)
+        .register(&mut listener2, ID2, Interest::READABLE)
         .unwrap();
 
     expect_events(
@@ -279,8 +279,8 @@ fn try_clone_different_poll() {
     let (mut poll1, mut events) = init_with_poll();
     let mut poll2 = Poll::new().unwrap();
 
-    let listener1 = TcpListener::bind(any_local_address()).unwrap();
-    let listener2 = listener1.try_clone().expect("unable to clone TCP listener");
+    let mut listener1 = TcpListener::bind(any_local_address()).unwrap();
+    let mut listener2 = listener1.try_clone().expect("unable to clone TCP listener");
     #[cfg(unix)]
     assert_ne!(listener1.as_raw_fd(), listener2.as_raw_fd());
     let address = listener1.local_addr().unwrap();
@@ -291,11 +291,11 @@ fn try_clone_different_poll() {
 
     poll1
         .registry()
-        .register(&listener1, ID1, Interest::READABLE)
+        .register(&mut listener1, ID1, Interest::READABLE)
         .unwrap();
     poll2
         .registry()
-        .register(&listener2, ID2, Interest::READABLE)
+        .register(&mut listener2, ID2, Interest::READABLE)
         .unwrap();
 
     expect_events(
@@ -348,7 +348,7 @@ fn try_clone_different_poll() {
 fn tcp_listener_two_streams() {
     let (mut poll1, mut events) = init_with_poll();
 
-    let listener = TcpListener::bind(any_local_address()).unwrap();
+    let mut listener = TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
     let barrier = Arc::new(Barrier::new(3));
@@ -356,7 +356,7 @@ fn tcp_listener_two_streams() {
 
     poll1
         .registry()
-        .register(&listener, ID1, Interest::READABLE)
+        .register(&mut listener, ID1, Interest::READABLE)
         .unwrap();
 
     expect_events(

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -65,7 +65,7 @@ where
     let mut stream = make_stream(addr).unwrap();
 
     poll.registry()
-        .register(&stream, ID1, Interest::WRITABLE.add(Interest::READABLE))
+        .register(&mut stream, ID1, Interest::WRITABLE.add(Interest::READABLE))
         .expect("unable to register TCP stream");
 
     expect_events(
@@ -137,7 +137,7 @@ fn try_clone() {
     let mut stream1 = TcpStream::connect(address).unwrap();
 
     poll.registry()
-        .register(&stream1, ID1, Interest::WRITABLE)
+        .register(&mut stream1, ID1, Interest::WRITABLE)
         .expect("unable to register TCP stream");
 
     expect_events(
@@ -151,11 +151,11 @@ fn try_clone() {
     let mut stream2 = stream1.try_clone().unwrap();
 
     // When using `try_clone` the `TcpStream` needs to be deregistered!
-    poll.registry().deregister(&stream1).unwrap();
+    poll.registry().deregister(&mut stream1).unwrap();
     drop(stream1);
 
     poll.registry()
-        .register(&stream2, ID2, Interest::READABLE)
+        .register(&mut stream2, ID2, Interest::READABLE)
         .expect("unable to register TCP stream");
 
     expect_events(
@@ -178,13 +178,13 @@ fn set_get_ttl() {
     let barrier = Arc::new(Barrier::new(2));
     let (thread_handle, address) = start_listener(1, Some(barrier.clone()), false);
 
-    let stream = TcpStream::connect(address).unwrap();
+    let mut stream = TcpStream::connect(address).unwrap();
 
     // on Windows: the stream must be connected before setting the ttl, otherwise
     // it is undefined behavior, register and expect a WRITABLE here to make sure
     // the stream is connected
     poll.registry()
-        .register(&stream, ID1, Interest::WRITABLE)
+        .register(&mut stream, ID1, Interest::WRITABLE)
         .expect("unable to register TCP stream");
 
     expect_events(
@@ -210,13 +210,13 @@ fn get_ttl_without_previous_set() {
     let barrier = Arc::new(Barrier::new(2));
     let (thread_handle, address) = start_listener(1, Some(barrier.clone()), false);
 
-    let stream = TcpStream::connect(address).unwrap();
+    let mut stream = TcpStream::connect(address).unwrap();
 
     // on Windows: the stream must be connected before getting the ttl, otherwise
     // it is undefined behavior, register and expect a WRITABLE here to make sure
     // the stream is connected
     poll.registry()
-        .register(&stream, ID1, Interest::WRITABLE)
+        .register(&mut stream, ID1, Interest::WRITABLE)
         .expect("unable to register TCP stream");
 
     expect_events(
@@ -240,13 +240,13 @@ fn set_get_nodelay() {
     let barrier = Arc::new(Barrier::new(2));
     let (thread_handle, address) = start_listener(1, Some(barrier.clone()), false);
 
-    let stream = TcpStream::connect(address).unwrap();
+    let mut stream = TcpStream::connect(address).unwrap();
 
     // on Windows: the stream must be connected before setting the nodelay, otherwise
     // it is undefined behavior, register and expect a WRITABLE here to make sure
     // the stream is connected
     poll.registry()
-        .register(&stream, ID1, Interest::WRITABLE)
+        .register(&mut stream, ID1, Interest::WRITABLE)
         .expect("unable to register TCP stream");
 
     expect_events(
@@ -272,13 +272,13 @@ fn get_nodelay_without_previous_set() {
     let barrier = Arc::new(Barrier::new(2));
     let (thread_handle, address) = start_listener(1, Some(barrier.clone()), false);
 
-    let stream = TcpStream::connect(address).unwrap();
+    let mut stream = TcpStream::connect(address).unwrap();
 
     // on Windows: the stream must be connected before setting the nodelay, otherwise
     // it is undefined behavior, register and expect a WRITABLE here to make sure
     // the stream is connected
     poll.registry()
-        .register(&stream, ID1, Interest::WRITABLE)
+        .register(&mut stream, ID1, Interest::WRITABLE)
         .expect("unable to register TCP stream");
 
     expect_events(
@@ -306,7 +306,7 @@ fn shutdown_read() {
     let mut stream = TcpStream::connect(address).unwrap();
 
     poll.registry()
-        .register(&stream, ID1, Interest::WRITABLE.add(Interest::READABLE))
+        .register(&mut stream, ID1, Interest::WRITABLE.add(Interest::READABLE))
         .expect("unable to register TCP stream");
 
     expect_events(
@@ -354,7 +354,7 @@ fn shutdown_write() {
     let mut stream = TcpStream::connect(address).unwrap();
 
     poll.registry()
-        .register(&stream, ID1, Interest::WRITABLE.add(Interest::READABLE))
+        .register(&mut stream, ID1, Interest::WRITABLE.add(Interest::READABLE))
         .expect("unable to register TCP stream");
 
     expect_events(
@@ -394,7 +394,7 @@ fn shutdown_both() {
     let mut stream = TcpStream::connect(address).unwrap();
 
     poll.registry()
-        .register(&stream, ID1, Interest::WRITABLE.add(Interest::READABLE))
+        .register(&mut stream, ID1, Interest::WRITABLE.add(Interest::READABLE))
         .expect("unable to register TCP stream");
 
     expect_events(
@@ -465,10 +465,10 @@ fn registering() {
 
     let (thread_handle, address) = echo_listener(any_local_address(), 1);
 
-    let stream = TcpStream::connect(address).unwrap();
+    let mut stream = TcpStream::connect(address).unwrap();
 
     poll.registry()
-        .register(&stream, ID1, Interest::READABLE)
+        .register(&mut stream, ID1, Interest::READABLE)
         .expect("unable to register TCP stream");
 
     expect_no_events(&mut poll, &mut events);
@@ -485,14 +485,14 @@ fn reregistering() {
 
     let (thread_handle, address) = echo_listener(any_local_address(), 1);
 
-    let stream = TcpStream::connect(address).unwrap();
+    let mut stream = TcpStream::connect(address).unwrap();
 
     poll.registry()
-        .register(&stream, ID1, Interest::READABLE)
+        .register(&mut stream, ID1, Interest::READABLE)
         .expect("unable to register TCP stream");
 
     poll.registry()
-        .reregister(&stream, ID2, Interest::WRITABLE)
+        .reregister(&mut stream, ID2, Interest::WRITABLE)
         .expect("unable to reregister TCP stream");
 
     expect_events(
@@ -516,11 +516,11 @@ fn no_events_after_deregister() {
     let mut stream = TcpStream::connect(address).unwrap();
 
     poll.registry()
-        .register(&stream, ID1, Interest::WRITABLE.add(Interest::READABLE))
+        .register(&mut stream, ID1, Interest::WRITABLE.add(Interest::READABLE))
         .expect("unable to register TCP stream");
 
     poll.registry()
-        .deregister(&stream)
+        .deregister(&mut stream)
         .expect("unable to deregister TCP stream");
 
     expect_no_events(&mut poll, &mut events);
@@ -552,11 +552,13 @@ fn tcp_shutdown_client_read_close_event() {
     let barrier = Arc::new(Barrier::new(2));
 
     let (handle, sockaddr) = start_listener(1, Some(barrier.clone()), false);
-    let stream = TcpStream::connect(sockaddr).unwrap();
+    let mut stream = TcpStream::connect(sockaddr).unwrap();
 
     let interests = Interest::READABLE | Interest::WRITABLE;
 
-    poll.registry().register(&stream, ID1, interests).unwrap();
+    poll.registry()
+        .register(&mut stream, ID1, interests)
+        .unwrap();
 
     expect_events(
         &mut poll,
@@ -586,11 +588,13 @@ fn tcp_shutdown_client_write_close_event() {
     let barrier = Arc::new(Barrier::new(2));
 
     let (handle, sockaddr) = start_listener(1, Some(barrier.clone()), false);
-    let stream = TcpStream::connect(sockaddr).unwrap();
+    let mut stream = TcpStream::connect(sockaddr).unwrap();
 
     let interests = Interest::READABLE | Interest::WRITABLE;
 
-    poll.registry().register(&stream, ID1, interests).unwrap();
+    poll.registry()
+        .register(&mut stream, ID1, interests)
+        .unwrap();
 
     expect_events(
         &mut poll,
@@ -615,10 +619,10 @@ fn tcp_shutdown_server_write_close_event() {
     let barrier = Arc::new(Barrier::new(2));
 
     let (handle, sockaddr) = start_listener(1, Some(barrier.clone()), true);
-    let stream = TcpStream::connect(sockaddr).unwrap();
+    let mut stream = TcpStream::connect(sockaddr).unwrap();
 
     poll.registry()
-        .register(&stream, ID1, Interest::READABLE.add(Interest::WRITABLE))
+        .register(&mut stream, ID1, Interest::READABLE.add(Interest::WRITABLE))
         .unwrap();
 
     expect_events(
@@ -649,10 +653,10 @@ fn tcp_shutdown_client_both_close_event() {
     let barrier = Arc::new(Barrier::new(2));
 
     let (handle, sockaddr) = start_listener(1, Some(barrier.clone()), false);
-    let stream = TcpStream::connect(sockaddr).unwrap();
+    let mut stream = TcpStream::connect(sockaddr).unwrap();
 
     poll.registry()
-        .register(&stream, ID1, Interest::READABLE.add(Interest::WRITABLE))
+        .register(&mut stream, ID1, Interest::READABLE.add(Interest::WRITABLE))
         .unwrap();
 
     expect_events(

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -65,17 +65,25 @@ fn unconnected_udp_socket_std() {
     smoke_test_unconnected_udp_socket(socket1, socket2);
 }
 
-fn smoke_test_unconnected_udp_socket(socket1: UdpSocket, socket2: UdpSocket) {
+fn smoke_test_unconnected_udp_socket(mut socket1: UdpSocket, mut socket2: UdpSocket) {
     let (mut poll, mut events) = init_with_poll();
 
     let address1 = socket1.local_addr().unwrap();
     let address2 = socket2.local_addr().unwrap();
 
     poll.registry()
-        .register(&socket1, ID1, Interest::READABLE.add(Interest::WRITABLE))
+        .register(
+            &mut socket1,
+            ID1,
+            Interest::READABLE.add(Interest::WRITABLE),
+        )
         .expect("unable to register UDP socket");
     poll.registry()
-        .register(&socket2, ID2, Interest::READABLE.add(Interest::WRITABLE))
+        .register(
+            &mut socket2,
+            ID2,
+            Interest::READABLE.add(Interest::WRITABLE),
+        )
         .expect("unable to register UDP socket");
 
     expect_events(
@@ -182,14 +190,22 @@ fn connected_udp_socket_std() {
     smoke_test_connected_udp_socket(socket1, socket2);
 }
 
-fn smoke_test_connected_udp_socket(socket1: UdpSocket, socket2: UdpSocket) {
+fn smoke_test_connected_udp_socket(mut socket1: UdpSocket, mut socket2: UdpSocket) {
     let (mut poll, mut events) = init_with_poll();
 
     poll.registry()
-        .register(&socket1, ID1, Interest::READABLE.add(Interest::WRITABLE))
+        .register(
+            &mut socket1,
+            ID1,
+            Interest::READABLE.add(Interest::WRITABLE),
+        )
         .expect("unable to register UDP socket");
     poll.registry()
-        .register(&socket2, ID2, Interest::READABLE.add(Interest::WRITABLE))
+        .register(
+            &mut socket2,
+            ID2,
+            Interest::READABLE.add(Interest::WRITABLE),
+        )
         .expect("unable to register UDP socket");
 
     expect_events(
@@ -232,9 +248,9 @@ fn smoke_test_connected_udp_socket(socket1: UdpSocket, socket2: UdpSocket) {
 fn reconnect_udp_socket_sending() {
     let (mut poll, mut events) = init_with_poll();
 
-    let socket1 = UdpSocket::bind(any_local_address()).unwrap();
-    let socket2 = UdpSocket::bind(any_local_address()).unwrap();
-    let socket3 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket1 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket2 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket3 = UdpSocket::bind(any_local_address()).unwrap();
 
     let address1 = socket1.local_addr().unwrap();
     let address2 = socket2.local_addr().unwrap();
@@ -245,13 +261,17 @@ fn reconnect_udp_socket_sending() {
     socket3.connect(address1).unwrap();
 
     poll.registry()
-        .register(&socket1, ID1, Interest::READABLE.add(Interest::WRITABLE))
+        .register(
+            &mut socket1,
+            ID1,
+            Interest::READABLE.add(Interest::WRITABLE),
+        )
         .unwrap();
     poll.registry()
-        .register(&socket2, ID2, Interest::READABLE)
+        .register(&mut socket2, ID2, Interest::READABLE)
         .unwrap();
     poll.registry()
-        .register(&socket3, ID3, Interest::READABLE)
+        .register(&mut socket3, ID3, Interest::READABLE)
         .unwrap();
 
     expect_events(
@@ -291,9 +311,9 @@ fn reconnect_udp_socket_sending() {
 fn reconnect_udp_socket_receiving() {
     let (mut poll, mut events) = init_with_poll();
 
-    let socket1 = UdpSocket::bind(any_local_address()).unwrap();
-    let socket2 = UdpSocket::bind(any_local_address()).unwrap();
-    let socket3 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket1 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket2 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket3 = UdpSocket::bind(any_local_address()).unwrap();
 
     let address1 = socket1.local_addr().unwrap();
     let address2 = socket2.local_addr().unwrap();
@@ -304,13 +324,13 @@ fn reconnect_udp_socket_receiving() {
     socket3.connect(address1).unwrap();
 
     poll.registry()
-        .register(&socket1, ID1, Interest::READABLE)
+        .register(&mut socket1, ID1, Interest::READABLE)
         .unwrap();
     poll.registry()
-        .register(&socket2, ID2, Interest::WRITABLE)
+        .register(&mut socket2, ID2, Interest::WRITABLE)
         .unwrap();
     poll.registry()
-        .register(&socket3, ID3, Interest::WRITABLE)
+        .register(&mut socket3, ID3, Interest::WRITABLE)
         .unwrap();
 
     expect_events(
@@ -375,15 +395,15 @@ fn reconnect_udp_socket_receiving() {
 fn unconnected_udp_socket_connected_methods() {
     let (mut poll, mut events) = init_with_poll();
 
-    let socket1 = UdpSocket::bind(any_local_address()).unwrap();
-    let socket2 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket1 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket2 = UdpSocket::bind(any_local_address()).unwrap();
     let address2 = socket2.local_addr().unwrap();
 
     poll.registry()
-        .register(&socket1, ID1, Interest::WRITABLE)
+        .register(&mut socket1, ID1, Interest::WRITABLE)
         .unwrap();
     poll.registry()
-        .register(&socket2, ID2, Interest::READABLE)
+        .register(&mut socket2, ID2, Interest::READABLE)
         .unwrap();
 
     expect_events(
@@ -426,9 +446,9 @@ fn unconnected_udp_socket_connected_methods() {
 fn connected_udp_socket_unconnected_methods() {
     let (mut poll, mut events) = init_with_poll();
 
-    let socket1 = UdpSocket::bind(any_local_address()).unwrap();
-    let socket2 = UdpSocket::bind(any_local_address()).unwrap();
-    let socket3 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket1 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket2 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket3 = UdpSocket::bind(any_local_address()).unwrap();
 
     let address2 = socket2.local_addr().unwrap();
     let address3 = socket3.local_addr().unwrap();
@@ -437,13 +457,13 @@ fn connected_udp_socket_unconnected_methods() {
     socket3.connect(address2).unwrap();
 
     poll.registry()
-        .register(&socket1, ID1, Interest::WRITABLE)
+        .register(&mut socket1, ID1, Interest::WRITABLE)
         .unwrap();
     poll.registry()
-        .register(&socket2, ID2, Interest::WRITABLE)
+        .register(&mut socket2, ID2, Interest::WRITABLE)
         .unwrap();
     poll.registry()
-        .register(&socket3, ID3, Interest::READABLE)
+        .register(&mut socket3, ID3, Interest::READABLE)
         .unwrap();
 
     expect_events(
@@ -502,9 +522,9 @@ fn udp_socket_raw_fd() {
 fn udp_socket_register() {
     let (mut poll, mut events) = init_with_poll();
 
-    let socket = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket = UdpSocket::bind(any_local_address()).unwrap();
     poll.registry()
-        .register(&socket, ID1, Interest::READABLE)
+        .register(&mut socket, ID1, Interest::READABLE)
         .expect("unable to register UDP socket");
 
     expect_no_events(&mut poll, &mut events);
@@ -516,14 +536,14 @@ fn udp_socket_register() {
 fn udp_socket_reregister() {
     let (mut poll, mut events) = init_with_poll();
 
-    let socket = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket = UdpSocket::bind(any_local_address()).unwrap();
     let address = socket.local_addr().unwrap();
 
     let barrier = Arc::new(Barrier::new(2));
     let thread_handle = send_packets(address, 1, barrier.clone());
 
     poll.registry()
-        .register(&socket, ID1, Interest::WRITABLE)
+        .register(&mut socket, ID1, Interest::WRITABLE)
         .unwrap();
     // Let the first packet be send.
     barrier.wait();
@@ -534,7 +554,7 @@ fn udp_socket_reregister() {
     );
 
     poll.registry()
-        .reregister(&socket, ID2, Interest::READABLE)
+        .reregister(&mut socket, ID2, Interest::READABLE)
         .unwrap();
     expect_events(
         &mut poll,
@@ -552,20 +572,20 @@ fn udp_socket_reregister() {
 fn udp_socket_no_events_after_deregister() {
     let (mut poll, mut events) = init_with_poll();
 
-    let socket = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket = UdpSocket::bind(any_local_address()).unwrap();
     let address = socket.local_addr().unwrap();
 
     let barrier = Arc::new(Barrier::new(2));
     let thread_handle = send_packets(address, 1, barrier.clone());
 
     poll.registry()
-        .register(&socket, ID1, Interest::READABLE)
+        .register(&mut socket, ID1, Interest::READABLE)
         .unwrap();
 
     // Let the packet be send.
     barrier.wait();
 
-    poll.registry().deregister(&socket).unwrap();
+    poll.registry().deregister(&mut socket).unwrap();
 
     expect_no_events(&mut poll, &mut events);
 
@@ -617,7 +637,7 @@ impl UdpHandlerSendRecv {
 }
 
 #[cfg(test)]
-fn send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
+fn send_recv_udp(mut tx: UdpSocket, mut rx: UdpSocket, connected: bool) {
     init();
 
     debug!("Starting TEST_UDP_SOCKETS");
@@ -632,12 +652,12 @@ fn send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
 
     info!("Registering SENDER");
     poll.registry()
-        .register(&tx, SENDER, Interest::WRITABLE)
+        .register(&mut tx, SENDER, Interest::WRITABLE)
         .unwrap();
 
     info!("Registering LISTENER");
     poll.registry()
-        .register(&rx, LISTENER, Interest::READABLE)
+        .register(&mut rx, LISTENER, Interest::READABLE)
         .unwrap();
 
     let mut events = Events::with_capacity(1024);
@@ -721,8 +741,8 @@ pub fn udp_socket_send_recv() {
 pub fn udp_socket_discard() {
     init();
 
-    let tx = UdpSocket::bind(any_local_address()).unwrap();
-    let rx = UdpSocket::bind(any_local_address()).unwrap();
+    let mut tx = UdpSocket::bind(any_local_address()).unwrap();
+    let mut rx = UdpSocket::bind(any_local_address()).unwrap();
     let udp_outside = UdpSocket::bind(any_local_address()).unwrap();
 
     let tx_addr = tx.local_addr().unwrap();
@@ -737,10 +757,10 @@ pub fn udp_socket_discard() {
     checked_write!(udp_outside.send(b"hello world"));
 
     poll.registry()
-        .register(&rx, LISTENER, Interest::READABLE)
+        .register(&mut rx, LISTENER, Interest::READABLE)
         .unwrap();
     poll.registry()
-        .register(&tx, SENDER, Interest::WRITABLE)
+        .register(&mut tx, SENDER, Interest::WRITABLE)
         .unwrap();
 
     let mut events = Events::with_capacity(1024);
@@ -820,8 +840,8 @@ pub fn multicast() {
     debug!("Starting TEST_UDP_CONNECTIONLESS");
     let mut poll = Poll::new().unwrap();
 
-    let tx = UdpSocket::bind(any_local_address()).unwrap();
-    let rx = UdpSocket::bind(any_local_address()).unwrap();
+    let mut tx = UdpSocket::bind(any_local_address()).unwrap();
+    let mut rx = UdpSocket::bind(any_local_address()).unwrap();
 
     info!("Joining group 227.1.1.100");
     let any = "0.0.0.0".parse().unwrap();
@@ -834,12 +854,12 @@ pub fn multicast() {
 
     info!("Registering SENDER");
     poll.registry()
-        .register(&tx, SENDER, Interest::WRITABLE)
+        .register(&mut tx, SENDER, Interest::WRITABLE)
         .unwrap();
 
     info!("Registering LISTENER");
     poll.registry()
-        .register(&rx, LISTENER, Interest::READABLE)
+        .register(&mut rx, LISTENER, Interest::READABLE)
         .unwrap();
 
     let mut events = Events::with_capacity(1024);
@@ -867,16 +887,20 @@ pub fn multicast() {
 fn et_behavior_recv() {
     let (mut poll, mut events) = init_with_poll();
 
-    let socket1 = UdpSocket::bind(any_local_address()).unwrap();
-    let socket2 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket1 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket2 = UdpSocket::bind(any_local_address()).unwrap();
 
     let address2 = socket2.local_addr().unwrap();
 
     poll.registry()
-        .register(&socket1, ID1, Interest::WRITABLE)
+        .register(&mut socket1, ID1, Interest::WRITABLE)
         .expect("unable to register UDP socket");
     poll.registry()
-        .register(&socket2, ID2, Interest::READABLE.add(Interest::WRITABLE))
+        .register(
+            &mut socket2,
+            ID2,
+            Interest::READABLE.add(Interest::WRITABLE),
+        )
         .expect("unable to register UDP socket");
 
     expect_events(
@@ -917,17 +941,25 @@ fn et_behavior_recv() {
 fn et_behavior_recv_from() {
     let (mut poll, mut events) = init_with_poll();
 
-    let socket1 = UdpSocket::bind(any_local_address()).unwrap();
-    let socket2 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket1 = UdpSocket::bind(any_local_address()).unwrap();
+    let mut socket2 = UdpSocket::bind(any_local_address()).unwrap();
 
     let address1 = socket1.local_addr().unwrap();
     let address2 = socket2.local_addr().unwrap();
 
     poll.registry()
-        .register(&socket1, ID1, Interest::READABLE.add(Interest::WRITABLE))
+        .register(
+            &mut socket1,
+            ID1,
+            Interest::READABLE.add(Interest::WRITABLE),
+        )
         .expect("unable to register UDP socket");
     poll.registry()
-        .register(&socket2, ID2, Interest::READABLE.add(Interest::WRITABLE))
+        .register(
+            &mut socket2,
+            ID2,
+            Interest::READABLE.add(Interest::WRITABLE),
+        )
         .expect("unable to register UDP socket");
 
     expect_events(

--- a/tests/unix_listener.rs
+++ b/tests/unix_listener.rs
@@ -50,16 +50,16 @@ fn unix_listener_try_clone_same_poll() {
     let dir = TempDir::new("unix_listener").unwrap();
     let path = dir.path().join("any");
 
-    let listener1 = UnixListener::bind(&path).unwrap();
-    let listener2 = listener1.try_clone().unwrap();
+    let mut listener1 = UnixListener::bind(&path).unwrap();
+    let mut listener2 = listener1.try_clone().unwrap();
     assert_ne!(listener1.as_raw_fd(), listener2.as_raw_fd());
 
     let handle_1 = open_connections(path.clone(), 1, barrier.clone());
     poll.registry()
-        .register(&listener1, TOKEN_1, Interest::READABLE)
+        .register(&mut listener1, TOKEN_1, Interest::READABLE)
         .unwrap();
     poll.registry()
-        .register(&listener2, TOKEN_2, Interest::READABLE)
+        .register(&mut listener2, TOKEN_2, Interest::READABLE)
         .unwrap();
     expect_events(
         &mut poll,
@@ -103,18 +103,18 @@ fn unix_listener_try_clone_different_poll() {
     let dir = TempDir::new("unix_listener").unwrap();
     let path = dir.path().join("any");
 
-    let listener1 = UnixListener::bind(&path).unwrap();
-    let listener2 = listener1.try_clone().unwrap();
+    let mut listener1 = UnixListener::bind(&path).unwrap();
+    let mut listener2 = listener1.try_clone().unwrap();
     assert_ne!(listener1.as_raw_fd(), listener2.as_raw_fd());
 
     let handle_1 = open_connections(path.clone(), 1, barrier.clone());
     poll1
         .registry()
-        .register(&listener1, TOKEN_1, Interest::READABLE)
+        .register(&mut listener1, TOKEN_1, Interest::READABLE)
         .unwrap();
     poll2
         .registry()
-        .register(&listener2, TOKEN_2, Interest::READABLE)
+        .register(&mut listener2, TOKEN_2, Interest::READABLE)
         .unwrap();
     expect_events(
         &mut poll1,
@@ -161,10 +161,10 @@ fn unix_listener_local_addr() {
     let dir = TempDir::new("unix_listener").unwrap();
     let path = dir.path().join("any");
 
-    let listener = UnixListener::bind(&path).unwrap();
+    let mut listener = UnixListener::bind(&path).unwrap();
     poll.registry()
         .register(
-            &listener,
+            &mut listener,
             TOKEN_1,
             Interest::WRITABLE.add(Interest::READABLE),
         )
@@ -190,9 +190,9 @@ fn unix_listener_register() {
     let (mut poll, mut events) = init_with_poll();
     let dir = TempDir::new("unix_listener").unwrap();
 
-    let listener = UnixListener::bind(dir.path().join("any")).unwrap();
+    let mut listener = UnixListener::bind(dir.path().join("any")).unwrap();
     poll.registry()
-        .register(&listener, TOKEN_1, Interest::READABLE)
+        .register(&mut listener, TOKEN_1, Interest::READABLE)
         .unwrap();
     expect_no_events(&mut poll, &mut events)
 }
@@ -204,16 +204,16 @@ fn unix_listener_reregister() {
     let dir = TempDir::new("unix_listener").unwrap();
     let path = dir.path().join("any");
 
-    let listener = UnixListener::bind(&path).unwrap();
+    let mut listener = UnixListener::bind(&path).unwrap();
     poll.registry()
-        .register(&listener, TOKEN_1, Interest::WRITABLE)
+        .register(&mut listener, TOKEN_1, Interest::WRITABLE)
         .unwrap();
 
     let handle = open_connections(path, 1, barrier.clone());
     expect_no_events(&mut poll, &mut events);
 
     poll.registry()
-        .reregister(&listener, TOKEN_1, Interest::READABLE)
+        .reregister(&mut listener, TOKEN_1, Interest::READABLE)
         .unwrap();
     expect_events(
         &mut poll,
@@ -232,14 +232,14 @@ fn unix_listener_deregister() {
     let dir = TempDir::new("unix_listener").unwrap();
     let path = dir.path().join("any");
 
-    let listener = UnixListener::bind(&path).unwrap();
+    let mut listener = UnixListener::bind(&path).unwrap();
     poll.registry()
-        .register(&listener, TOKEN_1, Interest::READABLE)
+        .register(&mut listener, TOKEN_1, Interest::READABLE)
         .unwrap();
 
     let handle = open_connections(path, 1, barrier.clone());
 
-    poll.registry().deregister(&listener).unwrap();
+    poll.registry().deregister(&mut listener).unwrap();
     expect_no_events(&mut poll, &mut events);
 
     barrier.wait();
@@ -255,10 +255,10 @@ where
     let dir = TempDir::new("unix_listener").unwrap();
     let path = dir.path().join("any");
 
-    let listener = new_listener(&path).unwrap();
+    let mut listener = new_listener(&path).unwrap();
     poll.registry()
         .register(
-            &listener,
+            &mut listener,
             TOKEN_1,
             Interest::WRITABLE.add(Interest::READABLE),
         )


### PR DESCRIPTION
First commit changes the `event::Source` trait and fixes all call locations. The follow-up commits will make use of the fact that we now have mutable access and remove some `Mutex` where possible, e.g. in the Windows implementation.

Fixes #1064