### PR TITLE
Make Events' fmt::Debug implementation more useful

### DIFF
--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -212,8 +212,6 @@ impl<'a> Iterator for Iter<'a> {
 
 impl fmt::Debug for Events {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Events")
-            .field("capacity", &self.capacity())
-            .finish()
+        f.debug_list().entries(self).finish()
     }
 }


### PR DESCRIPTION
Now that Event has a nice debug output Events can make use of it.