### PR TITLE
net2 crate is deprecated replaced by socket2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ ntapi  = "0.3"
 
 [dev-dependencies]
 env_logger = { version = "0.6.2", default-features = false }
-net2       = "0.2.33"
+socket2    = "0.3.15"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -2,8 +2,6 @@
 
 use mio::net::{TcpListener, TcpStream};
 use mio::{Events, Interest, Poll, Token};
-#[cfg(unix)]
-use net2::TcpStreamExt;
 use std::io::{self, Read, Write};
 use std::net::{self, Shutdown};
 #[cfg(unix)]
@@ -473,10 +471,11 @@ fn connection_reset_by_peer() {
     let addr = listener.local_addr().unwrap();
 
     // Connect client
-    let client = net2::TcpBuilder::new_v4().unwrap().to_tcp_stream().unwrap();
+    let client =
+        socket2::Socket::new(socket2::Domain::ipv4(), socket2::Type::stream(), None).unwrap();
 
     client.set_linger(Some(Duration::from_millis(0))).unwrap();
-    client.connect(&addr).unwrap();
+    client.connect(&addr.into()).unwrap();
 
     // Convert to Mio stream
     // FIXME: how to convert the stream on Windows?


### PR DESCRIPTION
for more details please see https://rustsec.org/advisories/RUSTSEC-2020-0016