### PR TITLE
Replace deprecated dev-dependency net2 by socket2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ lazy_static = "1.4.0"
 
 [dev-dependencies]
 env_logger = { version = "0.6.2", default-features = false }
-net2       = "0.2.33"
+socket2    = "0.3.12"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -17,21 +17,26 @@ const WAKE_TOKEN: Token = Token(10);
 fn issue_776() {
     init();
 
-    let l = net::TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = l.local_addr().unwrap();
+    let listener = net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
 
-    let t = thread::spawn(move || {
-        let mut s = l.accept().expect("accept").0;
-        s.set_read_timeout(Some(Duration::from_secs(5)))
+    let thr = thread::spawn(move || {
+        let mut stream = listener.accept().expect("accept").0;
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
             .expect("set_read_timeout");
-        let _ = s.read(&mut [0; 16]).expect("read");
+        let _ = stream.read(&mut [0; 16]).expect("read");
     });
 
     let mut poll = Poll::new().unwrap();
-    let mut s = TcpStream::connect(addr).unwrap();
+    let mut stream = TcpStream::connect(addr).unwrap();
 
     poll.registry()
-        .register(&mut s, Token(1), Interest::READABLE | Interest::WRITABLE)
+        .register(
+            &mut stream,
+            Token(1),
+            Interest::READABLE | Interest::WRITABLE,
+        )
         .unwrap();
     let mut events = Events::with_capacity(16);
     'outer: loop {
@@ -44,15 +49,15 @@ fn issue_776() {
         }
     }
 
-    let mut b = [0; 1024];
-    match s.read(&mut b) {
+    let mut buff = [0; 1024];
+    match stream.read(&mut buff) {
         Ok(_) => panic!("unexpected ok"),
-        Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => (),
-        Err(e) => panic!("unexpected error: {:?}", e),
+        Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => (),
+        Err(err) => panic!("unexpected error: {:?}", err),
     }
 
-    drop(s);
-    t.join().unwrap();
+    drop(stream);
+    thr.join().unwrap();
 }
 
 #[test]

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -2,7 +2,6 @@
 
 use mio::net::{TcpListener, TcpStream};
 use mio::{Events, Interest, Poll, Token};
-#[cfg(unix)]
 use std::io::{self, Read, Write};
 use std::net::{self, Shutdown};
 #[cfg(unix)]

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -3,7 +3,6 @@
 use mio::net::{TcpListener, TcpStream};
 use mio::{Events, Interest, Poll, Token};
 #[cfg(unix)]
-use net2::TcpStreamExt;
 use std::io::{self, Read, Write};
 use std::net::{self, Shutdown};
 #[cfg(unix)]
@@ -469,14 +468,14 @@ fn connection_reset_by_peer() {
     let addr = l.local_addr().unwrap();
 
     // Connect client
-    let client = net2::TcpBuilder::new_v4().unwrap().to_tcp_stream().unwrap();
-
-    client.set_linger(Some(Duration::from_millis(0))).unwrap();
-    client.connect(&addr).unwrap();
+    let socket =
+        socket2::Socket::new(socket2::Domain::ipv4(), socket2::Type::stream(), None).unwrap();
+    socket.connect(&addr.into()).unwrap();
+    socket.set_linger(Some(Duration::from_millis(0))).unwrap();
 
     // Convert to Mio stream
     // FIXME: how to convert the stream on Windows?
-    let mut client = unsafe { TcpStream::from_raw_fd(client.into_raw_fd()) };
+    let mut client = unsafe { TcpStream::from_raw_fd(socket.into_raw_fd()) };
 
     // Register server
     poll.registry()


### PR DESCRIPTION
net2 crate was officially deprecated in favor of socket2

see https://rustsec.org/advisories/RUSTSEC-2020-0016.html

This patch replaces the dependency and fixes the test.