### PR TITLE
Change FreeBSD CI name

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ env:
   RUST_BACKTRACE: full
 
 task:
-  name: FreeBSD 12.1 amd64
+  name: FreeBSD
   setup_script:
     - pkg install -y curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh


### PR DESCRIPTION
These versions don't get bumped that often, but it's been a bit of a pain changing them and having to update the name of the required FreeBSD check. Now that the required check is just `FreeBSD`, this updates the name to reflect that.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>