### PR TITLE
Windows: Implement a workaround for non-AFD sockets.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ libc = "0.2.62"
 
 [target.'cfg(windows)'.dependencies]
 miow   = "0.3.3"
-winapi = { version = "0.3", features = ["winsock2", "mswsock"] }
+winapi = { version = "0.3", features = ["winsock2", "mswsock", "synchapi"] }
 ntapi  = "0.3"
 lazy_static = "1.4.0"
 

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -4,9 +4,6 @@ mod io_status_block;
 pub mod event;
 pub use event::{Event, Events};
 
-mod selector;
-pub use selector::{Selector, SelectorInner, SockState};
-
 // Macros must be defined before the modules that use them
 cfg_net! {
     /// Helper macro to execute a system call that returns an `io::Result`.
@@ -23,6 +20,9 @@ cfg_net! {
         }};
     }
 }
+
+mod selector;
+pub use selector::{Selector, SelectorInner, SockState};
 
 cfg_tcp! {
     pub(crate) mod tcp;

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -135,11 +135,13 @@ pub fn expect_events(poll: &mut Poll, events: &mut Events, mut expected: Vec<Exp
     // In a lot of calls we expect more then one event, but it could be that
     // poll returns the first event only in a single call. To be a bit more
     // lenient we'll poll a couple of times.
+    let mut got = vec![];
     for _ in 0..3 {
         poll.poll(events, Some(Duration::from_millis(500)))
             .expect("unable to poll");
 
         for event in events.iter() {
+            got.push(format!("{:#?}", event));
             let index = expected.iter().position(|expected| expected.matches(event));
 
             if let Some(index) = index {
@@ -157,8 +159,9 @@ pub fn expect_events(poll: &mut Poll, events: &mut Events, mut expected: Vec<Exp
 
     assert!(
         expected.is_empty(),
-        "the following expected events were not found: {:?}",
-        expected
+        "the following expected events were not found: {:?}, got {:?}",
+        expected,
+        got
     );
 }
 


### PR DESCRIPTION
In some system configurations the AFD apis don't work. Fall back to
spawning a new thread for each registration and using
WSAWaitForMultipleEvents.

I tested this (i.e. ran the test suite) in a Windows 7 VM with some
network intercepting drivers installed. Without this change, registrations
fail with the error

```
The system detected an invalid pointer address in attempting to use a pointer argument in a call. (os error 10014)
```

(The specific software I installed was Qustodio, but I can't vouch for it being safe or useful for anything else.)

Closes #1314.