### PR TITLE
Remove some mutexes from Windows implementation

### DIFF
--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -66,6 +66,7 @@ struct InternalState {
     selector: Arc<SelectorInner>,
     token: Token,
     interests: Interest,
+    // FIXME: this `Option` can be removed.
     sock_state: Option<Pin<Arc<Mutex<SockState>>>>,
 }
 

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -3,11 +3,14 @@ use std::mem::size_of_val;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex, Once};
+
 use winapi::ctypes::c_int;
 use winapi::shared::ws2def::SOCKADDR;
 use winapi::um::winsock2::{
     ioctlsocket, socket, FIONBIO, INVALID_SOCKET, PF_INET, PF_INET6, SOCKET,
 };
+
+use crate::{Interest, Token};
 
 /// Helper macro to execute a system call that returns an `io::Result`.
 //
@@ -50,17 +53,6 @@ pub use selector::{Selector, SelectorInner, SockState};
 pub use tcp::{TcpListener, TcpStream};
 pub use udp::UdpSocket;
 pub use waker::Waker;
-
-pub trait SocketState {
-    // The `SockState` struct needs to be pinned in memory because it contains
-    // `OVERLAPPED` and `AFD_POLL_INFO` fields which are modified in the
-    // background by the windows kernel, therefore we need to ensure they are
-    // never moved to a different memory address.
-    fn get_sock_state(&self) -> Option<Pin<Arc<Mutex<SockState>>>>;
-    fn set_sock_state(&self, sock_state: Option<Pin<Arc<Mutex<SockState>>>>);
-}
-
-use crate::{Interest, Token};
 
 struct InternalState {
     selector: Arc<SelectorInner>,

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -70,17 +70,6 @@ struct InternalState {
     sock_state: Option<Pin<Arc<Mutex<SockState>>>>,
 }
 
-impl InternalState {
-    fn new(selector: Arc<SelectorInner>, token: Token, interests: Interest) -> InternalState {
-        InternalState {
-            selector,
-            token,
-            interests,
-            sock_state: None,
-        }
-    }
-}
-
 impl Drop for InternalState {
     fn drop(&mut self) {
         if let Some(sock_state) = self.sock_state.as_ref() {

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -58,16 +58,13 @@ struct InternalState {
     selector: Arc<SelectorInner>,
     token: Token,
     interests: Interest,
-    // FIXME: this `Option` can be removed.
-    sock_state: Option<Pin<Arc<Mutex<SockState>>>>,
+    sock_state: Pin<Arc<Mutex<SockState>>>,
 }
 
 impl Drop for InternalState {
     fn drop(&mut self) {
-        if let Some(sock_state) = self.sock_state.as_ref() {
-            let mut sock_state = sock_state.lock().unwrap();
-            sock_state.mark_delete();
-        }
+        let mut sock_state = self.sock_state.lock().unwrap();
+        sock_state.mark_delete();
     }
 }
 

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -499,7 +499,7 @@ impl SelectorInner {
             selector: this.clone(),
             token,
             interests,
-            sock_state: Some(sock.clone()),
+            sock_state: sock.clone(),
         };
 
         unsafe {

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -1,6 +1,6 @@
 use super::afd::{self, Afd, AfdPollInfo};
 use super::io_status_block::IoStatusBlock;
-use super::{Event, Events, InternalState, SocketState};
+use super::{Event, Events, InternalState};
 use crate::{Interest, Token};
 
 use miow::iocp::{CompletionPort, CompletionStatus};
@@ -9,7 +9,7 @@ use miow::Overlapped;
 use std::collections::VecDeque;
 use std::marker::PhantomPinned;
 use std::mem::size_of;
-use std::os::windows::io::{AsRawSocket, RawSocket};
+use std::os::windows::io::RawSocket;
 use std::pin::Pin;
 use std::ptr::null_mut;
 #[cfg(debug_assertions)]
@@ -347,55 +347,27 @@ impl Selector {
         self.inner.select(events, timeout)
     }
 
-    // FIXME: replace with `register2`.
-    pub fn register<S: SocketState + AsRawSocket>(
-        &self,
-        socket: &S,
-        token: Token,
-        interests: Interest,
-    ) -> io::Result<()> {
-        self.inner.register(socket, token, interests)
-    }
-
-    pub(super) fn register2(
+    pub(super) fn register(
         &self,
         socket: RawSocket,
         token: Token,
         interests: Interest,
     ) -> io::Result<InternalState> {
-        SelectorInner::register2(&self.inner, socket, token, interests)
+        SelectorInner::register(&self.inner, socket, token, interests)
     }
 
-    // FIXME: replace with `reregister2`.
-    pub fn reregister<S: SocketState>(
-        &self,
-        socket: &S,
-        token: Token,
-        interests: Interest,
-    ) -> io::Result<()> {
-        self.inner.reregister(socket, token, interests)
-    }
-
-    pub fn reregister2(
+    pub fn reregister(
         &self,
         state: &Pin<Arc<Mutex<SockState>>>,
         token: Token,
         interests: Interest,
     ) -> io::Result<()> {
-        self.inner.reregister2(state, token, interests)
-    }
-
-    pub fn deregister<S: SocketState>(&self, socket: &S) -> io::Result<()> {
-        self.inner.deregister(socket)
+        self.inner.reregister(state, token, interests)
     }
 
     #[cfg(debug_assertions)]
     pub fn id(&self) -> usize {
         self.id
-    }
-
-    pub(super) fn clone_inner(&self) -> Arc<SelectorInner> {
-        self.inner.clone()
     }
 
     pub(super) fn clone_port(&self) -> Arc<CompletionPort> {
@@ -505,38 +477,7 @@ impl SelectorInner {
         }
     }
 
-    // FIXME: replace with `register2`.
-    pub fn register<S: SocketState + AsRawSocket>(
-        &self,
-        socket: &S,
-        token: Token,
-        interests: Interest,
-    ) -> io::Result<()> {
-        if socket.get_sock_state().is_some() {
-            return Err(io::Error::from(io::ErrorKind::AlreadyExists));
-        }
-
-        let flags = interests_to_afd_flags(interests);
-
-        let sock = self._alloc_sock_for_rawsocket(socket.as_raw_socket())?;
-        let event = Event {
-            flags,
-            data: token.0 as u64,
-        };
-
-        {
-            sock.lock().unwrap().set_event(event);
-        }
-        socket.set_sock_state(Some(sock));
-        unsafe {
-            self.add_socket_to_update_queue(socket);
-            self.update_sockets_events_if_polling()?;
-        }
-
-        Ok(())
-    }
-
-    fn register2(
+    fn register(
         this: &Arc<Self>,
         socket: RawSocket,
         token: Token,
@@ -570,36 +511,7 @@ impl SelectorInner {
         Ok(state)
     }
 
-    // FIXME: replace with `reregister2`.
-    pub fn reregister<S: SocketState>(
-        &self,
-        socket: &S,
-        token: Token,
-        interests: Interest,
-    ) -> io::Result<()> {
-        let flags = interests_to_afd_flags(interests);
-
-        let sock = match socket.get_sock_state() {
-            Some(sock) => sock,
-            None => return Err(io::Error::from(io::ErrorKind::NotFound)),
-        };
-        let event = Event {
-            flags,
-            data: token.0 as u64,
-        };
-
-        {
-            sock.lock().unwrap().set_event(event);
-        }
-        unsafe {
-            self.add_socket_to_update_queue(socket);
-            self.update_sockets_events_if_polling()?;
-        }
-
-        Ok(())
-    }
-
-    pub fn reregister2(
+    pub fn reregister(
         &self,
         state: &Pin<Arc<Mutex<SockState>>>,
         token: Token,
@@ -617,15 +529,6 @@ impl SelectorInner {
         let mut update_queue = self.update_queue.lock().unwrap();
         update_queue.push_back(state.clone());
         unsafe { self.update_sockets_events_if_polling() }
-    }
-
-    pub fn deregister<S: SocketState>(&self, socket: &S) -> io::Result<()> {
-        if socket.get_sock_state().is_none() {
-            return Err(io::Error::from(io::ErrorKind::NotFound));
-        }
-        socket.set_sock_state(None);
-        self.afd_group.release_unused_afd();
-        Ok(())
     }
 
     unsafe fn update_sockets_events(&self) -> io::Result<()> {
@@ -667,12 +570,6 @@ impl SelectorInner {
         } else {
             Ok(())
         }
-    }
-
-    unsafe fn add_socket_to_update_queue<S: SocketState>(&self, socket: &S) {
-        let sock_state = socket.get_sock_state().unwrap();
-        let mut update_queue = self.update_queue.lock().unwrap();
-        update_queue.push_back(sock_state);
     }
 
     // It returns processed count of iocp_events rather than the events itself.

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -144,7 +144,7 @@ impl UdpSocket {
             let sock_state = state.sock_state.as_ref().unwrap();
             state
                 .selector
-                .reregister2(sock_state, state.token, state.interests)
+                .reregister(sock_state, state.token, state.interests)
         })
     }
 }
@@ -160,7 +160,7 @@ impl event::Source for UdpSocket {
             Err(io::Error::from(io::ErrorKind::AlreadyExists))
         } else {
             poll::selector(registry)
-                .register2(self.inner.as_raw_socket(), token, interests)
+                .register(self.inner.as_raw_socket(), token, interests)
                 .map(|state| {
                     self.state = Some(Box::new(state));
                 })
@@ -177,7 +177,7 @@ impl event::Source for UdpSocket {
             Some(state) => {
                 let sock_state = state.sock_state.as_ref().unwrap();
                 poll::selector(registry)
-                    .reregister2(sock_state, token, interests)
+                    .reregister(sock_state, token, interests)
                     .map(|()| {
                         state.token = token;
                         state.interests = interests;

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -194,11 +194,6 @@ impl event::Source for UdpSocket {
                     let mut sock_state = sock_state.lock().unwrap();
                     sock_state.mark_delete();
                 }
-
-                // TODO: in `SelectorInner::deregister` the following is called.
-                // But this is also done when polling, so maybe its not needed
-                // here.
-                //self.afd_group.release_unused_afd();
                 Ok(())
             }
             None => Err(io::Error::from(io::ErrorKind::NotFound)),

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -141,10 +141,9 @@ impl UdpSocket {
     // Used by `try_io` to register after an I/O operation blocked.
     fn io_blocked_reregister(&self) -> io::Result<()> {
         self.state.as_ref().map_or(Ok(()), |state| {
-            let sock_state = state.sock_state.as_ref().unwrap();
             state
                 .selector
-                .reregister(sock_state, state.token, state.interests)
+                .reregister(&state.sock_state, state.token, state.interests)
         })
     }
 }
@@ -174,15 +173,12 @@ impl event::Source for UdpSocket {
         interests: Interest,
     ) -> io::Result<()> {
         match self.state.as_mut() {
-            Some(state) => {
-                let sock_state = state.sock_state.as_ref().unwrap();
-                poll::selector(registry)
-                    .reregister(sock_state, token, interests)
-                    .map(|()| {
-                        state.token = token;
-                        state.interests = interests;
-                    })
-            }
+            Some(state) => poll::selector(registry)
+                .reregister(&state.sock_state, token, interests)
+                .map(|()| {
+                    state.token = token;
+                    state.interests = interests;
+                }),
             None => Err(io::Error::from(io::ErrorKind::NotFound)),
         }
     }
@@ -190,10 +186,8 @@ impl event::Source for UdpSocket {
     fn deregister(&mut self, _registry: &Registry) -> io::Result<()> {
         match self.state.as_mut() {
             Some(state) => {
-                if let Some(sock_state) = state.sock_state.as_ref() {
-                    let mut sock_state = sock_state.lock().unwrap();
-                    sock_state.mark_delete();
-                }
+                let mut sock_state = state.sock_state.lock().unwrap();
+                sock_state.mark_delete();
                 Ok(())
             }
             None => Err(io::Error::from(io::ErrorKind::NotFound)),


### PR DESCRIPTION
After #1064 we don't need as many mutexes in the Windows implementation.