### PR TITLE
Always use a timeout calling Poll::poll in tests

### DIFF
--- a/tests/close_on_drop.rs
+++ b/tests/close_on_drop.rs
@@ -1,12 +1,13 @@
 #![cfg(feature = "tcp")]
 
+use self::TestState::{AfterRead, Initial};
 use log::debug;
 use mio::net::{TcpListener, TcpStream};
 use mio::{Events, Interest, Poll, Token};
 use std::io::Read;
+
 mod util;
-use self::TestState::{AfterRead, Initial};
-use util::{any_local_address, init};
+use util::{any_local_address, init, NO_TIMEOUT};
 
 const SERVER: Token = Token(0);
 const CLIENT: Token = Token(1);
@@ -112,7 +113,8 @@ pub fn close_on_drop() {
 
     // == Run test
     while !handler.shutdown {
-        poll.poll(&mut events, None).unwrap();
+        poll.poll(&mut events, NO_TIMEOUT).unwrap();
+        assert!(!events.is_empty(), "expected at least one event");
 
         for event in &events {
             if event.is_readable() {

--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -13,6 +13,7 @@ mod util;
 
 use util::{
     any_local_address, assert_send, assert_sync, expect_events, init, init_with_poll, ExpectEvent,
+    NO_TIMEOUT,
 };
 
 const ID1: Token = Token(1);
@@ -142,7 +143,8 @@ fn drop_cancels_interest_and_shuts_down() {
         .unwrap();
     let mut events = Events::with_capacity(16);
     'outer: loop {
-        poll.poll(&mut events, None).unwrap();
+        poll.poll(&mut events, NO_TIMEOUT).unwrap();
+        assert!(!events.is_empty(), "expected at least one event");
         for event in &events {
             if event.token() == Token(1) {
                 // connected

--- a/tests/registering.rs
+++ b/tests/registering.rs
@@ -10,7 +10,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 mod util;
-use util::{any_local_address, init};
+use util::{any_local_address, init, NO_TIMEOUT};
 
 const SERVER: Token = Token(0);
 const CLIENT: Token = Token(1);
@@ -91,7 +91,8 @@ pub fn register_deregister() {
     let mut handler = TestHandler::new(server, client);
 
     loop {
-        poll.poll(&mut events, None).unwrap();
+        poll.poll(&mut events, NO_TIMEOUT).unwrap();
+        assert!(!events.is_empty(), "expected at least one event");
 
         if let Some(event) = events.iter().next() {
             if event.is_readable() {

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -18,6 +18,7 @@ mod util;
 use util::{
     any_local_address, any_local_ipv6_address, assert_error, assert_send, assert_sync,
     assert_would_block, expect_events, expect_no_events, init, init_with_poll, ExpectEvent,
+    NO_TIMEOUT,
 };
 
 const DATA1: &[u8] = b"Hello world!";
@@ -751,7 +752,8 @@ fn send_recv_udp(mut tx: UdpSocket, mut rx: UdpSocket, connected: bool) {
     let mut handler = UdpHandlerSendRecv::new(tx, rx, connected, "hello world");
 
     while !handler.shutdown {
-        poll.poll(&mut events, None).unwrap();
+        poll.poll(&mut events, NO_TIMEOUT).unwrap();
+        assert!(!events.is_empty(), "expected at least one event");
 
         for event in &events {
             if event.is_readable() {
@@ -954,7 +956,8 @@ pub fn multicast() {
     info!("Starting event loop to test with...");
 
     while !handler.shutdown {
-        poll.poll(&mut events, None).unwrap();
+        poll.poll(&mut events, NO_TIMEOUT).unwrap();
+        assert!(!events.is_empty(), "expected at least one event");
 
         for event in &events {
             if event.is_readable() {

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -12,6 +12,16 @@ use log::{error, warn};
 use mio::event::Event;
 use mio::{Events, Interest, Poll, Token};
 
+/// This timeout represents cases where we want to use no timeout, i.e. `None`,
+/// but we don't actually want to use no timeout as that could cause a failing
+/// test, one in which an event never comes, to run forever. This causes the CI
+/// to remain idle, up to one hour, after which its forcefully killed. This
+/// leaves us with a single line of logs; `test $name has been running for over
+/// 60 seconds`, not the best debugging experience. Instead we use this high,
+/// but not infinite, timeout after which assertions (that check the returned
+/// events) should start failing.
+pub const NO_TIMEOUT: Option<Duration> = Some(Duration::from_secs(10));
+
 pub fn init() {
     static INIT: Once = Once::new();
 


### PR DESCRIPTION
This is to prevent #1226 from happening too some extend, see the docs of `NO_TIMEOUT` in `tests/util/mod.rs`.