### PR TITLE
Format all CI files

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,64 +2,64 @@ trigger: ["master", "v0.6.x"]
 pr: ["master", "v0.6.x"]
 
 jobs:
-# Check formatting
-- template: ci/azure-rustfmt.yml
-  parameters:
-    name: rustfmt
+  # Check formatting
+  - template: ci/azure-rustfmt.yml
+    parameters:
+      name: rustfmt
 
-# Stable
-- template: ci/azure-test-stable.yml
-  parameters:
-    name: stable
-    displayName: Test
-    cross: true
+  # Stable
+  - template: ci/azure-test-stable.yml
+    parameters:
+      name: stable
+      displayName: Test
+      cross: true
 
-# Stable --release
-- template: ci/azure-test-stable.yml
-  parameters:
-    name: stable_release
-    displayName: Test --release
-    cmd: test --release
+  # Stable --release
+  - template: ci/azure-test-stable.yml
+    parameters:
+      name: stable_release
+      displayName: Test --release
+      cmd: test --release
 
-# Nightly
-- template: ci/azure-test-stable.yml
-  parameters:
-    name: nightly
-    displayName: Nightly
-    # Pin nightly to avoid being impacted by breakage
-    rust_version: nightly-2019-11-14
-    benches: true
+  # Nightly
+  - template: ci/azure-test-stable.yml
+    parameters:
+      name: nightly
+      displayName: Nightly
+      # Pin nightly to avoid being impacted by breakage
+      rust_version: nightly-2019-11-14
+      benches: true
 
-# This represents the minimum Rust version supported by
-# Mio. Updating this should be done in a dedicated PR.
-#
-# Tests are not run as tests may require newer versions of
-# rust.
-- template: ci/azure-test-stable.yml
-  parameters:
-    name: minrust
-    displayName: Min Rust
-    rust_version: 1.39.0
-    cmd: check
-    cross: true
+  # This represents the minimum Rust version supported by
+  # Mio. Updating this should be done in a dedicated PR.
+  #
+  # Tests are not run as tests may require newer versions of
+  # rust.
+  - template: ci/azure-test-stable.yml
+    parameters:
+      name: minrust
+      displayName: Min Rust
+      rust_version: 1.39.0
+      cmd: check
+      cross: true
 
-- template: ci/azure-minimal-versions.yml
-  parameters:
-    name: minimal_versions
+  - template: ci/azure-minimal-versions.yml
+    parameters:
+      name: minimal_versions
 
-- template: ci/azure-clippy.yml
-  parameters:
-    name: clippy
+  - template: ci/azure-clippy.yml
+    parameters:
+      name: clippy
 
-- template: ci/azure-cross-compile.yml
-  parameters:
-    name: cross
+  - template: ci/azure-cross-compile.yml
+    parameters:
+      name: cross
 
-- template: ci/azure-deploy-docs.yml
-  parameters:
-    dependsOn:
-      # - rustfmt
-      - stable
-      - nightly
-      - minrust
-      - cross
+  - template: ci/azure-deploy-docs.yml
+    parameters:
+      dependsOn:
+        # - rustfmt
+        - stable
+        - nightly
+        - minrust
+        - cross

--- a/ci/azure-cross-compile.yml
+++ b/ci/azure-cross-compile.yml
@@ -2,58 +2,58 @@ parameters:
   vmImage: ubuntu-16.04
 
 jobs:
-- job: ${{ parameters.name }}
-  displayName: Cross
-  strategy:
-    matrix:
-      iOS_64:
-        vmImage: macOS-10.13
-        target: x86_64-apple-ios
+  - job: ${{ parameters.name }}
+    displayName: Cross
+    strategy:
+      matrix:
+        iOS_64:
+          vmImage: macOS-10.13
+          target: x86_64-apple-ios
 
-      iOS_32:
-        vmImage: macOS-10.13
-        target: i386-apple-ios
+        iOS_32:
+          vmImage: macOS-10.13
+          target: i386-apple-ios
 
-      iOS_ARM:
-        vmImage: macOS-10.13
-        target: armv7s-apple-ios
+        iOS_ARM:
+          vmImage: macOS-10.13
+          target: armv7s-apple-ios
 
-      Android:
-        vmImage: ubuntu-16.04
-        target: arm-linux-androideabi
+        Android:
+          vmImage: ubuntu-16.04
+          target: arm-linux-androideabi
 
-      Android_ARM64:
-        vmImage: ubuntu-16.04
-        target: aarch64-linux-android
+        Android_ARM64:
+          vmImage: ubuntu-16.04
+          target: aarch64-linux-android
 
-      Android_32:
-        vmImage: ubuntu-16.04
-        target: i686-unknown-linux-gnu
+        Android_32:
+          vmImage: ubuntu-16.04
+          target: i686-unknown-linux-gnu
 
-      NetBSD:
-        vmImage: ubuntu-16.04
-        target: x86_64-unknown-netbsd
+        NetBSD:
+          vmImage: ubuntu-16.04
+          target: x86_64-unknown-netbsd
 
-      Solaris:
-        vmImage: ubuntu-16.04
-        target: x86_64-sun-solaris
+        Solaris:
+          vmImage: ubuntu-16.04
+          target: x86_64-sun-solaris
 
-  pool:
-    vmImage: $(vmImage)
+    pool:
+      vmImage: $(vmImage)
 
-  steps:
-    - template: azure-install-rust.yml
-      parameters:
-        rust_version: stable
+    steps:
+      - template: azure-install-rust.yml
+        parameters:
+          rust_version: stable
 
-    - script: rustup target add $(target)
-      displayName: "Add target"
+      - script: rustup target add $(target)
+        displayName: "Add target"
 
-    - script: cargo check --target $(target)
-      displayName: Check source
+      - script: cargo check --target $(target)
+        displayName: Check source
 
-    - script: cargo check --tests --target $(target) --all-features
-      displayName: Check tests
+      - script: cargo check --tests --target $(target) --all-features
+        displayName: Check tests
 
-    - script: cargo check --examples --target $(target) --all-features
-      displayName: Check examples
+      - script: cargo check --examples --target $(target) --all-features
+        displayName: Check examples

--- a/ci/azure-deploy-docs.yml
+++ b/ci/azure-deploy-docs.yml
@@ -2,38 +2,37 @@ parameters:
   dependsOn: []
 
 jobs:
-- job: documentation
-  displayName: 'Deploy API Documentation'
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-  pool:
-    vmImage: 'Ubuntu 16.04'
-  dependsOn:
-    - ${{ parameters.dependsOn }}
-  steps:
-  - template: azure-install-rust.yml
-    parameters:
-      rust_version: stable
-  - script: |
-      cargo doc --no-deps
-      cp -R target/doc '$(Build.BinariesDirectory)'
-    displayName: 'Generate Documentation'
-  - script: |
-      set -e
+  - job: documentation
+    displayName: "Deploy API Documentation"
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    pool:
+      vmImage: "Ubuntu 16.04"
+    dependsOn:
+      - ${{ parameters.dependsOn }}
+    steps:
+      - template: azure-install-rust.yml
+        parameters:
+          rust_version: stable
+      - script: |
+          cargo doc --no-deps
+          cp -R target/doc '$(Build.BinariesDirectory)'
+        displayName: "Generate Documentation"
+      - script: |
+          set -e
 
-      git --version
-      ls -la
-      git init
-      git config user.name 'Deployment Bot (from Azure Pipelines)'
-      git config user.email 'deploy@tokio-rs.com'
-      git config --global credential.helper 'store --file ~/.my-credentials'
-      printf "protocol=https\nhost=github.com\nusername=carllerche\npassword=%s\n\n" "$GITHUB_TOKEN" | git credential-store --file ~/.my-credentials store
-      git remote add origin https://github.com/tokio-rs/mio
-      git checkout -b gh-pages
-      git add .
-      git commit -m 'Deploy Mio API documentation'
-      git push -f origin gh-pages
-    env:
-      GITHUB_TOKEN: $(githubPersonalToken)
-    workingDirectory: '$(Build.BinariesDirectory)'
-    displayName: 'Deploy Documentation'
-
+          git --version
+          ls -la
+          git init
+          git config user.name 'Deployment Bot (from Azure Pipelines)'
+          git config user.email 'deploy@tokio-rs.com'
+          git config --global credential.helper 'store --file ~/.my-credentials'
+          printf "protocol=https\nhost=github.com\nusername=carllerche\npassword=%s\n\n" "$GITHUB_TOKEN" | git credential-store --file ~/.my-credentials store
+          git remote add origin https://github.com/tokio-rs/mio
+          git checkout -b gh-pages
+          git add .
+          git commit -m 'Deploy Mio API documentation'
+          git push -f origin gh-pages
+        env:
+          GITHUB_TOKEN: $(githubPersonalToken)
+        workingDirectory: "$(Build.BinariesDirectory)"
+        displayName: "Deploy Documentation"

--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -27,7 +27,7 @@ steps:
 
   # All platforms.
   - script: |
-        rustup toolchain list
-        rustc -Vv
-        cargo -V
+      rustup toolchain list
+      rustc -Vv
+      cargo -V
     displayName: Query rust and cargo versions

--- a/ci/azure-minimal-versions.yml
+++ b/ci/azure-minimal-versions.yml
@@ -2,31 +2,31 @@ parameters:
   rust_version: nightly
 
 jobs:
-- job: ${{ parameters.name }}
-  displayName: Minimal versions
-  strategy:
-    matrix:
-      Linux:
-        vmImage: ubuntu-16.04
-      Windows:
-        vmImage: vs2017-win2016
-  pool:
-    vmImage: $(vmImage)
+  - job: ${{ parameters.name }}
+    displayName: Minimal versions
+    strategy:
+      matrix:
+        Linux:
+          vmImage: ubuntu-16.04
+        Windows:
+          vmImage: vs2017-win2016
+    pool:
+      vmImage: $(vmImage)
 
-  variables:
-    RUST_BACKTRACE: full
+    variables:
+      RUST_BACKTRACE: full
 
-  steps:
-  - template: azure-install-rust.yml
-    parameters:
-      rust_version: ${{ parameters.rust_version }}
+    steps:
+      - template: azure-install-rust.yml
+        parameters:
+          rust_version: ${{ parameters.rust_version }}
 
-  - script: cargo update -Zminimal-versions
-    displayName: cargo update -Zminimal-versions
-    env:
-      CI: 'True'
+      - script: cargo update -Zminimal-versions
+        displayName: cargo update -Zminimal-versions
+        env:
+          CI: "True"
 
-  - script: cargo test --all-features
-    displayName: cargo test --all-features
-    env:
-      CI: 'True'
+      - script: cargo test --all-features
+        displayName: cargo test --all-features
+        env:
+          CI: "True"

--- a/ci/azure-rustfmt.yml
+++ b/ci/azure-rustfmt.yml
@@ -1,16 +1,16 @@
 jobs:
-# Check formatting
-- job: ${{ parameters.name }}
-  displayName: Check rustfmt
-  pool:
-    vmImage: ubuntu-16.04
-  steps:
-    - template: azure-install-rust.yml
-      parameters:
-        rust_version: stable
-    - script: |
-        rustup component add rustfmt
-      displayName: Install rustfmt
-    - script: |
-        cargo fmt --all -- --check
-      displayName: Check formatting
+  # Check formatting
+  - job: ${{ parameters.name }}
+    displayName: Check rustfmt
+    pool:
+      vmImage: ubuntu-16.04
+    steps:
+      - template: azure-install-rust.yml
+        parameters:
+          rust_version: stable
+      - script: |
+          rustup component add rustfmt
+        displayName: Install rustfmt
+      - script: |
+          cargo fmt --all -- --check
+        displayName: Check formatting

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -3,38 +3,38 @@ parameters:
   rust_version: stable
 
 jobs:
-- job: ${{ parameters.name }}
-  displayName: ${{ parameters.displayName }}
-  strategy:
-    matrix:
-      Linux:
-        vmImage: ubuntu-16.04
+  - job: ${{ parameters.name }}
+    displayName: ${{ parameters.displayName }}
+    strategy:
+      matrix:
+        Linux:
+          vmImage: ubuntu-16.04
 
-      ${{ if parameters.cross }}:
-        MacOS:
-          vmImage: macOS-10.13
-        Windows:
-          vmImage: vs2017-win2016
-  pool:
-    vmImage: $(vmImage)
+        ${{ if parameters.cross }}:
+          MacOS:
+            vmImage: macOS-10.13
+          Windows:
+            vmImage: vs2017-win2016
+    pool:
+      vmImage: $(vmImage)
 
-  variables:
-    RUST_BACKTRACE: full
+    variables:
+      RUST_BACKTRACE: full
 
-  steps:
-  - template: azure-install-rust.yml
-    parameters:
-      rust_version: ${{ parameters.rust_version }}
+    steps:
+      - template: azure-install-rust.yml
+        parameters:
+          rust_version: ${{ parameters.rust_version }}
 
-  - script: cargo ${{ parameters.cmd }} --all-features
-    displayName: cargo ${{ parameters.cmd }} --all-features
-    env:
-      CI: 'True'
+      - script: cargo ${{ parameters.cmd }} --all-features
+        displayName: cargo ${{ parameters.cmd }} --all-features
+        env:
+          CI: "True"
 
-  - ${{ if eq(parameters.cmd, 'test') }}:
-    - script: cargo doc --no-deps
-      displayName: cargo doc --no-deps
+      - ${{ if eq(parameters.cmd, 'test') }}:
+          - script: cargo doc --no-deps
+            displayName: cargo doc --no-deps
 
-  - ${{ if parameters.benches }}:
-    - script: cargo check --benches
-      displayName: Check benchmarks
+      - ${{ if parameters.benches }}:
+          - script: cargo check --benches
+            displayName: Check benchmarks


### PR DESCRIPTION
## Motivation

The last few times I've changed these files for testing CI in draft PRs or for
upstream changes, I've had to turn off formatting so that my change didn't
include these. This reformats all the `.yaml` files related to CI so that in the
future this is not the extremely mild incovenience that it currently is :P

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
