### PR TITLE
Implement ExactSizeIterator and FusedIterator for events::Iter

### DIFF
--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -208,7 +208,38 @@ impl<'a> Iterator for Iter<'a> {
         self.pos += 1;
         ret
     }
+
+    #[doc(hidden)]
+    #[cfg(not(debug_assertions))]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+
+    #[doc(hidden)]
+    #[cfg(not(debug_assertions))]
+    fn count(self) -> usize {
+        self.len()
+    }
 }
+
+/// Not part of the stable API.
+///
+/// This is only implemented as an optimisation on some platforms.
+#[doc(hidden)]
+#[cfg(not(debug_assertions))]
+impl<'a> ExactSizeIterator for Iter<'a> {
+    fn len(&self) -> usize {
+        self.inner.inner.len().saturating_sub(self.pos)
+    }
+}
+
+/// Not part of the stable API.
+///
+/// This is only implemented as an optimisation on some platforms.
+#[doc(hidden)]
+#[cfg(not(debug_assertions))]
+impl<'a> std::iter::FusedIterator for Iter<'a> {}
 
 impl fmt::Debug for Events {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -322,6 +322,11 @@ impl Events {
     pub fn with_capacity(capacity: usize) -> Events {
         Events(Vec::with_capacity(capacity))
     }
+
+    #[cfg(not(debug_assertions))]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 }
 
 impl Deref for Events {

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -98,6 +98,11 @@ impl Events {
         }
     }
 
+    #[cfg(not(debug_assertions))]
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.events.is_empty()
     }


### PR DESCRIPTION
I know @carllerche was against this previously because maybe not all platforms could support it. But this pr only enables it for release build to enforce it is not part of the stable API.