### PR TITLE
Accept IPv4 multicast addresses by reference

### DIFF
--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -465,7 +465,7 @@ impl UdpSocket {
     /// address of the local interface with which the system should join the
     /// multicast group. If it's equal to `INADDR_ANY` then an appropriate
     /// interface is chosen by the system.
-    #[allow(clippy::trivially-copy-pass-by-ref)]
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn join_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
         self.inner.join_multicast_v4(multiaddr, interface)
     }
@@ -475,7 +475,7 @@ impl UdpSocket {
     /// This function specifies a new multicast group for this socket to join.
     /// The address must be a valid multicast address, and `interface` is the
     /// index of the interface to join/leave (or 0 to indicate any interface).
-    #[allow(clippy::trivially-copy-pass-by-ref)]
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn join_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         self.inner.join_multicast_v6(multiaddr, interface)
     }
@@ -486,7 +486,7 @@ impl UdpSocket {
     /// [`join_multicast_v4`][link].
     ///
     /// [link]: #method.join_multicast_v4
-    #[allow(clippy::trivially-copy-pass-by-ref)]
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn leave_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
         self.inner.leave_multicast_v4(multiaddr, interface)
     }
@@ -497,7 +497,7 @@ impl UdpSocket {
     /// [`join_multicast_v6`][link].
     ///
     /// [link]: #method.join_multicast_v6
-    #[allow(clippy::trivially-copy-pass-by-ref)]
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn leave_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         self.inner.leave_multicast_v6(multiaddr, interface)
     }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -465,6 +465,7 @@ impl UdpSocket {
     /// address of the local interface with which the system should join the
     /// multicast group. If it's equal to `INADDR_ANY` then an appropriate
     /// interface is chosen by the system.
+    #[allow(clippy::trivially-copy-pass-by-ref)]
     pub fn join_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
         self.inner.join_multicast_v4(multiaddr, interface)
     }
@@ -474,6 +475,7 @@ impl UdpSocket {
     /// This function specifies a new multicast group for this socket to join.
     /// The address must be a valid multicast address, and `interface` is the
     /// index of the interface to join/leave (or 0 to indicate any interface).
+    #[allow(clippy::trivially-copy-pass-by-ref)]
     pub fn join_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         self.inner.join_multicast_v6(multiaddr, interface)
     }
@@ -484,6 +486,7 @@ impl UdpSocket {
     /// [`join_multicast_v4`][link].
     ///
     /// [link]: #method.join_multicast_v4
+    #[allow(clippy::trivially-copy-pass-by-ref)]
     pub fn leave_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
         self.inner.leave_multicast_v4(multiaddr, interface)
     }
@@ -494,6 +497,7 @@ impl UdpSocket {
     /// [`join_multicast_v6`][link].
     ///
     /// [link]: #method.join_multicast_v6
+    #[allow(clippy::trivially-copy-pass-by-ref)]
     pub fn leave_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         self.inner.leave_multicast_v6(multiaddr, interface)
     }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -465,8 +465,8 @@ impl UdpSocket {
     /// address of the local interface with which the system should join the
     /// multicast group. If it's equal to `INADDR_ANY` then an appropriate
     /// interface is chosen by the system.
-    pub fn join_multicast_v4(&self, multiaddr: Ipv4Addr, interface: Ipv4Addr) -> io::Result<()> {
-        self.inner.join_multicast_v4(&multiaddr, &interface)
+    pub fn join_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
+        self.inner.join_multicast_v4(multiaddr, interface)
     }
 
     /// Executes an operation of the `IPV6_ADD_MEMBERSHIP` type.
@@ -484,8 +484,8 @@ impl UdpSocket {
     /// [`join_multicast_v4`][link].
     ///
     /// [link]: #method.join_multicast_v4
-    pub fn leave_multicast_v4(&self, multiaddr: Ipv4Addr, interface: Ipv4Addr) -> io::Result<()> {
-        self.inner.leave_multicast_v4(&multiaddr, &interface)
+    pub fn leave_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
+        self.inner.leave_multicast_v4(multiaddr, interface)
     }
 
     /// Executes an operation of the `IPV6_DROP_MEMBERSHIP` type.

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -933,12 +933,12 @@ pub fn multicast() {
     let mut rx = UdpSocket::bind(any_local_address()).unwrap();
 
     info!("Joining group 227.1.1.100");
-    let any = "0.0.0.0".parse().unwrap();
-    rx.join_multicast_v4("227.1.1.100".parse().unwrap(), any)
+    let any = &"0.0.0.0".parse().unwrap();
+    rx.join_multicast_v4(&"227.1.1.100".parse().unwrap(), any)
         .unwrap();
 
     info!("Joining group 227.1.1.101");
-    rx.join_multicast_v4("227.1.1.101".parse().unwrap(), any)
+    rx.join_multicast_v4(&"227.1.1.101".parse().unwrap(), any)
         .unwrap();
 
     info!("Registering SENDER");


### PR DESCRIPTION
This is not a breaking change, since the original PR to accept multicast addresses by value was only accepted in v7-alpha.

Furthermore, if this PR isn't merged, I suggest creating another PR that accepts ipv6 addresses by value, to maintain consistency with the ipv4 equivalents.

Fixes #1235 