### PR TITLE
Add back repr(transparent) to Event

### DIFF
--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -12,6 +12,7 @@ use std::fmt;
 /// [`Poll::poll`]: ../struct.Poll.html#method.poll
 /// [`Poll`]: ../struct.Poll.html
 /// [`Token`]: ../struct.Token.html
+#[repr(transparent)]
 pub struct Event {
     inner: sys::Event,
 }


### PR DESCRIPTION
I removed the attribute in pull request #1155, however we still need
this attribute for Event::from_sys_event_ref.

Original issue: #1122.