### PR TITLE
Draft: Check against feature combinations

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,13 @@ jobs:
       displayName: Test --release
       cmd: test --release
 
+  # Stable feature powerset
+  - template: ci/azure-test-stable.yml
+    parameters:
+      name: stable_feature_powerset
+      displayName: Check feature powerset
+      cmd: hack check --feature-powerset
+
   # Nightly
   - template: ci/azure-test-stable.yml
     parameters:

--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -30,4 +30,5 @@ steps:
       rustup toolchain list
       rustc -Vv
       cargo -V
+      cargo install cargo-hack
     displayName: Query rust and cargo versions

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -26,7 +26,7 @@ jobs:
         parameters:
           rust_version: ${{ parameters.rust_version }}
 
-      - ${{ if eq(parameters.cmd, 'test') }}:
+      - ${{ if contains(parameters.cmd, 'test') }}:
           - script: cargo ${{ parameters.cmd }} --all-features
             displayName: cargo ${{ parameters.cmd }} --all-features
             env:

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -32,11 +32,11 @@ jobs:
             env:
               CI: "True"
 
-      - ${{ if eq(parameters.cmd, 'test') }}:
+      - ${{ if contains(parameters.cmd, 'test') }}:
           - script: cargo doc --no-deps
             displayName: cargo doc --no-deps
 
-      - ${{ if ne(parameters.cmd, 'test') }}:
+      - ${{ if contains(parameters.cmd, 'check') }}:
           - script: cargo ${{ parameters.cmd }}
             displayName: cargo ${{ parameters.cmd }}
             env:

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -26,14 +26,21 @@ jobs:
         parameters:
           rust_version: ${{ parameters.rust_version }}
 
-      - script: cargo ${{ parameters.cmd }} --all-features
-        displayName: cargo ${{ parameters.cmd }} --all-features
-        env:
-          CI: "True"
+      - ${{ if eq(parameters.cmd, 'test') }}:
+          - script: cargo ${{ parameters.cmd }} --all-features
+            displayName: cargo ${{ parameters.cmd }} --all-features
+            env:
+              CI: "True"
 
       - ${{ if eq(parameters.cmd, 'test') }}:
           - script: cargo doc --no-deps
             displayName: cargo doc --no-deps
+
+      - ${{ if ne(parameters.cmd, 'test') }}:
+          - script: cargo ${{ parameters.cmd }}
+            displayName: cargo ${{ parameters.cmd }}
+            env:
+              CI: "True"
 
       - ${{ if parameters.benches }}:
           - script: cargo check --benches


### PR DESCRIPTION
## Draft

This may add a significant amount of time to CI, so this is starting out as a
draft to see what the change is. If it is too long, I'm going to just manually
add the combinations that should be tested.

The main difference between the feature powerset and what I would manually add
is the combinations will not include `guide`, reducing the amount of checks by
half.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
