### PR TITLE
Remove 32bit iOS and replace ARM with ARM 64 bit iOS in CI

### DIFF
--- a/ci/azure-cross-compile.yml
+++ b/ci/azure-cross-compile.yml
@@ -10,15 +10,11 @@ jobs:
           vmImage: macOS-10.13
           target: x86_64-apple-ios
 
-        iOS_32:
+        iOS_ARM64:
           vmImage: macOS-10.13
-          target: i386-apple-ios
+          target: aarch64-apple-ios
 
-        iOS_ARM:
-          vmImage: macOS-10.13
-          target: armv7s-apple-ios
-
-        Android:
+        Android_ARM:
           vmImage: ubuntu-16.04
           target: arm-linux-androideabi
 

--- a/ci/azure-cross-compile.yml
+++ b/ci/azure-cross-compile.yml
@@ -7,11 +7,11 @@ jobs:
     strategy:
       matrix:
         iOS_64:
-          vmImage: macOS-10.13
+          vmImage: macOS-10.15
           target: x86_64-apple-ios
 
         iOS_ARM64:
-          vmImage: macOS-10.13
+          vmImage: macOS-10.15
           target: aarch64-apple-ios
 
         Android_ARM:

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -12,7 +12,7 @@ jobs:
 
         ${{ if parameters.cross }}:
           MacOS:
-            vmImage: macOS-10.13
+            vmImage: macOS-10.15
           Windows:
             vmImage: vs2017-win2016
     pool:
@@ -25,7 +25,7 @@ jobs:
       - template: azure-install-rust.yml
         parameters:
           rust_version: ${{ parameters.rust_version }}
-      
+
       - ${{ if eq(parameters.cmd, 'test') }}:
           - script: |
               cargo install cargo-hack


### PR DESCRIPTION
Both i386 and armv7s iOS targets are no longer supported by Rust (or
Apple for the matter), so remove them both from the CI.

And use the aarch64 (ARM 64 bit) iOS target instead.