### PR TITLE
Remove the bytes dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,9 +52,6 @@ ntapi  = "0.3"
 lazy_static = "1.4.0"
 
 [dev-dependencies]
-# Bytes v0.4 still depends on winapi v0.2, but Bytes v0.5 is released yet. So
-# for testing we'll use the git version.
-bytes      = { version = "0.5.0", git = "https://github.com/tokio-rs/bytes", rev = "79e4b2847f27137faaf149d116a352cbeae47fd1" }
 env_logger = { version = "0.6.2", default-features = false }
 tempdir    = "0.3.7"
 net2       = "0.2.33"


### PR DESCRIPTION
The types and traits from the bytes crate were only used in two tests
for the UdpSocket. But a Vec<u8> (now) has all the same functionality,
so we don't need the crate anymore.