### PR TITLE
draft: Introduce `TcpSocket` (Unix right now)

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -9,7 +9,7 @@
 
 cfg_tcp! {
     mod tcp;
-    pub use self::tcp::{TcpListener, TcpStream};
+    pub use self::tcp::{TcpListener, TcpStream, TcpSocket};
 }
 
 cfg_udp! {

--- a/src/net/tcp/mod.rs
+++ b/src/net/tcp/mod.rs
@@ -3,3 +3,6 @@ pub use self::listener::TcpListener;
 
 mod stream;
 pub use self::stream::TcpStream;
+
+mod socket;
+pub use self::socket::TcpSocket;

--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -1,0 +1,41 @@
+use crate::sys;
+
+use std::io::Result;
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+
+/// todo
+#[derive(Debug)]
+pub struct TcpSocket {
+    inner: sys::Socket,
+}
+
+impl TcpSocket {
+    /// todo
+    pub fn new(domain: libc::c_int) -> Result<Self> {
+        sys::Socket::new(domain, libc::SOCK_STREAM, 0).map(|socket| TcpSocket { inner: socket })
+    }
+}
+
+#[cfg(unix)]
+impl AsRawFd for TcpSocket {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.as_raw_fd()
+    }
+}
+
+#[cfg(unix)]
+impl FromRawFd for TcpSocket {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        TcpSocket {
+            inner: FromRawFd::from_raw_fd(fd),
+        }
+    }
+}
+
+#[cfg(unix)]
+impl IntoRawFd for TcpSocket {
+    fn into_raw_fd(self) -> RawFd {
+        self.inner.into_raw_fd()
+    }
+}

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -68,11 +68,11 @@ cfg_os_poll! {
 
     cfg_uds! {
         pub use self::unix::SocketAddr;
-
         pub(crate) use self::unix::uds;
     }
 
     cfg_net! {
+        pub(crate) use self::unix::Socket;
         pub(crate) use self::unix::IoSourceState;
     }
 }

--- a/src/sys/shell/mod.rs
+++ b/src/sys/shell/mod.rs
@@ -11,6 +11,9 @@ mod waker;
 pub(crate) use self::waker::Waker;
 
 cfg_tcp! {
+    pub(crate) mod socket;
+    pub(crate) use self::socket::Socket;
+
     pub(crate) mod tcp;
 }
 

--- a/src/sys/shell/socket.rs
+++ b/src/sys/shell/socket.rs
@@ -1,0 +1,33 @@
+use std::io::Result;
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+
+#[derive(Debug)]
+pub(crate) struct Socket {}
+
+impl Socket {
+    pub(crate) fn new(_: libc::c_int, _: libc::c_int, _: libc::c_int) -> Result<Self> {
+        os_required!()
+    }
+}
+
+#[cfg(unix)]
+impl AsRawFd for Socket {
+    fn as_raw_fd(&self) -> RawFd {
+        os_required!()
+    }
+}
+
+#[cfg(unix)]
+impl FromRawFd for Socket {
+    unsafe fn from_raw_fd(_: RawFd) -> Self {
+        os_required!()
+    }
+}
+
+#[cfg(unix)]
+impl IntoRawFd for Socket {
+    fn into_raw_fd(self) -> RawFd {
+        os_required!()
+    }
+}

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -41,6 +41,9 @@ cfg_os_poll! {
     cfg_net! {
         use std::io;
 
+        pub(crate) mod socket;
+        pub(crate) use self::socket::Socket;
+
         // Both `kqueue` and `epoll` don't need to hold any user space state.
         pub(crate) struct IoSourceState;
 

--- a/src/sys/unix/net.rs
+++ b/src/sys/unix/net.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "os-poll", any(feature = "tcp", feature = "udp")))]
+#![cfg(any(feature = "tcp", feature = "udp"))]
 
 use std::net::SocketAddr;
 

--- a/src/sys/unix/net.rs
+++ b/src/sys/unix/net.rs
@@ -1,63 +1,8 @@
-#[cfg(all(feature = "os-poll", any(feature = "tcp", feature = "udp")))]
+#![cfg(all(feature = "os-poll", any(feature = "tcp", feature = "udp")))]
+
 use std::net::SocketAddr;
 
-#[cfg(all(feature = "os-poll", any(feature = "tcp", feature = "udp")))]
-pub(crate) fn new_ip_socket(
-    addr: SocketAddr,
-    socket_type: libc::c_int,
-) -> std::io::Result<libc::c_int> {
-    let domain = match addr {
-        SocketAddr::V4(..) => libc::AF_INET,
-        SocketAddr::V6(..) => libc::AF_INET6,
-    };
-
-    new_socket(domain, socket_type)
-}
-
-/// Create a new non-blocking socket.
-#[cfg(all(
-    feature = "os-poll",
-    any(feature = "tcp", feature = "udp", feature = "uds")
-))]
-pub(crate) fn new_socket(
-    domain: libc::c_int,
-    socket_type: libc::c_int,
-) -> std::io::Result<libc::c_int> {
-    #[cfg(any(
-        target_os = "android",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "linux",
-        target_os = "netbsd",
-        target_os = "openbsd"
-    ))]
-    let socket_type = socket_type | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
-
-    // Gives a warning for platforms without SOCK_NONBLOCK.
-    #[allow(clippy::let_and_return)]
-    let socket = syscall!(socket(domain, socket_type, 0));
-
-    // Darwin doesn't have SOCK_NONBLOCK or SOCK_CLOEXEC. Not sure about
-    // Solaris, couldn't find anything online.
-    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "solaris"))]
-    let socket = socket.and_then(|socket| {
-        // For platforms that don't support flags in socket, we need to
-        // set the flags ourselves.
-        syscall!(fcntl(socket, libc::F_SETFL, libc::O_NONBLOCK))
-            .and_then(|_| syscall!(fcntl(socket, libc::F_SETFD, libc::FD_CLOEXEC)).map(|_| socket))
-            .map_err(|e| {
-                // If either of the `fcntl` calls failed, ensure the socket is
-                // closed and return the error.
-                let _ = syscall!(close(socket));
-                e
-            })
-    });
-
-    socket
-}
-
-#[cfg(all(feature = "os-poll", any(feature = "tcp", feature = "udp")))]
-pub(crate) fn socket_addr(addr: &SocketAddr) -> (*const libc::sockaddr, libc::socklen_t) {
+pub(crate) fn from_socket_addr(addr: &SocketAddr) -> (*const libc::sockaddr, libc::socklen_t) {
     use std::mem::size_of_val;
 
     match addr {
@@ -73,7 +18,7 @@ pub(crate) fn socket_addr(addr: &SocketAddr) -> (*const libc::sockaddr, libc::so
 }
 
 /// `storage` must be initialised to `sockaddr_in` or `sockaddr_in6`.
-#[cfg(all(feature = "os-poll", feature = "tcp"))]
+#[cfg(feature = "tcp")]
 pub(crate) unsafe fn to_socket_addr(
     storage: *const libc::sockaddr_storage,
 ) -> std::io::Result<SocketAddr> {

--- a/src/sys/unix/socket.rs
+++ b/src/sys/unix/socket.rs
@@ -98,12 +98,16 @@ impl Socket {
     }
 
     #[cfg(any(feature = "tcp", feature = "udp"))]
-    pub(crate) fn from_addr(addr: SocketAddr, socket_type: libc::c_int) -> Result<Self> {
+    pub(crate) fn from_addr(
+        addr: SocketAddr,
+        socket_type: libc::c_int,
+        protocol: libc::c_int,
+    ) -> Result<Self> {
         let domain = match addr {
             SocketAddr::V4(..) => libc::AF_INET,
             SocketAddr::V6(..) => libc::AF_INET6,
         };
-        Self::new(domain, socket_type, 0)
+        Self::new(domain, socket_type, protocol)
     }
 
     #[cfg(feature = "tcp")]

--- a/src/sys/unix/socket.rs
+++ b/src/sys/unix/socket.rs
@@ -1,0 +1,189 @@
+#[cfg(any(feature = "tcp", feature = "udp"))]
+use crate::sys::unix::net::from_socket_addr;
+#[cfg(feature = "tcp")]
+use crate::sys::unix::net::to_socket_addr;
+use std::io::Result;
+#[cfg(any(feature = "tcp", feature = "udp"))]
+use std::mem;
+#[cfg(feature = "tcp")]
+use std::mem::MaybeUninit;
+#[cfg(any(feature = "tcp", feature = "udp"))]
+use std::net::SocketAddr;
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+
+#[derive(Debug)]
+pub(crate) struct Socket {
+    fd: libc::c_int,
+}
+
+impl Socket {
+    pub(crate) fn new(
+        domain: libc::c_int,
+        socket_type: libc::c_int,
+        protocol: libc::c_int,
+    ) -> Result<Self> {
+        #[cfg(any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "linux",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ))]
+        let socket_type = socket_type | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
+
+        // Gives a warning for platforms without SOCK_NONBLOCK.
+        #[allow(clippy::let_and_return)]
+        let socket = syscall!(socket(domain, socket_type, protocol));
+
+        // Darwin doesn't have SOCK_NONBLOCK or SOCK_CLOEXEC. Not sure about
+        // Solaris, couldn't find anything online.
+        #[cfg(any(target_os = "ios", target_os = "macos", target_os = "solaris"))]
+        let socket = socket.and_then(|socket| {
+            // For platforms that don't support flags in socket, we need to
+            // set the flags ourselves.
+            syscall!(fcntl(socket, libc::F_SETFL, libc::O_NONBLOCK))
+                .and_then(|_| {
+                    syscall!(fcntl(socket, libc::F_SETFD, libc::FD_CLOEXEC)).map(|_| socket)
+                })
+                .map_err(|e| {
+                    // If either of the `fcntl` calls failed, close the
+                    // socket. Ignore the error from closing since we can't
+                    // pass back two errors.
+                    let _ = syscall!(close(socket));
+                    e
+                })
+        });
+
+        socket.map(|socket| Socket { fd: socket })
+    }
+
+    #[cfg(any(feature = "tcp", feature = "udp"))]
+    pub(crate) fn from_addr(addr: SocketAddr, socket_type: libc::c_int) -> Result<Self> {
+        let domain = match addr {
+            SocketAddr::V4(..) => libc::AF_INET,
+            SocketAddr::V6(..) => libc::AF_INET6,
+        };
+        Self::new(domain, socket_type, 0)
+    }
+
+    #[cfg(feature = "tcp")]
+    pub(crate) fn connect(&self, addr: SocketAddr) -> Result<i32> {
+        let (storage, len) = from_socket_addr(&addr);
+        let res = syscall!(connect(self.fd, storage, len));
+        match res {
+            Ok(res) => Ok(res),
+            Err(ref err) if err.raw_os_error() == Some(libc::EINPROGRESS) => {
+                // Connect hasn't finished, but that is fine.
+                Ok(0)
+            }
+            Err(err) => {
+                // Close the socket if we hit an error, ignoring the error
+                // from closing since we can't pass back two errors.
+                let _ = unsafe { libc::close(self.fd) };
+                Err(err)
+            }
+        }
+    }
+
+    #[cfg(any(feature = "tcp", feature = "udp"))]
+    pub(crate) fn bind(&self, addr: SocketAddr) -> Result<i32> {
+        let (storage, len) = from_socket_addr(&addr);
+        syscall!(bind(self.fd, storage, len)).map_err(|err| {
+            // Close the socket if we hit an error, ignoring the error
+            // from closing since we can't pass back two errors.
+            let _ = unsafe { libc::close(self.fd) };
+            err
+        })
+    }
+
+    #[cfg(feature = "tcp")]
+    pub(crate) fn listen(&self, backlog: i32) -> Result<i32> {
+        syscall!(listen(self.fd, backlog))
+    }
+
+    #[cfg(feature = "tcp")]
+    pub(crate) fn accept(&self) -> Result<(Self, SocketAddr)> {
+        let mut storage: MaybeUninit<libc::sockaddr_storage> = MaybeUninit::uninit();
+        let mut len = mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+
+        // On platforms that support it we can use `accept4(2)` to set `NONBLOCK`
+        // and `CLOEXEC` in the call to accept the connection.
+        #[cfg(any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "linux",
+            target_os = "openbsd"
+        ))]
+        let socket = syscall!(accept4(
+            self.fd,
+            storage.as_mut_ptr() as *mut _,
+            &mut len,
+            libc::SOCK_CLOEXEC | libc::SOCK_NONBLOCK,
+        ))?;
+
+        // But not all platforms have the `accept4(2)` call. Luckily BSD (derived)
+        // OSes inherit the non-blocking flag from the listener, so we just have to
+        // set `CLOEXEC`.
+        #[cfg(any(
+            target_os = "ios",
+            target_os = "macos",
+            // NetBSD 8.0 actually has `accept4(2)`, but libc doesn't expose it
+            // (yet). See https://github.com/rust-lang/libc/issues/1636.
+            target_os = "netbsd",
+            target_os = "solaris",
+        ))]
+        let socket = {
+            let socket = syscall!(accept(self.fd, storage.as_mut_ptr() as *mut _, &mut len))?;
+            syscall!(fcntl(socket, libc::F_SETFD, libc::FD_CLOEXEC))?;
+            socket
+        };
+
+        // This is safe because `accept` calls above ensures the address
+        // initialised.
+        let socket_addr = unsafe { to_socket_addr(storage.as_ptr())? };
+
+        Ok((Socket { fd: socket }, socket_addr))
+    }
+
+    #[cfg(feature = "tcp")]
+    pub(crate) fn set_reuse_address(&self) -> Result<i32> {
+        syscall!(setsockopt(
+            self.fd,
+            libc::SOL_SOCKET,
+            libc::SO_REUSEADDR,
+            &1 as *const libc::c_int as *const libc::c_void,
+            mem::size_of::<libc::c_int>() as libc::socklen_t,
+        ))
+    }
+
+    #[cfg(feature = "udp")]
+    pub(crate) fn set_no_sigpipe(&self) -> Result<i32> {
+        syscall!(setsockopt(
+            self.fd,
+            libc::SOL_SOCKET,
+            libc::SO_NOSIGPIPE,
+            &1 as *const libc::c_int as *const libc::c_void,
+            mem::size_of::<libc::c_int>() as libc::socklen_t,
+        ))
+    }
+}
+
+impl AsRawFd for Socket {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
+    }
+}
+
+impl FromRawFd for Socket {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        Socket { fd }
+    }
+}
+
+impl IntoRawFd for Socket {
+    fn into_raw_fd(self) -> RawFd {
+        self.fd
+    }
+}

--- a/src/sys/unix/socket.rs
+++ b/src/sys/unix/socket.rs
@@ -3,7 +3,10 @@ use crate::sys::unix::net::from_socket_addr;
 #[cfg(feature = "tcp")]
 use crate::sys::unix::net::to_socket_addr;
 use std::io::Result;
-#[cfg(any(feature = "tcp", feature = "udp"))]
+#[cfg(any(
+    feature = "tcp",
+    all(any(target_os = "ios", target_os = "macos"), feature = "udp")
+))]
 use std::mem;
 #[cfg(feature = "tcp")]
 use std::mem::MaybeUninit;
@@ -204,6 +207,7 @@ impl Socket {
         ))
     }
 
+    #[cfg(any(target_os = "ios", target_os = "macos"))]
     #[cfg(feature = "udp")]
     pub(crate) fn set_no_sigpipe(&self) -> Result<i32> {
         syscall!(setsockopt(

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -5,7 +5,7 @@ use std::net::{self, SocketAddr};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 
 pub fn connect(addr: SocketAddr) -> io::Result<net::TcpStream> {
-    let socket = Socket::from_addr(addr, libc::SOCK_STREAM)?;
+    let socket = Socket::from_addr(addr, libc::SOCK_STREAM, 0)?;
 
     // Set SO_REUSEADDR (mirrors what libstd does).
     socket.set_reuse_address()?;
@@ -15,7 +15,7 @@ pub fn connect(addr: SocketAddr) -> io::Result<net::TcpStream> {
 }
 
 pub fn bind(addr: SocketAddr) -> io::Result<net::TcpListener> {
-    let socket = Socket::from_addr(addr, libc::SOCK_STREAM)?;
+    let socket = Socket::from_addr(addr, libc::SOCK_STREAM, 0)?;
     socket.bind(addr)?;
     socket.listen(1024)?;
     unsafe { Ok(net::TcpListener::from_raw_fd(socket.into_raw_fd())) }

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -1,101 +1,30 @@
-use std::io;
-use std::mem::{size_of, MaybeUninit};
-use std::net::{self, SocketAddr};
-use std::os::unix::io::{AsRawFd, FromRawFd};
+use crate::sys::Socket;
 
-use crate::sys::unix::net::{new_ip_socket, socket_addr, to_socket_addr};
+use std::io;
+use std::net::{self, SocketAddr};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 
 pub fn connect(addr: SocketAddr) -> io::Result<net::TcpStream> {
-    new_ip_socket(addr, libc::SOCK_STREAM)
-        .and_then(|socket| {
-            let (raw_addr, raw_addr_length) = socket_addr(&addr);
-            syscall!(connect(socket, raw_addr, raw_addr_length))
-                .or_else(|err| match err {
-                    // Connect hasn't finished, but that is fine.
-                    ref err if err.raw_os_error() == Some(libc::EINPROGRESS) => Ok(0),
-                    err => Err(err),
-                })
-                .map(|_| socket)
-                .map_err(|err| {
-                    // Close the socket if we hit an error, ignoring the error
-                    // from closing since we can't pass back two errors.
-                    let _ = unsafe { libc::close(socket) };
-                    err
-                })
-        })
-        .map(|socket| unsafe { net::TcpStream::from_raw_fd(socket) })
+    let socket = Socket::from_addr(addr, libc::SOCK_STREAM)?;
+
+    // Set SO_REUSEADDR (mirrors what libstd does).
+    socket.set_reuse_address()?;
+
+    socket.connect(addr)?;
+    unsafe { Ok(net::TcpStream::from_raw_fd(socket.into_raw_fd())) }
 }
 
 pub fn bind(addr: SocketAddr) -> io::Result<net::TcpListener> {
-    new_ip_socket(addr, libc::SOCK_STREAM).and_then(|socket| {
-        // Set SO_REUSEADDR (mirrors what libstd does).
-        syscall!(setsockopt(
-            socket,
-            libc::SOL_SOCKET,
-            libc::SO_REUSEADDR,
-            &1 as *const libc::c_int as *const libc::c_void,
-            size_of::<libc::c_int>() as libc::socklen_t,
-        ))
-        .and_then(|_| {
-            let (raw_addr, raw_addr_length) = socket_addr(&addr);
-            syscall!(bind(socket, raw_addr, raw_addr_length))
-        })
-        .and_then(|_| syscall!(listen(socket, 1024)))
-        .map_err(|err| {
-            // Close the socket if we hit an error, ignoring the error
-            // from closing since we can't pass back two errors.
-            let _ = unsafe { libc::close(socket) };
-            err
-        })
-        .map(|_| unsafe { net::TcpListener::from_raw_fd(socket) })
-    })
+    let socket = Socket::from_addr(addr, libc::SOCK_STREAM)?;
+    socket.bind(addr)?;
+    socket.listen(1024)?;
+    unsafe { Ok(net::TcpListener::from_raw_fd(socket.into_raw_fd())) }
 }
 
 pub fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream, SocketAddr)> {
-    let mut addr: MaybeUninit<libc::sockaddr_storage> = MaybeUninit::uninit();
-    let mut length = size_of::<libc::sockaddr_storage>() as libc::socklen_t;
-
-    // On platforms that support it we can use `accept4(2)` to set `NONBLOCK`
-    // and `CLOEXEC` in the call to accept the connection.
-    #[cfg(any(
-        target_os = "android",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "linux",
-        target_os = "openbsd"
-    ))]
-    let stream = {
-        syscall!(accept4(
-            listener.as_raw_fd(),
-            addr.as_mut_ptr() as *mut _,
-            &mut length,
-            libc::SOCK_CLOEXEC | libc::SOCK_NONBLOCK,
-        ))
-        .map(|socket| unsafe { net::TcpStream::from_raw_fd(socket) })
-    }?;
-
-    // But not all platforms have the `accept4(2)` call. Luckily BSD (derived)
-    // OSes inherit the non-blocking flag from the listener, so we just have to
-    // set `CLOEXEC`.
-    #[cfg(any(
-        target_os = "ios",
-        target_os = "macos",
-        // NetBSD 8.0 actually has `accept4(2)`, but libc doesn't expose it
-        // (yet). See https://github.com/rust-lang/libc/issues/1636.
-        target_os = "netbsd",
-        target_os = "solaris",
-    ))]
-    let stream = {
-        syscall!(accept(
-            listener.as_raw_fd(),
-            addr.as_mut_ptr() as *mut _,
-            &mut length
-        ))
-        .map(|socket| unsafe { net::TcpStream::from_raw_fd(socket) })
-        .and_then(|s| syscall!(fcntl(s.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC)).map(|_| s))
-    }?;
-
-    // This is safe because `accept` calls above ensures the address
-    // initialised.
-    unsafe { to_socket_addr(addr.as_ptr()) }.map(|addr| (stream, addr))
+    let socket = unsafe { Socket::from_raw_fd(listener.as_raw_fd()) };
+    socket.accept().map(|(socket, addr)| {
+        let stream = unsafe { net::TcpStream::from_raw_fd(socket.into_raw_fd()) };
+        (stream, addr)
+    })
 }

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -5,7 +5,7 @@ use std::net::{self, SocketAddr};
 use std::os::unix::io::{FromRawFd, IntoRawFd};
 
 pub fn bind(addr: SocketAddr) -> io::Result<net::UdpSocket> {
-    let socket = Socket::from_addr(addr, libc::SOCK_DGRAM)?;
+    let socket = Socket::from_addr(addr, libc::SOCK_DGRAM, 0)?;
 
     // Set SO_NOSIGPIPE on iOS and macOS (mirrors what libstd does).
     #[cfg(any(target_os = "ios", target_os = "macos"))]

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,36 +1,16 @@
-use crate::sys::unix::net::{new_ip_socket, socket_addr};
+use crate::sys::Socket;
 
 use std::io;
 use std::net::{self, SocketAddr};
-use std::os::unix::io::FromRawFd;
+use std::os::unix::io::{FromRawFd, IntoRawFd};
 
 pub fn bind(addr: SocketAddr) -> io::Result<net::UdpSocket> {
-    // Gives a warning for non Apple platforms.
-    #[allow(clippy::let_and_return)]
-    let socket = new_ip_socket(addr, libc::SOCK_DGRAM);
+    let socket = Socket::from_addr(addr, libc::SOCK_DGRAM)?;
 
     // Set SO_NOSIGPIPE on iOS and macOS (mirrors what libstd does).
     #[cfg(any(target_os = "ios", target_os = "macos"))]
-    let socket = socket.and_then(|socket| {
-        syscall!(setsockopt(
-            socket,
-            libc::SOL_SOCKET,
-            libc::SO_NOSIGPIPE,
-            &1 as *const libc::c_int as *const libc::c_void,
-            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-        ))
-        .map(|_| socket)
-    });
+    socket.set_no_sigpipe()?;
 
-    socket.and_then(|socket| {
-        let (raw_addr, raw_addr_length) = socket_addr(&addr);
-        syscall!(bind(socket, raw_addr, raw_addr_length))
-            .map_err(|err| {
-                // Close the socket if we hit an error, ignoring the error
-                // from closing since we can't pass back two errors.
-                let _ = unsafe { libc::close(socket) };
-                err
-            })
-            .map(|_| unsafe { net::UdpSocket::from_raw_fd(socket) })
-    })
+    socket.bind(addr)?;
+    unsafe { Ok(net::UdpSocket::from_raw_fd(socket.into_raw_fd())) }
 }

--- a/src/sys/unix/uds/datagram.rs
+++ b/src/sys/unix/uds/datagram.rs
@@ -1,4 +1,4 @@
-use super::{socket_addr, SocketAddr};
+use super::{from_socket_addr, SocketAddr};
 use crate::sys::Socket;
 
 use std::io;
@@ -10,7 +10,7 @@ pub(crate) fn bind(path: &Path) -> io::Result<net::UnixDatagram> {
     let socket = Socket::new(libc::AF_UNIX, libc::SOCK_DGRAM, 0)?;
 
     // `Socket::bind` does not satisfy this case because of Mio's `SocketAddr`.
-    let (storage, len) = socket_addr(path)?;
+    let (storage, len) = from_socket_addr(path)?;
     let sockaddr = &storage as *const libc::sockaddr_un as *const _;
     match syscall!(bind(socket.as_raw_fd(), sockaddr, len)) {
         Ok(_) => Ok(unsafe { net::UnixDatagram::from_raw_fd(socket.into_raw_fd()) }),

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -22,8 +22,8 @@ pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, So
     let socket = unsafe { Socket::from_raw_fd(listener.as_raw_fd()) };
     let storage = mem::MaybeUninit::<libc::sockaddr_un>::zeroed();
 
-    // This is safe to assume because a `libc::sockaddr_un` filled with `0`
-    // bytes is properly initialized.
+    // Safety: A `libc::sockaddr_un` initialized with `0` bytes is properly
+    // initialized.
     //
     // `0` is a valid value for `sockaddr_un::sun_family`; it is
     // `libc::AF_UNSPEC`.

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -1,15 +1,20 @@
 use super::socket_addr;
 use crate::net::{SocketAddr, UnixStream};
-use crate::sys::unix::net::new_socket;
+use crate::sys::Socket;
+
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::os::unix::net;
 use std::path::Path;
 use std::{io, mem};
 
 pub(crate) fn bind(path: &Path) -> io::Result<net::UnixListener> {
-    let socket = new_socket(libc::AF_UNIX, libc::SOCK_STREAM)?;
+    let socket = Socket::new(libc::AF_UNIX, libc::SOCK_STREAM, 0)?;
     let (sockaddr, socklen) = socket_addr(path)?;
     let sockaddr = &sockaddr as *const libc::sockaddr_un as *const libc::sockaddr;
+
+    // temp: Most of the below can be moved into `Socket` methods. Create a
+    // `RawFd` for now until those are added.
+    let socket = socket.as_raw_fd();
 
     syscall!(bind(socket, sockaddr, socklen))
         .and_then(|_| syscall!(listen(socket, 1024)))

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -2,21 +2,18 @@ use super::socket_addr;
 use crate::net::{SocketAddr, UnixStream};
 use crate::sys::Socket;
 
-use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::os::unix::net;
 use std::path::Path;
 use std::{io, mem};
 
 pub(crate) fn bind(path: &Path) -> io::Result<net::UnixListener> {
-    let socket = Socket::new(libc::AF_UNIX, libc::SOCK_STREAM, 0)?;
-    let (sockaddr, socklen) = socket_addr(path)?;
-    let sockaddr = &sockaddr as *const libc::sockaddr_un as *const libc::sockaddr;
+    let socket = Socket::new(libc::AF_UNIX, libc::SOCK_STREAM, 0)?.into_raw_fd();
+    let (storage, len) = socket_addr(path)?;
+    let sockaddr = &storage as *const libc::sockaddr_un as *const libc::sockaddr;
 
-    // temp: Most of the below can be moved into `Socket` methods. Create a
-    // `RawFd` for now until those are added.
-    let socket = socket.as_raw_fd();
-
-    syscall!(bind(socket, sockaddr, socklen))
+    // `Socket::bind` does not satisfy this case because of Mio's `SocketAddr`.
+    syscall!(bind(socket, sockaddr, len))
         .and_then(|_| syscall!(listen(socket, 1024)))
         .map_err(|err| {
             // Close the socket if we hit an error, ignoring the error from

--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -26,7 +26,7 @@ cfg_os_poll! {
     pub(crate) mod listener;
     pub(crate) mod stream;
 
-    pub(in crate::sys) fn socket_addr(path: &Path) -> io::Result<(libc::sockaddr_un, libc::socklen_t)> {
+    pub(crate) fn from_socket_addr(path: &Path) -> io::Result<(libc::sockaddr_un, libc::socklen_t)> {
         let sockaddr = mem::MaybeUninit::<libc::sockaddr_un>::zeroed();
 
         // This is safe to assume because a `libc::sockaddr_un` filled with `0`
@@ -96,7 +96,7 @@ cfg_os_poll! {
 
     #[cfg(test)]
     mod tests {
-        use super::{path_offset, socket_addr};
+        use super::{path_offset, from_socket_addr};
         use std::path::Path;
         use std::str;
 
@@ -108,7 +108,7 @@ cfg_os_poll! {
             // Pathname addresses do have a null terminator, so `socklen` is
             // expected to be `PATH_LEN` + `offset` + 1.
             let path = Path::new(PATH);
-            let (sockaddr, actual) = socket_addr(path).unwrap();
+            let (sockaddr, actual) = from_socket_addr(path).unwrap();
             let offset = path_offset(&sockaddr);
             let expected = PATH_LEN + offset + 1;
             assert_eq!(expected as libc::socklen_t, actual)
@@ -123,7 +123,7 @@ cfg_os_poll! {
             // expected to be `PATH_LEN` + `offset`.
             let abstract_path = str::from_utf8(PATH).unwrap();
             let path = Path::new(abstract_path);
-            let (sockaddr, actual) = socket_addr(path).unwrap();
+            let (sockaddr, actual) = from_socket_addr(path).unwrap();
             let offset = path_offset(&sockaddr);
             let expected = PATH_LEN + offset;
             assert_eq!(expected as libc::socklen_t, actual)

--- a/src/sys/unix/uds/stream.rs
+++ b/src/sys/unix/uds/stream.rs
@@ -1,5 +1,5 @@
 use super::{socket_addr, SocketAddr};
-use crate::sys::unix::net::new_socket;
+use crate::sys::Socket;
 
 use std::io;
 use std::os::unix::io::{AsRawFd, FromRawFd};
@@ -7,9 +7,13 @@ use std::os::unix::net;
 use std::path::Path;
 
 pub(crate) fn connect(path: &Path) -> io::Result<net::UnixStream> {
-    let socket = new_socket(libc::AF_UNIX, libc::SOCK_STREAM)?;
+    let socket = Socket::new(libc::AF_UNIX, libc::SOCK_STREAM, 0)?;
     let (sockaddr, socklen) = socket_addr(path)?;
     let sockaddr = &sockaddr as *const libc::sockaddr_un as *const libc::sockaddr;
+
+    // temp: Most of the below can be moved into `Socket` methods. Create a
+    // `RawFd` for now until those are added.
+    let socket = socket.as_raw_fd();
 
     match syscall!(connect(socket, sockaddr, socklen)) {
         Ok(_) => {}

--- a/src/sys/unix/uds/stream.rs
+++ b/src/sys/unix/uds/stream.rs
@@ -1,4 +1,4 @@
-use super::{socket_addr, SocketAddr};
+use super::{from_socket_addr, SocketAddr};
 use crate::sys::Socket;
 
 use std::io;
@@ -6,9 +6,10 @@ use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::os::unix::net;
 use std::path::Path;
 
+// Todo: Use `Socket::connect`
 pub(crate) fn connect(path: &Path) -> io::Result<net::UnixStream> {
     let socket = Socket::new(libc::AF_UNIX, libc::SOCK_STREAM, 0)?.into_raw_fd();
-    let (sockaddr, socklen) = socket_addr(path)?;
+    let (sockaddr, socklen) = from_socket_addr(path)?;
     let sockaddr = &sockaddr as *const libc::sockaddr_un as *const libc::sockaddr;
 
     // `Socket::connect` does not satisfy this case because of Mio's `SocketAddr`.

--- a/src/sys/unix/uds/stream.rs
+++ b/src/sys/unix/uds/stream.rs
@@ -6,26 +6,14 @@ use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::os::unix::net;
 use std::path::Path;
 
-// Todo: Use `Socket::connect`
 pub(crate) fn connect(path: &Path) -> io::Result<net::UnixStream> {
-    let socket = Socket::new(libc::AF_UNIX, libc::SOCK_STREAM, 0)?.into_raw_fd();
-    let (sockaddr, socklen) = from_socket_addr(path)?;
-    let sockaddr = &sockaddr as *const libc::sockaddr_un as *const libc::sockaddr;
-
-    // `Socket::connect` does not satisfy this case because of Mio's `SocketAddr`.
-    match syscall!(connect(socket, sockaddr, socklen)) {
-        Ok(_) => {}
-        Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {}
-        Err(e) => {
-            // Close the socket if we hit an error, ignoring the error
-            // from closing since we can't pass back two errors.
-            let _ = unsafe { libc::close(socket) };
-
-            return Err(e);
-        }
-    }
-
-    Ok(unsafe { net::UnixStream::from_raw_fd(socket) })
+    let socket = Socket::new(libc::AF_UNIX, libc::SOCK_STREAM, 0)?;
+    let (storage, len) = from_socket_addr(path)?;
+    socket.connect2(
+        &storage as *const libc::sockaddr_un as *const libc::sockaddr,
+        len,
+    )?;
+    Ok(unsafe { net::UnixStream::from_raw_fd(socket.into_raw_fd()) })
 }
 
 pub(crate) fn pair() -> io::Result<(net::UnixStream, net::UnixStream)> {

--- a/src/sys/unix/uds/stream.rs
+++ b/src/sys/unix/uds/stream.rs
@@ -2,19 +2,16 @@ use super::{socket_addr, SocketAddr};
 use crate::sys::Socket;
 
 use std::io;
-use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::os::unix::net;
 use std::path::Path;
 
 pub(crate) fn connect(path: &Path) -> io::Result<net::UnixStream> {
-    let socket = Socket::new(libc::AF_UNIX, libc::SOCK_STREAM, 0)?;
+    let socket = Socket::new(libc::AF_UNIX, libc::SOCK_STREAM, 0)?.into_raw_fd();
     let (sockaddr, socklen) = socket_addr(path)?;
     let sockaddr = &sockaddr as *const libc::sockaddr_un as *const libc::sockaddr;
 
-    // temp: Most of the below can be moved into `Socket` methods. Create a
-    // `RawFd` for now until those are added.
-    let socket = socket.as_raw_fd();
-
+    // `Socket::connect` does not satisfy this case because of Mio's `SocketAddr`.
     match syscall!(connect(socket, sockaddr, socklen)) {
         Ok(_) => {}
         Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {}

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -36,14 +36,17 @@ mod waker;
 pub(crate) use waker::Waker;
 
 cfg_net! {
+    use crate::{poll, Interest, Registry, Token};
+
     use std::io;
     use std::os::windows::io::RawSocket;
     use std::pin::Pin;
     use std::sync::{Arc, Mutex};
 
-    use crate::{poll, Interest, Registry, Token};
-
     mod net;
+
+    pub(crate) mod socket;
+    pub(crate) use self::socket::Socket;
 
     struct InternalState {
         selector: Arc<SelectorInner>,

--- a/src/sys/windows/net.rs
+++ b/src/sys/windows/net.rs
@@ -1,45 +1,24 @@
-use std::io;
 use std::mem::size_of_val;
 use std::net::SocketAddr;
-#[cfg(all(feature = "os-poll", feature = "tcp"))]
+#[cfg(feature = "tcp")]
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 use std::sync::Once;
 
 use winapi::ctypes::c_int;
 use winapi::shared::ws2def::SOCKADDR;
-use winapi::um::winsock2::{
-    ioctlsocket, socket, FIONBIO, INVALID_SOCKET, PF_INET, PF_INET6, SOCKET,
-};
 
 /// Initialise the network stack for Windows.
 pub(crate) fn init() {
     static INIT: Once = Once::new();
     INIT.call_once(|| {
         // Let standard library call `WSAStartup` for us, we can't do it
-        // ourselves because otherwise using any type in `std::net` would panic
-        // when it tries to call `WSAStartup` a second time.
+        // ourselves because otherwise using any type in `std::net` would
+        // panic when it tries to call `WSAStartup` a second time.
         drop(std::net::UdpSocket::bind("127.0.0.1:0"));
     });
 }
 
-/// Create a new non-blocking socket.
-pub(crate) fn new_socket(addr: SocketAddr, socket_type: c_int) -> io::Result<SOCKET> {
-    let domain = match addr {
-        SocketAddr::V4(..) => PF_INET,
-        SocketAddr::V6(..) => PF_INET6,
-    };
-
-    syscall!(
-        socket(domain, socket_type, 0),
-        PartialEq::eq,
-        INVALID_SOCKET
-    )
-    .and_then(|socket| {
-        syscall!(ioctlsocket(socket, FIONBIO, &mut 1), PartialEq::ne, 0).map(|_| socket as SOCKET)
-    })
-}
-
-pub(crate) fn socket_addr(addr: &SocketAddr) -> (*const SOCKADDR, c_int) {
+pub(crate) fn from_socket_addr(addr: &SocketAddr) -> (*const SOCKADDR, c_int) {
     match addr {
         SocketAddr::V4(ref addr) => (
             addr as *const _ as *const SOCKADDR,
@@ -52,8 +31,8 @@ pub(crate) fn socket_addr(addr: &SocketAddr) -> (*const SOCKADDR, c_int) {
     }
 }
 
-#[cfg(all(feature = "os-poll", feature = "tcp"))]
-pub(crate) fn inaddr_any(other: SocketAddr) -> SocketAddr {
+#[cfg(feature = "tcp")]
+pub(crate) fn any_socket_addr(other: SocketAddr) -> SocketAddr {
     match other {
         SocketAddr::V4(..) => {
             let any = Ipv4Addr::new(0, 0, 0, 0);

--- a/src/sys/windows/socket.rs
+++ b/src/sys/windows/socket.rs
@@ -30,12 +30,12 @@ impl Socket {
         Ok(unsafe { Socket::from_raw_socket(socket as StdSocket) })
     }
 
-    pub(crate) fn from_addr(addr: SocketAddr, socket_type: c_int) -> Result<Self> {
+    pub(crate) fn from_addr(addr: SocketAddr, socket_type: c_int, protocol: c_int) -> Result<Self> {
         let af = match addr {
             SocketAddr::V4(..) => PF_INET,
             SocketAddr::V6(..) => PF_INET6,
         };
-        Self::new(af, socket_type, 0)
+        Self::new(af, socket_type, protocol)
     }
 
     #[cfg(feature = "tcp")]

--- a/src/sys/windows/socket.rs
+++ b/src/sys/windows/socket.rs
@@ -1,0 +1,94 @@
+use crate::sys::windows::net::from_socket_addr;
+
+use std::io::{self, Result};
+use std::net::SocketAddr;
+use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
+use std::os::windows::raw::SOCKET as StdSocket; // winapi uses usize, stdlib uses u32/u64.
+
+use winapi::ctypes::c_int;
+use winapi::um::winsock2::{
+    bind, closesocket, ioctlsocket, socket, FIONBIO, INVALID_SOCKET, PF_INET, PF_INET6, SOCKET,
+    SOCKET_ERROR,
+};
+#[cfg(feature = "tcp")]
+use winapi::um::winsock2::{connect, listen};
+
+pub(crate) struct Socket {
+    socket: SOCKET,
+}
+
+impl Socket {
+    pub(crate) fn new(af: c_int, socket_type: c_int, protocol: c_int) -> Result<Self> {
+        let socket = syscall!(
+            socket(af, socket_type, protocol),
+            PartialEq::eq,
+            INVALID_SOCKET
+        )?;
+        // Set the socket I/O mode: FIOBIO enables non-blocking based on the
+        // numerical value of iMode (1).
+        syscall!(ioctlsocket(socket, FIONBIO, &mut 1), PartialEq::ne, 0)?;
+        Ok(unsafe { Socket::from_raw_socket(socket as StdSocket) })
+    }
+
+    pub(crate) fn from_addr(addr: SocketAddr, socket_type: c_int) -> Result<Self> {
+        let af = match addr {
+            SocketAddr::V4(..) => PF_INET,
+            SocketAddr::V6(..) => PF_INET6,
+        };
+        Self::new(af, socket_type, 0)
+    }
+
+    #[cfg(feature = "tcp")]
+    pub(crate) fn connect(&self, addr: SocketAddr) -> Result<i32> {
+        let (storage, len) = from_socket_addr(&addr);
+        match syscall!(
+            connect(self.socket, storage, len),
+            PartialEq::eq,
+            SOCKET_ERROR
+        ) {
+            Ok(res) => Ok(res),
+            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => Ok(0),
+            Err(err) => {
+                // Close the socket if we hit an error, ignoring the error
+                // from closing since we can't pass back two errors.
+                let _ = unsafe { closesocket(self.socket) };
+                Err(err)
+            }
+        }
+    }
+
+    pub(crate) fn bind(&self, addr: SocketAddr) -> Result<i32> {
+        let (storage, len) = from_socket_addr(&addr);
+        syscall!(bind(self.socket, storage, len), PartialEq::eq, SOCKET_ERROR).map_err(|err| {
+            // Close the socket if we hit an error, ignoring the error from
+            // closing since we can't pass back two errors.
+            let _ = unsafe { closesocket(self.socket) };
+            err
+        })
+    }
+
+    #[cfg(feature = "tcp")]
+    pub(crate) fn listen(&self, backlog: i32) -> Result<i32> {
+        syscall!(listen(self.socket, backlog), PartialEq::eq, SOCKET_ERROR)
+    }
+}
+
+impl AsRawSocket for Socket {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.socket as StdSocket
+    }
+}
+
+impl FromRawSocket for Socket {
+    unsafe fn from_raw_socket(socket: RawSocket) -> Self {
+        Socket {
+            socket: socket as SOCKET,
+        }
+    }
+}
+
+impl IntoRawSocket for Socket {
+    fn into_raw_socket(self) -> RawSocket {
+        self.socket as StdSocket
+    }
+}

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -9,7 +9,7 @@ use winapi::um::winsock2::SOCK_STREAM;
 
 pub fn connect(addr: SocketAddr) -> io::Result<net::TcpStream> {
     init();
-    let socket = Socket::from_addr(addr, SOCK_STREAM)?;
+    let socket = Socket::from_addr(addr, SOCK_STREAM, 0)?;
 
     // Required for a future `connect_overlapped` operation to be executed
     // successfully (todo: ?).
@@ -22,7 +22,7 @@ pub fn connect(addr: SocketAddr) -> io::Result<net::TcpStream> {
 
 pub fn bind(addr: SocketAddr) -> io::Result<net::TcpListener> {
     init();
-    let socket = Socket::from_addr(addr, SOCK_STREAM)?;
+    let socket = Socket::from_addr(addr, SOCK_STREAM, 0)?;
     socket.bind(addr)?;
     socket.listen(1024)?;
     Ok(unsafe { net::TcpListener::from_raw_socket(socket.into_raw_socket()) })

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -1,68 +1,31 @@
+use crate::sys::windows::net::{any_socket_addr, init};
+use crate::sys::Socket;
+
 use std::io;
 use std::net::{self, SocketAddr};
-use std::os::windows::io::FromRawSocket;
-use std::os::windows::raw::SOCKET as StdSocket; // winapi uses usize, stdlib uses u32/u64.
+use std::os::windows::io::{FromRawSocket, IntoRawSocket};
 
-use winapi::um::winsock2::{
-    bind as win_bind, closesocket, connect as win_connect, listen, SOCKET_ERROR, SOCK_STREAM,
-};
-
-use crate::sys::windows::net::{inaddr_any, init, new_socket, socket_addr};
+use winapi::um::winsock2::SOCK_STREAM;
 
 pub fn connect(addr: SocketAddr) -> io::Result<net::TcpStream> {
     init();
-    new_socket(addr, SOCK_STREAM)
-        .and_then(|socket| {
-            // Required for a future `connect_overlapped` operation to be
-            // executed successfully.
-            let any_addr = inaddr_any(addr);
-            let (raw_addr, raw_addr_length) = socket_addr(&any_addr);
-            syscall!(
-                win_bind(socket, raw_addr, raw_addr_length),
-                PartialEq::eq,
-                SOCKET_ERROR
-            )
-            .and_then(|_| {
-                let (raw_addr, raw_addr_length) = socket_addr(&addr);
-                syscall!(
-                    win_connect(socket, raw_addr, raw_addr_length),
-                    PartialEq::eq,
-                    SOCKET_ERROR
-                )
-                .or_else(|err| match err {
-                    ref err if err.kind() == io::ErrorKind::WouldBlock => Ok(0),
-                    err => Err(err),
-                })
-            })
-            .map(|_| socket)
-            .map_err(|err| {
-                // Close the socket if we hit an error, ignoring the error
-                // from closing since we can't pass back two errors.
-                let _ = unsafe { closesocket(socket) };
-                err
-            })
-        })
-        .map(|socket| unsafe { net::TcpStream::from_raw_socket(socket as StdSocket) })
+    let socket = Socket::from_addr(addr, SOCK_STREAM)?;
+
+    // Required for a future `connect_overlapped` operation to be executed
+    // successfully (todo: ?).
+    let any_addr = any_socket_addr(addr);
+
+    socket.bind(any_addr)?;
+    socket.connect(addr)?;
+    Ok(unsafe { net::TcpStream::from_raw_socket(socket.into_raw_socket()) })
 }
 
 pub fn bind(addr: SocketAddr) -> io::Result<net::TcpListener> {
     init();
-    new_socket(addr, SOCK_STREAM).and_then(|socket| {
-        let (raw_addr, raw_addr_length) = socket_addr(&addr);
-        syscall!(
-            win_bind(socket, raw_addr, raw_addr_length,),
-            PartialEq::eq,
-            SOCKET_ERROR
-        )
-        .and_then(|_| syscall!(listen(socket, 1024), PartialEq::eq, SOCKET_ERROR))
-        .map_err(|err| {
-            // Close the socket if we hit an error, ignoring the error
-            // from closing since we can't pass back two errors.
-            let _ = unsafe { closesocket(socket) };
-            err
-        })
-        .map(|_| unsafe { net::TcpListener::from_raw_socket(socket as StdSocket) })
-    })
+    let socket = Socket::from_addr(addr, SOCK_STREAM)?;
+    socket.bind(addr)?;
+    socket.listen(1024)?;
+    Ok(unsafe { net::TcpListener::from_raw_socket(socket.into_raw_socket()) })
 }
 
 pub fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream, SocketAddr)> {

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -9,7 +9,7 @@ use winapi::um::winsock2::SOCK_DGRAM;
 
 pub fn bind(addr: SocketAddr) -> io::Result<net::UdpSocket> {
     init();
-    let socket = Socket::from_addr(addr, SOCK_DGRAM)?;
+    let socket = Socket::from_addr(addr, SOCK_DGRAM, 0)?;
     socket.bind(addr)?;
     Ok(unsafe { net::UdpSocket::from_raw_socket(socket.into_raw_socket()) })
 }

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -1,27 +1,15 @@
+use crate::sys::windows::net::init;
+use crate::sys::Socket;
+
 use std::io;
 use std::net::{self, SocketAddr};
-use std::os::windows::io::FromRawSocket;
-use std::os::windows::raw::SOCKET as StdSocket; // winapi uses usize, stdlib uses u32/u64.
+use std::os::windows::io::{FromRawSocket, IntoRawSocket};
 
-use winapi::um::winsock2::{bind as win_bind, closesocket, SOCKET_ERROR, SOCK_DGRAM};
-
-use crate::sys::windows::net::{init, new_socket, socket_addr};
+use winapi::um::winsock2::SOCK_DGRAM;
 
 pub fn bind(addr: SocketAddr) -> io::Result<net::UdpSocket> {
     init();
-    new_socket(addr, SOCK_DGRAM).and_then(|socket| {
-        let (raw_addr, raw_addr_length) = socket_addr(&addr);
-        syscall!(
-            win_bind(socket, raw_addr, raw_addr_length,),
-            PartialEq::eq,
-            SOCKET_ERROR
-        )
-        .map_err(|err| {
-            // Close the socket if we hit an error, ignoring the error
-            // from closing since we can't pass back two errors.
-            let _ = unsafe { closesocket(socket) };
-            err
-        })
-        .map(|_| unsafe { net::UdpSocket::from_raw_socket(socket as StdSocket) })
-    })
+    let socket = Socket::from_addr(addr, SOCK_DGRAM)?;
+    socket.bind(addr)?;
+    Ok(unsafe { net::UdpSocket::from_raw_socket(socket.into_raw_socket()) })
 }

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -1,0 +1,13 @@
+#![cfg(all(feature = "os-poll", feature = "tcp"))]
+
+use mio::net::TcpSocket;
+
+mod util;
+use util::{assert_socket_close_on_exec, assert_socket_non_blocking};
+
+#[test]
+fn it_works() {
+    let socket = TcpSocket::new(libc::AF_INET).unwrap();
+    assert_socket_close_on_exec(&socket);
+    assert_socket_non_blocking(&socket);
+}


### PR DESCRIPTION
Depends on #1258 

Draft to test targets other than MacOS and Linux.