### PR TITLE
Use io::Error::last_os_error in get_base_socket

### DIFF
--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -520,7 +520,7 @@ cfg_net! {
     use std::mem::size_of;
     use std::ptr::null_mut;
     use winapi::um::mswsock::SIO_BASE_HANDLE;
-    use winapi::um::winsock2::{WSAIoctl, INVALID_SOCKET, SOCKET_ERROR};
+    use winapi::um::winsock2::{WSAIoctl, SOCKET_ERROR};
 
     impl SelectorInner {
         pub fn register<S: SocketState + AsRawSocket>(
@@ -647,10 +647,11 @@ cfg_net! {
                 None,
             ) == SOCKET_ERROR
             {
-                return Err(io::Error::from_raw_os_error(INVALID_SOCKET as i32));
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(base_socket)
             }
         }
-        Ok(base_socket)
     }
 }
 


### PR DESCRIPTION
Using INVALID_SOCKET as i32 was invalid as INVALID_SOCKET had the
maximum value a 64 bit integer could hold, which doesn't find in 31
bits. Found by the new const_err lint in the nightly compiler.

For the CI failure found in #1240.

/cc @dtacalau 