### PR TITLE
implement event::Source on &IoSource and &TcpStream

### DIFF
--- a/src/io_source.rs
+++ b/src/io_source.rs
@@ -232,41 +232,6 @@ where
     }
 }
 
-#[cfg(windows)]
-impl<T> event::Source for &IoSource<T>
-where
-    T: AsRawSocket,
-{
-    fn register(
-        &mut self,
-        registry: &Registry,
-        token: Token,
-        interests: Interest,
-    ) -> io::Result<()> {
-        #[cfg(debug_assertions)]
-        self.selector_id.associate(registry)?;
-        self.state
-            .register(registry, token, interests, self.inner.as_raw_socket())
-    }
-
-    fn reregister(
-        &mut self,
-        registry: &Registry,
-        token: Token,
-        interests: Interest,
-    ) -> io::Result<()> {
-        #[cfg(debug_assertions)]
-        self.selector_id.check_association(registry)?;
-        self.state.reregister(registry, token, interests)
-    }
-
-    fn deregister(&mut self, _registry: &Registry) -> io::Result<()> {
-        #[cfg(debug_assertions)]
-        self.selector_id.remove_association(_registry)?;
-        self.state.deregister()
-    }
-}
-
 impl<T> fmt::Debug for IoSource<T>
 where
     T: fmt::Debug,

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -241,6 +241,7 @@ impl event::Source for TcpStream {
     }
 }
 
+#[cfg(unix)]
 impl event::Source for &TcpStream {
     fn register(
         &mut self,

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -241,6 +241,30 @@ impl event::Source for TcpStream {
     }
 }
 
+impl event::Source for &TcpStream {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        (&self.inner).register(registry, token, interests)
+    }
+
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        (&self.inner).reregister(registry, token, interests)
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        (&self.inner).deregister(registry)
+    }
+}
+
 impl fmt::Debug for TcpStream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)


### PR DESCRIPTION
As of now, it's implemented for IoSource and TcpStream but not for their references. The only operation on the underlying TcpStream from the stdlib is as_raw_fd/as_raw_socket, iiuc, which does not require a mutable state.
Having event::Source implemented on &TcpStream would allow registerig a TcpStream without it being mut. Given Read and Write are also implemented on &TcpStream, I think this would make sense?