### PR TITLE
refactor: remove dependency on lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ libc = "0.2.69"
 miow   = "0.3.3"
 winapi = { version = "0.3", features = ["winsock2", "mswsock"] }
 ntapi  = "0.3"
-lazy_static = "1.4.0"
 
 [dev-dependencies]
 env_logger = { version = "0.6.2", default-features = false }


### PR DESCRIPTION
This was only used in `src/sys/windows/afd.rs` for a set of objects that could instead be defined using constant expressions.