### PR TITLE
Windows: Fix afd::POLL_ABORT and POLL_CONNECT_FAIL handling

### DIFF
--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -29,7 +29,7 @@ pub fn is_error(event: &Event) -> bool {
 }
 
 pub fn is_read_closed(event: &Event) -> bool {
-    event.flags & afd::POLL_DISCONNECT != 0
+    event.flags & (afd::POLL_ABORT | afd::POLL_DISCONNECT) != 0
 }
 
 pub fn is_write_closed(event: &Event) -> bool {

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -14,26 +14,35 @@ pub fn token(event: &Event) -> Token {
     Token(event.data as usize)
 }
 
+pub(crate) const READABLE_FLAGS: u32 = afd::POLL_RECEIVE
+    | afd::POLL_DISCONNECT
+    | afd::POLL_ACCEPT
+    | afd::POLL_ABORT
+    | afd::POLL_CONNECT_FAIL;
+pub(crate) const WRITABLE_FLAGS: u32 = afd::POLL_SEND | afd::POLL_ABORT | afd::POLL_CONNECT_FAIL;
+pub(crate) const ERROR_FLAGS: u32 = afd::POLL_CONNECT_FAIL;
+pub(crate) const READ_CLOSED_FLAGS: u32 =
+    afd::POLL_DISCONNECT | afd::POLL_ABORT | afd::POLL_CONNECT_FAIL;
+pub(crate) const WRITE_CLOSED_FLAGS: u32 = afd::POLL_ABORT | afd::POLL_CONNECT_FAIL;
+
 pub fn is_readable(event: &Event) -> bool {
-    event.flags
-        & (afd::POLL_RECEIVE | afd::POLL_DISCONNECT | afd::POLL_ACCEPT | afd::POLL_CONNECT_FAIL)
-        != 0
+    event.flags & READABLE_FLAGS != 0
 }
 
 pub fn is_writable(event: &Event) -> bool {
-    event.flags & (afd::POLL_SEND | afd::POLL_CONNECT_FAIL) != 0
+    event.flags & WRITABLE_FLAGS != 0
 }
 
 pub fn is_error(event: &Event) -> bool {
-    event.flags & afd::POLL_CONNECT_FAIL != 0
+    event.flags & ERROR_FLAGS != 0
 }
 
 pub fn is_read_closed(event: &Event) -> bool {
-    event.flags & (afd::POLL_ABORT | afd::POLL_DISCONNECT) != 0
+    event.flags & READ_CLOSED_FLAGS != 0
 }
 
 pub fn is_write_closed(event: &Event) -> bool {
-    event.flags & (afd::POLL_ABORT | afd::POLL_CONNECT_FAIL) != 0
+    event.flags & WRITE_CLOSED_FLAGS != 0
 }
 
 pub fn is_priority(event: &Event) -> bool {

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -1,6 +1,9 @@
 use super::afd::{self, Afd, AfdPollInfo};
 use super::io_status_block::IoStatusBlock;
 use super::Event;
+use crate::sys::event::{
+    ERROR_FLAGS, READABLE_FLAGS, READ_CLOSED_FLAGS, WRITABLE_FLAGS, WRITE_CLOSED_FLAGS,
+};
 use crate::sys::Events;
 use crate::Interest;
 
@@ -719,12 +722,11 @@ fn interests_to_afd_flags(interests: Interest) -> u32 {
     let mut flags = 0;
 
     if interests.is_readable() {
-        // afd::POLL_DISCONNECT for is_read_hup()
-        flags |= afd::POLL_RECEIVE | afd::POLL_ACCEPT | afd::POLL_DISCONNECT | afd::POLL_ABORT;
+        flags |= READABLE_FLAGS | READ_CLOSED_FLAGS | ERROR_FLAGS;
     }
 
     if interests.is_writable() {
-        flags |= afd::POLL_SEND | afd::POLL_ABORT;
+        flags |= WRITABLE_FLAGS | WRITE_CLOSED_FLAGS | ERROR_FLAGS;
     }
 
     flags

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -720,11 +720,11 @@ fn interests_to_afd_flags(interests: Interest) -> u32 {
 
     if interests.is_readable() {
         // afd::POLL_DISCONNECT for is_read_hup()
-        flags |= afd::POLL_RECEIVE | afd::POLL_ACCEPT | afd::POLL_DISCONNECT;
+        flags |= afd::POLL_RECEIVE | afd::POLL_ACCEPT | afd::POLL_DISCONNECT | afd::POLL_ABORT;
     }
 
     if interests.is_writable() {
-        flags |= afd::POLL_SEND;
+        flags |= afd::POLL_SEND | afd::POLL_ABORT;
     }
 
     flags

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -574,6 +574,8 @@ fn connect_error() {
     }
 
     assert!(l.take_error().unwrap().is_some());
+
+    expect_no_events(&mut poll, &mut events);
 }
 
 #[test]


### PR DESCRIPTION
This does two things:
1. POLL_ABORT is considered both read_closed and write_closed, much like EPOLLHUP.
2. POLL_ABORT and POLL_CONNECT_FAIL events are properly handled by the edge-triggered-event emulation.

Fixes #1303.