### PR TITLE
Add API to hook into Windows IOCP loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,9 @@ libc = "0.2.69"
 
 [target.'cfg(windows)'.dependencies]
 miow   = "0.3.3"
-winapi = { version = "0.3", features = ["winsock2", "mswsock"] }
+winapi = { version = "0.3", features = ["winsock2", "mswsock", "impl-default", "errhandlingapi"] }
 ntapi  = "0.3"
+slab   = "0.4"
 
 [dev-dependencies]
 env_logger = { version = "0.6.2", default-features = false }

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -70,6 +70,17 @@ macro_rules! cfg_udp {
     }
 }
 
+/// Feature `os-util` enabled.
+macro_rules! cfg_os_util {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "os-util")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "os-util")))]
+            $item
+        )*
+    }
+}
+
 /// Feature `uds` enabled.
 #[cfg(unix)]
 macro_rules! cfg_uds {

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -80,7 +80,27 @@ cfg_os_poll! {
 #[cfg(windows)]
 cfg_os_poll! {
     mod windows;
-    pub(crate) use self::windows::*;
+    pub(crate) use self::windows::{Waker, Event, Events, event, Selector};
+    cfg_any_os_util! {
+        pub use self::windows::{
+            Binding,
+            CompletionCallback,
+            Overlapped,
+            Readiness,
+        };
+    }
+
+    cfg_net! {
+        pub(crate) use self::windows::IoSourceState;
+    }
+
+    cfg_tcp! {
+        pub(crate) use self::windows::tcp;
+    }
+
+    cfg_udp! {
+        pub(crate) use self::windows::udp;
+    }
 }
 
 cfg_not_os_poll! {

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -5,6 +5,7 @@ use miow::iocp::CompletionStatus;
 use super::afd;
 use crate::Token;
 
+#[derive(Debug)]
 pub struct Event {
     pub flags: u32,
     pub data: u64,

--- a/src/sys/windows/iocp_handler.rs
+++ b/src/sys/windows/iocp_handler.rs
@@ -1,0 +1,182 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+    io,
+    fmt
+};
+
+use winapi::shared::winerror;
+use miow::{
+    Overlapped,
+    iocp::{
+        CompletionPort,
+        CompletionStatus
+    }
+};
+
+use slab::Slab;
+
+use crate::{
+    Token,
+    sys::windows::{
+        Event,
+        afd,
+        selector::AfdCompletionPortEventHandler,
+    },
+};
+
+#[cfg(feature = "os-util")]
+use crate::sys::windows::selector::RawHandleCompletionHandler;
+
+pub trait IocpHandler: fmt::Debug + Send + Sync + 'static {
+    fn handle_completion(&mut self, status: &CompletionStatus) -> Option<Event>;
+    fn on_poll_finished(&mut self) { }
+}
+
+#[derive(Debug)]
+pub(crate) enum RegisteredHandler {
+    AfdHandler(AfdCompletionPortEventHandler),
+    WakerHandler(WakerHandler),
+    #[cfg(feature = "os-util")]
+    RawHandleHandler(RawHandleCompletionHandler)
+}
+
+impl From<AfdCompletionPortEventHandler> for RegisteredHandler {
+    fn from(h: AfdCompletionPortEventHandler) -> Self {
+        RegisteredHandler::AfdHandler(h)
+    }
+}
+
+impl From<WakerHandler> for RegisteredHandler {
+    fn from(h: WakerHandler) -> Self {
+        RegisteredHandler::WakerHandler(h)
+    }
+}
+
+#[cfg(feature = "os-util")]
+impl From<RawHandleCompletionHandler> for RegisteredHandler {
+    fn from(h: RawHandleCompletionHandler) -> Self {
+        RegisteredHandler::RawHandleHandler(h)
+    }
+}
+
+impl IocpHandler for RegisteredHandler {
+    fn handle_completion(&mut self, status: &CompletionStatus) -> Option<Event> {
+        match self {
+            RegisteredHandler::AfdHandler(handler) => handler.handle_completion(status),
+            RegisteredHandler::WakerHandler(handler) => handler.handle_completion(status),
+            #[cfg(feature = "os-util")]
+            RegisteredHandler::RawHandleHandler(handler) => handler.handle_completion(status),
+        }
+    }
+
+    fn on_poll_finished(&mut self) {
+        match self {
+            RegisteredHandler::AfdHandler(handler) => handler.on_poll_finished(),
+            RegisteredHandler::WakerHandler(handler) => handler.on_poll_finished(),
+            #[cfg(feature = "os-util")]
+            RegisteredHandler::RawHandleHandler(handler) => handler.on_poll_finished(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct IocpWaker {
+    token: usize,
+    iocp_registry: Arc<IocpHandlerRegistry>,
+}
+
+#[derive(Debug)]
+pub(crate) struct WakerHandler {
+    external_token: Token,
+}
+
+impl IocpHandler for WakerHandler {
+    fn handle_completion(&mut self, _status: &CompletionStatus) -> Option<Event> {
+        Some(Event {
+            flags: afd::POLL_RECEIVE,
+            data: self.external_token.0 as u64
+        })
+    }
+}
+
+impl IocpWaker {
+    pub fn post(&self, bytes: u32, overlapped: *mut Overlapped) -> io::Result<()> {
+        self.iocp_registry.cp.post(CompletionStatus::new(bytes, self.token, overlapped))
+    }
+}
+
+#[derive(Debug)]
+pub struct IocpHandlerRegistry {
+    cp: CompletionPort,
+    handlers: Mutex<Slab<RegisteredHandler>>,
+}
+
+impl IocpHandlerRegistry {
+    pub fn new() -> io::Result<Self> {
+        CompletionPort::new(0).map(|cp|
+            Self {
+                cp,
+                handlers: Mutex::new(Slab::new())
+            })
+    }
+
+    pub fn register_waker(self: Arc<Self>, token: Token) -> IocpWaker {
+        let handler = WakerHandler {
+            external_token: token
+        };
+        let slab_token = self.handlers.lock().unwrap()
+            .insert(handler.into());
+        IocpWaker {
+            token: slab_token,
+            iocp_registry: self
+        }
+    }
+
+    pub fn handle_pending_events(&self,
+                                 statuses: &mut [CompletionStatus],
+                                 mut events: Option<&mut Vec<Event>>,
+                                 timeout: Option<Duration>) -> io::Result<usize> {
+        let result = match self.cp.get_many(statuses, timeout) {
+            Ok(iocp_events) => {
+                let mut num_events = 0;
+                let mut handlers = self.handlers.lock().unwrap();
+                for status in iocp_events {
+                    let key = status.token();
+                    if let Some(handler) = handlers.get_mut(key) {
+                        if let Some(event) = handler.handle_completion(status) {
+                            if let Some(events) = &mut events {
+                                events.push(event);
+                            }
+                            num_events += 1;
+                        }
+                    }
+                }
+
+                Ok(num_events)
+            },
+
+            Err(ref e) if e.raw_os_error() == Some(winerror::WAIT_TIMEOUT as i32) => Ok(0),
+
+            Err(e) => Err(e)
+        };
+
+        for (_, handler) in self.handlers.lock().unwrap().iter_mut() {
+            handler.on_poll_finished();
+        }
+
+        result
+    }
+}
+
+cfg_any_os_util! {
+    use std::os::windows::io::AsRawHandle;
+
+    impl IocpHandlerRegistry {
+        pub(crate) fn register_handle<T>(&self, handle: &T, handler: RegisteredHandler) -> io::Result<()>
+            where T: AsRawHandle + ?Sized {
+            let token = self.handlers.lock().unwrap().insert(handler);
+            self.cp.add_handle(token, handle)
+        }
+    }
+}

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -7,6 +7,12 @@ pub use event::{Event, Events};
 mod selector;
 pub use selector::{Selector, SelectorInner, SockState};
 
+mod iocp_handler;
+
+cfg_any_os_util! {
+    pub use selector::{CompletionCallback, Overlapped, Readiness, Binding};
+}
+
 // Macros must be defined before the modules that use them
 cfg_net! {
     /// Helper macro to execute a system call that returns an `io::Result`.

--- a/src/sys/windows/waker.rs
+++ b/src/sys/windows/waker.rs
@@ -1,28 +1,24 @@
 use crate::sys::windows::selector::WAKER_OVERLAPPED;
 use crate::sys::windows::Selector;
+use crate::sys::windows::iocp_handler::IocpWaker;
 use crate::Token;
 
-use miow::iocp::{CompletionPort, CompletionStatus};
 use std::io;
-use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct Waker {
-    token: Token,
-    port: Arc<CompletionPort>,
+    cp_waker: IocpWaker,
 }
 
 impl Waker {
     pub fn new(selector: &Selector, token: Token) -> io::Result<Waker> {
-        Ok(Waker {
-            token,
-            port: selector.clone_port(),
-        })
+        let cp_registry = selector.clone_port();
+        let cp_waker = cp_registry.register_waker(token);
+        Ok(Waker { cp_waker })
     }
 
     pub fn wake(&self) -> io::Result<()> {
         // Keep NULL as Overlapped value to notify waking.
-        let status = CompletionStatus::new(0, self.token.0, WAKER_OVERLAPPED);
-        self.port.post(status)
+        self.cp_waker.post(0, WAKER_OVERLAPPED)
     }
 }

--- a/tests/win_rawhandlesrc.rs
+++ b/tests/win_rawhandlesrc.rs
@@ -1,0 +1,123 @@
+#![cfg(all(windows, feature = "os-util"))]
+
+use mio::windows;
+use mio::windows::Readiness;
+use mio::{event::Source, Events, Interest, Poll, Registry, Token};
+use std::default::Default;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::{self, Seek, SeekFrom, Write};
+use std::iter;
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle};
+use std::ptr;
+use winapi::shared::winerror::ERROR_IO_PENDING;
+use winapi::um::minwinbase::OVERLAPPED_ENTRY;
+use winapi::um::{
+    errhandlingapi::GetLastError,
+    fileapi::{CreateFileW, WriteFile, CREATE_ALWAYS},
+    handleapi::INVALID_HANDLE_VALUE,
+    minwinbase::OVERLAPPED,
+    winbase::FILE_FLAG_OVERLAPPED,
+    winnt::GENERIC_WRITE,
+};
+
+struct AsyncFile {
+    file: File,
+    binding: Option<windows::Binding>,
+}
+
+impl Source for AsyncFile {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        _interests: Interest,
+    ) -> io::Result<()> {
+        let binding = windows::Binding::new(registry, token);
+        self.binding = Some(binding);
+        self.binding.as_ref().unwrap().register_handle(&self.file)
+    }
+
+    fn reregister(
+        &mut self,
+        _registry: &Registry,
+        _token: Token,
+        _interests: Interest,
+    ) -> io::Result<()> {
+        unimplemented!()
+    }
+
+    fn deregister(&mut self, _registry: &Registry) -> io::Result<()> {
+        unimplemented!()
+    }
+}
+
+impl AsRawHandle for AsyncFile {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.file.as_raw_handle()
+    }
+}
+
+#[test]
+fn register_custom_iocp_handler() {
+    let mut poll = Poll::new().unwrap();
+
+    let path: &OsStr = "C:\\temp\\test.txt".as_ref();
+    let path_u16: Vec<u16> = path.encode_wide().chain(iter::once(0)).collect();
+    let mut file = unsafe {
+        let handle = CreateFileW(
+            path_u16.as_ptr(),
+            GENERIC_WRITE,
+            0,
+            ptr::null_mut(),
+            CREATE_ALWAYS,
+            FILE_FLAG_OVERLAPPED,
+            ptr::null_mut(),
+        );
+        if handle == INVALID_HANDLE_VALUE {
+            panic!("Unable to open file!");
+        }
+        AsyncFile {
+            file: File::from_raw_handle(handle),
+            binding: None,
+        }
+    };
+
+    poll.registry()
+        .register(&mut file, Token(0), Interest::WRITABLE)
+        .unwrap();
+
+    let mut buffer: Vec<_> = iter::successors(Some(15u8), |p| Some(p.wrapping_add(2)))
+        .take(1024)
+        .collect();
+    loop {
+        unsafe {
+            let mut overlapped =
+                windows::Overlapped::new(move |_: &OVERLAPPED_ENTRY| Some(Readiness::WRITE));
+            if WriteFile(
+                file.as_raw_handle(),
+                buffer.as_mut_ptr() as *mut _,
+                buffer.len() as u32,
+                ptr::null_mut(),
+                &mut overlapped as *mut windows::Overlapped as *mut OVERLAPPED,
+            ) == 0
+            {
+                match GetLastError() {
+                    ERROR_IO_PENDING => {
+                        let mut events = Events::with_capacity(16);
+                        poll.poll(&mut events, None).unwrap();
+                        let mut event_iter = events.iter();
+                        let event = event_iter.next().unwrap();
+                        assert_eq!(0, event.token().0);
+                        assert!(event.is_writable());
+                        assert!(event_iter.next().is_none());
+                        break;
+                    }
+
+                    e => panic!("Error during file write operation: {}", e),
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
An API similar to the one of mio 0.6 is now available so that custom objects can be added to the IOCP that is used to implement Poll. Relates to https://github.com/tokio-rs/mio/issues/1047.

This change isn't complete yet but in a draft state as I wanted to gather some feedback on the suggested API.

Since sockets are polled by using a single connection to afd.sys, there is no 1:1 relationship between a user-provided token and the completion key of the IOCP. The implementation therefore uses a slab to keep track of the registered handlers and the mapping of the user-provided token to the reported events.

Other notable things about the change:
* The Overlapped type now uses a boxed trait object instead of a function pointer. While this is resource-heavier, it also enables writing more clean completion handlers as they can now directy carry state instead of having to do some pointer magic or accessing some sort of global state.
* There is anew type "Readiness" to convert the completion events into polling events. There is also a similar (equally named) type inside the tests and maybe this type is misplaced inside the Windows module.
* I still need to write more tests and add them to this PR before it can be accepted. Working on it.