### PR TITLE
Add support for illumos target (0.6.x)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ fuchsia-zircon = "0.3.2"
 fuchsia-zircon-sys = "0.3.2"
 
 [target.'cfg(unix)'.dependencies]
-libc   = "0.2.42"
+libc   = "0.2.54"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2.6"

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -3,10 +3,20 @@ use libc::{self, c_int};
 #[macro_use]
 pub mod dlsym;
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "solaris"
+))]
 mod epoll;
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "solaris"
+))]
 pub use self::epoll::{Events, Selector};
 
 #[cfg(any(target_os = "bitrig", target_os = "dragonfly",

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -109,10 +109,20 @@ const LIO: usize   = 0b10_0000;
 #[cfg(not(any(target_os = "freebsd")))]
 const LIO: usize   = 0b00_0000;
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "solaris"
+))]
 const PRI: usize = 0b100_0000;
 
-#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "solaris")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "solaris"
+)))]
 const PRI: usize = 0;
 
 // Export to support `Ready::all`
@@ -129,7 +139,12 @@ fn test_ready_all() {
     );
 
     // Issue #896.
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
+    #[cfg(any(
+        target_os = "android",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "solaris"
+    ))]
     assert!(!Ready::from(UnixReady::priority()).is_writable());
 }
 
@@ -258,8 +273,12 @@ impl UnixReady {
     ///
     /// [`Poll`]: struct.Poll.html
     #[inline]
-    #[cfg(any(target_os = "linux",
-        target_os = "android", target_os = "solaris"))]
+    #[cfg(any(
+        target_os = "android",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "solaris"
+    ))]
     pub fn priority() -> UnixReady {
         UnixReady(ready_from_usize(PRI))
     }
@@ -385,8 +404,12 @@ impl UnixReady {
     ///
     /// [`Poll`]: struct.Poll.html
     #[inline]
-    #[cfg(any(target_os = "linux",
-        target_os = "android", target_os = "solaris"))]
+    #[cfg(any(
+        target_os = "android",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "solaris"
+    ))]
     pub fn is_priority(&self) -> bool {
         self.contains(ready_from_usize(PRI))
     }
@@ -476,8 +499,12 @@ impl fmt::Debug for UnixReady {
             (UnixReady::hup(), "Hup"),
             #[allow(deprecated)]
             (UnixReady::aio(), "Aio"),
-            #[cfg(any(target_os = "linux",
-                target_os = "android", target_os = "solaris"))]
+            #[cfg(any(
+                target_os = "android",
+                target_os = "illumos",
+                target_os = "linux",
+                target_os = "solaris"
+            ))]
             (UnixReady::priority(), "Priority"),
         ];
 

--- a/test/test_tcp_shutdown.rs
+++ b/test/test_tcp_shutdown.rs
@@ -200,9 +200,16 @@ fn test_graceful_shutdown() {
     drop(socket);
 
     assert_ready!(poll, Token(0), Ready::readable());
-    #[cfg(not(any(target_os = "bitrig", target_os = "dragonfly",
-        target_os = "freebsd", target_os = "ios", target_os = "macos",
-        target_os = "netbsd", target_os = "openbsd")))]
+    #[cfg(not(any(
+        target_os = "bitrig",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "illumos",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
     assert_hup_ready!(poll);
 
     let mut buf = [0; 1024];
@@ -236,9 +243,16 @@ fn test_abrupt_shutdown() {
 
     drop(socket);
 
-    #[cfg(not(any(target_os = "bitrig", target_os = "dragonfly",
-        target_os = "freebsd", target_os = "ios", target_os = "macos",
-        target_os = "netbsd", target_os = "openbsd")))]
+    #[cfg(not(any(
+        target_os = "bitrig",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "illumos",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
     assert_hup_ready!(poll);
     assert_ready!(poll, Token(0), Ready::writable());
     assert_ready!(poll, Token(0), Ready::readable());


### PR DESCRIPTION
With support for an illumos target [on its way](https://github.com/rust-lang/rust/pull/71145) into rust, the cfg guards for `solaris` should be updated to include `illumos` as well.