### PR TITLE
Move SocketAddr to the net module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ pub use waker::Waker;
 #[cfg(unix)]
 pub mod unix {
     //! Unix only extensions.
-    pub use crate::sys::SocketAddr;
     pub use crate::sys::SourceFd;
 }
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -16,4 +16,4 @@ pub use self::udp::UdpSocket;
 #[cfg(unix)]
 mod uds;
 #[cfg(unix)]
-pub use self::uds::{UnixDatagram, UnixListener, UnixStream};
+pub use self::uds::{SocketAddr, UnixDatagram, UnixListener, UnixStream};

--- a/src/net/uds/listener.rs
+++ b/src/net/uds/listener.rs
@@ -1,7 +1,6 @@
-use crate::net::UnixStream;
+use crate::net::{SocketAddr, UnixStream};
 #[cfg(debug_assertions)]
 use crate::poll::SelectorId;
-use crate::unix::SocketAddr;
 use crate::{event, sys, Interest, Registry, Token};
 
 use std::io;

--- a/src/net/uds/mod.rs
+++ b/src/net/uds/mod.rs
@@ -6,3 +6,5 @@ pub use self::listener::UnixListener;
 
 mod stream;
 pub use self::stream::UnixStream;
+
+pub use crate::sys::SocketAddr;


### PR DESCRIPTION
From the unix module. Even though its a Unix only type it should be
located with the UDS types that use it.