### PR TITLE
added a note in README mentioning wepoll

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Mio can handle interfacing with each of the event systems of the aforementioned
 platforms. The details of their implementation are further discussed in the
 `Poll` type of the API documentation (see above).
 
+The Windows implementation for polling sockets is using the [wepoll] strategy.
+This uses the Windows AFD system to access socket readiness events.
+[wepoll]: https://github.com/piscisaureus/wepoll
+
 There are potentially others. If you find that Mio works on another
 platform, submit a PR to update the list!
 


### PR DESCRIPTION
This fixes the following item from issue #1041 :
```ensure wepoll licensing requirements are met (copy license file).``` 

Carl suggested to add a note in the README file, no need to copy license file.

Signed-off-by: Daniel Tacalau <dst4096@gmail.com>