### PR TITLE
Optimise Iter::{size_hint, count} for events::Iter

### DIFF
--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -208,6 +208,15 @@ impl<'a> Iterator for Iter<'a> {
         self.pos += 1;
         ret
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = self.inner.inner.len();
+        (size, Some(size))
+    }
+
+    fn count(self) -> usize {
+        self.inner.inner.len()
+    }
 }
 
 impl fmt::Debug for Events {

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -106,6 +106,10 @@ impl Events {
         self.events.capacity()
     }
 
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
     pub fn get(&self, idx: usize) -> Option<&Event> {
         self.events.get(idx)
     }


### PR DESCRIPTION
This replaces the default implementation with an optimised one.