### PR TITLE
Set `SO_NOSIGPIPE` on all sockets on Apple systems.

### DIFF
--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -9,19 +9,6 @@ pub fn bind(addr: SocketAddr) -> io::Result<net::UdpSocket> {
     #[allow(clippy::let_and_return)]
     let socket = new_ip_socket(addr, libc::SOCK_DGRAM);
 
-    // Set SO_NOSIGPIPE on iOS and macOS (mirrors what libstd does).
-    #[cfg(any(target_os = "ios", target_os = "macos"))]
-    let socket = socket.and_then(|socket| {
-        syscall!(setsockopt(
-            socket,
-            libc::SOL_SOCKET,
-            libc::SO_NOSIGPIPE,
-            &1 as *const libc::c_int as *const libc::c_void,
-            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-        ))
-        .map(|_| socket)
-    });
-
     socket.and_then(|socket| {
         let (raw_addr, raw_addr_length) = socket_addr(&addr);
         syscall!(bind(socket, raw_addr, raw_addr_length))


### PR DESCRIPTION
Previously this option was only set for UDP sockets but is equally important for TCP. [Like `libstd`](https://github.com/rust-lang/rust/blob/7c34d8d6629506a596215886e5fc4bb2b04b00ae/src/libstd/sys/unix/net.rs#L79) this PR enables the option on all sockets if compiled for Apple systems.