### PR TITLE
RUSTSEC-2020-0016: Replace net2 with socket2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ lazy_static = "1.4.0"
 
 [dev-dependencies]
 env_logger = { version = "0.6.2", default-features = false }
-net2       = "0.2.33"
+socket2    = "0.3.12"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -3,7 +3,6 @@
 use mio::net::{TcpListener, TcpStream};
 use mio::{Events, Interest, Poll, Token};
 #[cfg(unix)]
-use net2::TcpStreamExt;
 use std::io::{self, Read, Write};
 use std::net::{self, Shutdown};
 #[cfg(unix)]
@@ -469,10 +468,15 @@ fn connection_reset_by_peer() {
     let addr = l.local_addr().unwrap();
 
     // Connect client
-    let client = net2::TcpBuilder::new_v4().unwrap().to_tcp_stream().unwrap();
+    let client = socket2::Socket::new(
+        socket2::Domain::ipv4(),
+        socket2::Type::stream(),
+        Some(socket2::Protocol::tcp()),
+    )
+    .unwrap();
 
     client.set_linger(Some(Duration::from_millis(0))).unwrap();
-    client.connect(&addr).unwrap();
+    client.connect(&addr.into()).unwrap();
 
     // Convert to Mio stream
     // FIXME: how to convert the stream on Windows?


### PR DESCRIPTION
`cargo audit` now passes without error.