### PR TITLE
Report EPOLLERR as is_write_closed

### DIFF
--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -172,6 +172,8 @@ pub mod event {
             // Unix pipe write end has closed
             || (event.events as libc::c_int & libc::EPOLLOUT != 0
                 && event.events as libc::c_int & libc::EPOLLERR != 0)
+            // The other side (read end) of a Unix pipe has closed.
+            || event.events as libc::c_int == libc::EPOLLERR
     }
 
     pub fn is_priority(event: &Event) -> bool {


### PR DESCRIPTION
The epoll_ctl(2) manual says to following about EPOLLERR

    Error condition happened on the associated file descriptor. This
    event is also reported for the write end of a pipe when the read end
    has been closed.

In practice we've seen a number of event variations when the read side
of a Unix pipe(2) is closed, including EPOLLHUP and EPOLLOUT|EPOLLERR.
And now we've also seen just EPOLLERR, without EPOLLOUT.

This caused the process_issue_2174 test to fail in Tokio, currently
found here:
https://github.com/tokio-rs/tokio/blob/078d0a2ebc4d4f88cb6bce05c8ac4f5038dae9be/tokio/tests/process_issue_2174.rs.