### PR TITLE
Add tcp feature flag to events test

### DIFF
--- a/tests/events.rs
+++ b/tests/events.rs
@@ -1,7 +1,8 @@
-use std::time::Duration;
+#![cfg(feature = "tcp")]
 
 use mio::net::TcpStream;
 use mio::{event, Token, Waker};
+use std::time::Duration;
 
 mod util;
 use util::init_with_poll;


### PR DESCRIPTION
#1210 introduced a TCP dependency to the `event` tests. Without a module cfg, it
warns about the use of `mio::net`.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
