### PR TITLE
Release v0.7.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Unreleased (Unreleased)
+# 0.7.0 alpha.1
+
+Currently the changelog for v0.7.0 is incomplete, this tracked in issue #1217.
 
 * The `join_multicast_v4` and `leave_multicast_v4` methods now take their
   `Ipv4Addr` arguments by value rather than by reference.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ name = "mio"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create git tag
-version       = "0.7.0"
+version       = "0.7.0-alpha.1"
 license       = "MIT"
 authors       = ["Carl Lerche <me@carllerche.com>"]
 description   = "Lightweight non-blocking IO"
-documentation = "https://docs.rs/mio/0.7.0/mio/"
+documentation = "https://docs.rs/mio/0.7.0-alpha.1/mio/"
 homepage      = "https://github.com/tokio-rs/mio"
 repository    = "https://github.com/tokio-rs/mio"
 readme        = "README.md"
@@ -19,7 +19,6 @@ categories    = ["asynchronous"]
 exclude       = [
   ".gitignore",
   ".travis.yml",
-  "deploy.sh",
 ]
 publish = false
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/mio/0.7.0")]
+#![doc(html_root_url = "https://docs.rs/mio/0.7.0-alpha.1")]
 #![deny(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 // Disallow warnings when running tests.


### PR DESCRIPTION
This needs two more things:

* ~~A git tag.~~ Git tag: https://github.com/tokio-rs/mio/tree/v0.7.0-alpha.1.
* Publishing to crates.io