### PR TITLE
Add comments on how to run the examples

### DIFF
--- a/examples/tcp_server.rs
+++ b/examples/tcp_server.rs
@@ -1,3 +1,5 @@
+// You can run this example from the root of the mio repo:
+// cargo run --example tcp_server --features="os-poll tcp"
 use mio::event::Event;
 use mio::net::{TcpListener, TcpStream};
 use mio::{Events, Interest, Poll, Registry, Token};

--- a/examples/udp_server.rs
+++ b/examples/udp_server.rs
@@ -1,3 +1,5 @@
+// You can run this example from the root of the mio repo:
+// cargo run --example udp_server --features="os-poll udp"
 use log::warn;
 use mio::net::UdpSocket;
 use mio::{Events, Interest, Poll, Token};


### PR DESCRIPTION
It took me some time to figure out how to run the examples until I learned that Cargo supports "examples" out of the box. Initially, I tried to copy the file into my own project but I had trouble using the `TcpServer` before I didn't know how to enable the `tcp` feature. 

Adding this comment will hopefully help others get started with mio faster with less frustration.