### PR TITLE
Add IoSource

### DIFF
--- a/src/event/source.rs
+++ b/src/event/source.rs
@@ -1,7 +1,6 @@
 use crate::{Interest, Registry, Token};
 
 use std::io;
-use std::ops::DerefMut;
 
 /// An event source that may be registered with [`Registry`].
 ///
@@ -111,10 +110,9 @@ pub trait Source {
     fn deregister(&mut self, registry: &Registry) -> io::Result<()>;
 }
 
-impl<T, S> Source for T
+impl<T> Source for Box<T>
 where
-    T: DerefMut<Target = S>,
-    S: Source + ?Sized,
+    T: Source + ?Sized,
 {
     fn register(
         &mut self,
@@ -122,7 +120,7 @@ where
         token: Token,
         interests: Interest,
     ) -> io::Result<()> {
-        self.deref_mut().register(registry, token, interests)
+        (&mut **self).register(registry, token, interests)
     }
 
     fn reregister(
@@ -131,10 +129,10 @@ where
         token: Token,
         interests: Interest,
     ) -> io::Result<()> {
-        self.deref_mut().reregister(registry, token, interests)
+        (&mut **self).reregister(registry, token, interests)
     }
 
     fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
-        self.deref_mut().deregister(registry)
+        (&mut **self).deregister(registry)
     }
 }

--- a/src/io_source.rs
+++ b/src/io_source.rs
@@ -1,0 +1,202 @@
+#![allow(dead_code)] // Currently unused.
+
+use std::ops::{Deref, DerefMut};
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawSocket;
+use std::{fmt, io};
+
+#[cfg(unix)]
+use crate::poll;
+#[cfg(debug_assertions)]
+use crate::poll::SelectorId;
+use crate::sys::IoSourceState;
+use crate::{event, Interest, Registry, Token};
+
+/// Adapter for a [`RawFd`] or [`RawSocket`] providing an [`event::Source`]
+/// implementation.
+///
+/// `IoSource` enables registering any FD or socket wrapper with [`Poll`].
+///
+/// While only implementations for TCP, UDP, and UDS (Unix only) are provided,
+/// Mio supports registering any FD or socket that can be registered with the
+/// underlying OS selector. `IoSource` provides the necessary bridge.
+///
+/// [`RawFd`]: std::os::unix::io::RawFd
+/// [`RawSocket`]: std::os::windows::io::RawSocket
+///
+/// # Notes
+///
+/// To handle the registrations and events properly **all** I/O operations (such
+/// as `read`, `write`, etc.) must go through the [`do_io`] method to ensure the
+/// internal state is updated accordingly.
+///
+/// [`Poll`]: crate::Poll
+/// [`do_io`]: IoSource::do_io
+/*
+///
+/// # Examples
+///
+/// Basic usage.
+///
+/// ```
+/// # use std::error::Error;
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// use mio::{Interest, Poll, Token};
+/// use mio::IoSource;
+///
+/// use std::net;
+///
+/// let poll = Poll::new()?;
+///
+/// // Bind a std TCP listener.
+/// let listener = net::TcpListener::bind("127.0.0.1:0")?;
+/// // Wrap it in the `IoSource` type.
+/// let mut listener = IoSource::new(listener);
+///
+/// // Register the listener.
+/// poll.registry().register(&mut listener, Token(0), Interest::READABLE)?;
+/// #     Ok(())
+/// # }
+/// ```
+*/
+pub struct IoSource<T> {
+    state: IoSourceState,
+    inner: T,
+    #[cfg(debug_assertions)]
+    selector_id: SelectorId,
+}
+
+impl<T> IoSource<T> {
+    /// Create a new `IoSource`.
+    pub fn new(io: T) -> IoSource<T> {
+        IoSource {
+            state: IoSourceState::new(),
+            inner: io,
+            #[cfg(debug_assertions)]
+            selector_id: SelectorId::new(),
+        }
+    }
+
+    /// Execute an I/O operations ensuring that the socket receives more events
+    /// if it hit a [`WouldBlock`] error.
+    ///
+    /// # Notes
+    ///
+    /// This method is required to be called for **all** I/O operations to
+    /// ensure the user will receive events once the socket is ready again after
+    /// returning a [`WouldBlock`] error.
+    ///
+    /// [`WouldBlock`]: io::ErrorKind::WouldBlock
+    pub fn do_io<F, R>(&mut self, f: F) -> io::Result<R>
+    where
+        F: FnOnce(&mut T) -> io::Result<R>,
+    {
+        self.state.do_io(f, &mut self.inner)
+    }
+
+    /// Returns the I/O source, dropping the state.
+    ///
+    /// # Notes
+    ///
+    /// To ensure no more events are to be received for this I/O source first
+    /// [`deregister`] it.
+    ///
+    /// [`deregister`]: Registry::deregister
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+/// Be careful when using this method. All I/O operations that may block must go
+/// through the [`do_io`] method.
+///
+/// [`do_io`]: IoSource::do_io
+impl<T> Deref for IoSource<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// Be careful when using this method. All I/O operations that may block must go
+/// through the [`do_io`] method.
+///
+/// [`do_io`]: IoSource::do_io
+impl<T> DerefMut for IoSource<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+#[cfg(unix)]
+impl<T> event::Source for IoSource<T>
+where
+    T: AsRawFd,
+{
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        #[cfg(debug_assertions)]
+        self.selector_id.associate_selector(registry)?;
+        poll::selector(registry).register(self.inner.as_raw_fd(), token, interests)
+    }
+
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        poll::selector(registry).reregister(self.inner.as_raw_fd(), token, interests)
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        poll::selector(registry).deregister(self.inner.as_raw_fd())
+    }
+}
+
+#[cfg(windows)]
+impl<T> event::Source for IoSource<T>
+where
+    T: AsRawSocket,
+{
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        #[cfg(debug_assertions)]
+        self.selector_id.associate_selector(registry)?;
+        self.state
+            .register(registry, token, interests, self.inner.as_raw_socket())
+    }
+
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        self.state.reregister(registry, token, interests)
+    }
+
+    fn deregister(&mut self, _registry: &Registry) -> io::Result<()> {
+        self.state.deregister()
+    }
+}
+
+impl<T> fmt::Debug for IoSource<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.inner, f)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ mod waker;
 pub mod event;
 
 cfg_net! {
+    mod io_source;
+
     pub mod net;
 }
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -7,6 +7,7 @@
 //! * `event`: a module with various helper functions for `Event`, see
 //!            [`crate::event::Event`] for the required functions.
 //! * `Events`: collection of `Event`s, see [`crate::Events`].
+//! * `IoSourceState`: state for the `IoSource` type.
 //! * `Selector`: selector used to register event sources and poll for events,
 //!               see [`crate::Poll`] and [`crate::Registry`] for required
 //!               methods.
@@ -67,6 +68,10 @@ cfg_os_poll! {
     cfg_uds! {
         pub(crate) use self::unix::{UnixDatagram, UnixListener, UnixStream};
         pub use self::unix::SocketAddr;
+    }
+
+    cfg_any_os_util! {
+        pub(crate) use self::unix::IoSourceState;
     }
 }
 

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -40,6 +40,28 @@ cfg_os_poll! {
         pub use self::uds::SocketAddr;
         pub(crate) use self::uds::{UnixDatagram, UnixListener, UnixStream};
     }
+
+    cfg_net! {
+        use std::io;
+
+        // Both `kqueue` and `epoll` don't need to hold any user space state.
+        pub struct IoSourceState;
+
+        impl IoSourceState {
+            pub fn new() -> IoSourceState {
+                IoSourceState
+            }
+
+            pub fn do_io<T, F, R>(&mut self, f: F, io: &mut T) -> io::Result<R>
+            where
+                F: FnOnce(&mut T) -> io::Result<R>,
+            {
+                // We don't hold state, so we can just call the function and
+                // return.
+                f(io)
+            }
+        }
+    }
 }
 
 cfg_not_os_poll! {

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -1,6 +1,6 @@
 use super::afd::{self, Afd, AfdPollInfo};
 use super::io_status_block::IoStatusBlock;
-use super::Event;
+use super::{Event, InternalState};
 use crate::sys::Events;
 use crate::Interest;
 
@@ -371,6 +371,15 @@ cfg_net! {
             self.inner.register(socket, token, interests)
         }
 
+        pub(super) fn register2(
+            &self,
+            socket: RawSocket,
+            token: Token,
+            interests: Interest,
+        ) -> io::Result<InternalState> {
+            SelectorInner::register2(&self.inner, socket, token, interests)
+        }
+
         pub fn reregister<S: SocketState>(
             &self,
             socket: &S,
@@ -378,6 +387,15 @@ cfg_net! {
             interests: Interest,
         ) -> io::Result<()> {
             self.inner.reregister(socket, token, interests)
+        }
+
+        pub fn reregister2(
+            &self,
+            state: &Pin<Arc<Mutex<SockState>>>,
+            token: Token,
+            interests: Interest,
+        ) -> io::Result<()> {
+            self.inner.reregister2(state, token, interests)
         }
 
         pub fn deregister<S: SocketState>(&self, socket: &S) -> io::Result<()> {
@@ -553,6 +571,40 @@ cfg_net! {
             Ok(())
         }
 
+        fn register2(
+            this: &Arc<Self>,
+            socket: RawSocket,
+            token: Token,
+            interests: Interest,
+        ) -> io::Result<InternalState> {
+            let flags = interests_to_afd_flags(interests);
+
+            let sock = {
+                let sock = this._alloc_sock_for_rawsocket(socket)?;
+                let event = Event {
+                    flags,
+                    data: token.0 as u64,
+                };
+                sock.lock().unwrap().set_event(event);
+                sock
+            };
+
+            let state = InternalState {
+                selector: this.clone(),
+                token,
+                interests,
+                sock_state: Some(sock.clone()),
+            };
+
+            unsafe {
+                let mut update_queue = this.update_queue.lock().unwrap();
+                update_queue.push_back(sock);
+                this.update_sockets_events_if_polling()?;
+            }
+
+            Ok(state)
+        }
+
         pub fn reregister<S: SocketState>(
             &self,
             socket: &S,
@@ -579,6 +631,26 @@ cfg_net! {
             }
 
             Ok(())
+        }
+
+        pub fn reregister2(
+            &self,
+            state: &Pin<Arc<Mutex<SockState>>>,
+            token: Token,
+            interests: Interest,
+        ) -> io::Result<()> {
+            {
+                let event = Event {
+                    flags: interests_to_afd_flags(interests),
+                    data: token.0 as u64,
+                };
+
+                state.lock().unwrap().set_event(event);
+            }
+
+            let mut update_queue = self.update_queue.lock().unwrap();
+            update_queue.push_back(state.clone());
+            unsafe { self.update_sockets_events_if_polling() }
         }
 
         pub fn deregister<S: SocketState>(&self, socket: &S) -> io::Result<()> {


### PR DESCRIPTION
`IoSource` is a wrapper around a raw file descriptor or socket that implements `event::Source`.

This will replace `SourceFd` on Unix (not removed in this pr). I'll send some more pr that replace the usage of `SourceFd` on Unix and use them in the net types on Windows.

Updates #880
Updates #1187

/cc @dtacalau 