### PR TITLE
Add support for illumos target

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -174,6 +174,7 @@ use std::{fmt, io};
 /// | NetBSD        | [kqueue]  |
 /// | OpenBSD       | [kqueue]  |
 /// | Solaris       | [epoll]   |
+/// | illumos       | [epoll]   |
 /// | Windows       | [IOCP]    |
 /// | iOS           | [kqueue]  |
 /// | macOS         | [kqueue]  |

--- a/src/sys/unix/net.rs
+++ b/src/sys/unix/net.rs
@@ -27,6 +27,7 @@ pub(crate) fn new_socket(
         target_os = "android",
         target_os = "dragonfly",
         target_os = "freebsd",
+        target_os = "illumos",
         target_os = "linux",
         target_os = "netbsd",
         target_os = "openbsd"

--- a/src/sys/unix/selector/mod.rs
+++ b/src/sys/unix/selector/mod.rs
@@ -1,7 +1,17 @@
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "solaris"
+))]
 mod epoll;
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "solaris"
+))]
 pub(crate) use self::epoll::{event, Event, Events, Selector};
 
 #[cfg(any(

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -61,6 +61,7 @@ pub fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream, Socket
         target_os = "android",
         target_os = "dragonfly",
         target_os = "freebsd",
+        target_os = "illumos",
         target_os = "linux",
         target_os = "netbsd",
         target_os = "openbsd"

--- a/src/sys/unix/waker.rs
+++ b/src/sys/unix/waker.rs
@@ -100,6 +100,7 @@ pub use self::kqueue::Waker;
 
 #[cfg(any(
     target_os = "dragonfly",
+    target_os = "illumos",
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "solaris"
@@ -165,6 +166,7 @@ mod pipe {
 
 #[cfg(any(
     target_os = "dragonfly",
+    target_os = "illumos",
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "solaris"

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -540,7 +540,12 @@ fn tcp_shutdown_client_read_close_event() {
 #[test]
 #[cfg_attr(windows, ignore = "fails; client write_closed events are not found")]
 #[cfg_attr(
-    any(target_os = "linux", target_os = "android", target_os = "solaris"),
+    any(
+        target_os = "android",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "solaris"
+    ),
     ignore = "fails; client write_closed events are not found"
 )]
 fn tcp_shutdown_client_write_close_event() {


### PR DESCRIPTION
As the master branch counterpart to the 0.6.x PR (#1294), this adds support for the Solaris-like (but distinct) `illumos` target.  When support is [merged](https://github.com/rust-lang/rust/pull/71145) into rust, it would be nice for mio to be immediately usable.