### PR TITLE
Enable all mio features in Rust Playground

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,9 +52,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
-default-features = true
 features = ["os-poll", "os-util", "tcp", "udp", "uds"]
-all-features = false
 
 [[example]]
 name = "tcp_server"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,11 @@ net2       = "0.2.33"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.playground]
+default-features = true
+features = ["os-poll", "os-util", "tcp", "udp", "uds"]
+all-features = false
+
 [[example]]
 name = "tcp_server"
 required-features = ["os-poll", "tcp"]


### PR DESCRIPTION
Some common mio examples do not currently work in Rust playground (https://play.rust-lang.org/), because modules like `net` are not available with default features.