### PR TITLE
Add windows NamedPipe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ ntapi  = "0.3"
 [dev-dependencies]
 env_logger = { version = "0.6.2", default-features = false }
 net2       = "0.2.33"
-futures-test = "0.3"
 rand = "0.4"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ ntapi  = "0.3"
 [dev-dependencies]
 env_logger = { version = "0.6.2", default-features = false }
 net2       = "0.2.33"
+futures    = "0.3"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ ntapi  = "0.3"
 env_logger = { version = "0.6.2", default-features = false }
 net2       = "0.2.33"
 futures-test = "0.3"
+rand = "0.4"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ ntapi  = "0.3"
 [dev-dependencies]
 env_logger = { version = "0.6.2", default-features = false }
 net2       = "0.2.33"
-futures    = "0.3"
+futures-test = "0.3"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,13 @@ pub mod unix {
     pub use crate::sys::SourceFd;
 }
 
+#[cfg(all(windows, feature = "os-util"))]
+#[cfg_attr(docsrs, doc(cfg(all(windows, feature = "os-util"))))]
+pub mod windows {
+    //! Windows only extensions.
+    pub use crate::sys::named_pipe::NamedPipe;
+}
+
 // Enable with `cargo doc --features extra-docs`.
 #[cfg(feature = "extra-docs")]
 pub mod features {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,10 @@ pub mod unix {
 #[cfg_attr(docsrs, doc(cfg(all(windows, feature = "os-util"))))]
 pub mod windows {
     //! Windows only extensions.
-    pub use crate::sys::named_pipe::NamedPipe;
+
+    cfg_os_poll! {
+        pub use crate::sys::named_pipe::NamedPipe;
+    }
 }
 
 // Enable with `cargo doc --features extra-docs`.

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -77,7 +77,8 @@ cfg_os_poll! {
     }
 }
 
-cfg_any_os_util! {
+#[cfg(windows)]
+cfg_os_poll! {
     mod windows;
     pub use self::windows::*;
 }

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -80,7 +80,7 @@ cfg_os_poll! {
 #[cfg(windows)]
 cfg_os_poll! {
     mod windows;
-    pub(crate) use self::windows::*;
+    pub use self::windows::*;
 }
 
 cfg_not_os_poll! {

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -77,8 +77,7 @@ cfg_os_poll! {
     }
 }
 
-#[cfg(windows)]
-cfg_os_poll! {
+cfg_any_os_util! {
     mod windows;
     pub use self::windows::*;
 }

--- a/src/sys/windows/afd.rs
+++ b/src/sys/windows/afd.rs
@@ -194,7 +194,10 @@ cfg_net! {
                     ));
                 }
                 let fd = File::from_raw_handle(afd_helper_handle as RawHandle);
-                // Increment by 2 to reserve space for other types of handles
+                // Increment by 2 to reserve space for other types of handles.
+                // Non-AFD types (currently only NamedPipe), use odd numbered
+                // tokens. This allows the selector to differentate between them
+                // and dispatch events accordingly.
                 let token = NEXT_TOKEN.fetch_add(2, Ordering::Relaxed) + 2;
                 let afd = Afd { fd };
                 cp.add_handle(token, &afd.fd)?;

--- a/src/sys/windows/afd.rs
+++ b/src/sys/windows/afd.rs
@@ -194,7 +194,8 @@ cfg_net! {
                     ));
                 }
                 let fd = File::from_raw_handle(afd_helper_handle as RawHandle);
-                let token = NEXT_TOKEN.fetch_add(1, Ordering::Relaxed) + 1;
+                // Increment by 2 to reserve space for other types of handles
+                let token = NEXT_TOKEN.fetch_add(2, Ordering::Relaxed) + 2;
                 let afd = Afd { fd };
                 cp.add_handle(token, &afd.fd)?;
                 match SetFileCompletionNotificationModes(

--- a/src/sys/windows/afd.rs
+++ b/src/sys/windows/afd.rs
@@ -7,9 +7,7 @@ use std::io;
 use std::mem::size_of;
 use std::os::windows::io::AsRawHandle;
 use std::ptr::null_mut;
-use winapi::shared::ntdef::{
-    HANDLE, LARGE_INTEGER, NTSTATUS, PVOID, ULONG,
-};
+use winapi::shared::ntdef::{HANDLE, LARGE_INTEGER, NTSTATUS, PVOID, ULONG};
 use winapi::shared::ntstatus::{STATUS_NOT_FOUND, STATUS_PENDING, STATUS_SUCCESS};
 
 const IOCTL_AFD_POLL: ULONG = 0x00012024;

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -14,6 +14,34 @@ pub fn token(event: &Event) -> Token {
     Token(event.data as usize)
 }
 
+impl Event {
+    pub(super) fn new(token: Token) -> Event {
+        Event {
+            flags: 0,
+            data: usize::from(token) as u64,
+        }
+    }
+
+    pub(super) fn set_readable(&mut self) {
+        self.flags |= READABLE_FLAGS
+    }
+
+    pub(super) fn set_writable(&mut self) {
+        self.flags |= WRITABLE_FLAGS
+    }
+
+    pub(super) fn from_completion_status(status: &CompletionStatus) -> Event {
+        Event {
+            flags: status.bytes_transferred(),
+            data: status.token() as u64,
+        }
+    }
+
+    pub(super) fn to_completion_status(&self) -> CompletionStatus {
+        CompletionStatus::new(self.flags, self.data as usize, std::ptr::null_mut())
+    }
+}
+
 pub(crate) const READABLE_FLAGS: u32 = afd::POLL_RECEIVE
     | afd::POLL_DISCONNECT
     | afd::POLL_ACCEPT

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -26,6 +26,7 @@ impl Event {
         self.flags |= READABLE_FLAGS
     }
 
+    #[cfg(feature = "os-util")]
     pub(super) fn set_writable(&mut self) {
         self.flags |= WRITABLE_FLAGS
     }

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -23,12 +23,12 @@ impl Event {
     }
 
     pub(super) fn set_readable(&mut self) {
-        self.flags |= READABLE_FLAGS
+        self.flags |= afd::POLL_RECEIVE
     }
 
     #[cfg(feature = "os-util")]
     pub(super) fn set_writable(&mut self) {
-        self.flags |= WRITABLE_FLAGS
+        self.flags |= afd::POLL_SEND;
     }
 
     pub(super) fn from_completion_status(status: &CompletionStatus) -> Event {

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -32,6 +32,8 @@ cfg_udp! {
     pub(crate) mod udp;
 }
 
+pub(crate) mod named_pipe;
+
 mod waker;
 pub(crate) use waker::Waker;
 

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -7,6 +7,9 @@ pub use event::{Event, Events};
 mod selector;
 pub use selector::{Selector, SelectorInner, SockState};
 
+mod overlapped;
+use overlapped::Overlapped;
+
 // Macros must be defined before the modules that use them
 cfg_net! {
     /// Helper macro to execute a system call that returns an `io::Result`.

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -32,6 +32,7 @@ cfg_udp! {
     pub(crate) mod udp;
 }
 
+#[cfg(feature = "os-util")]
 pub(crate) mod named_pipe;
 
 mod waker;

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -1,0 +1,654 @@
+//! Windows named pipes bindings for mio.
+//!
+//! This crate implements bindings for named pipes for the mio crate. This
+//! crate compiles on all platforms but only contains anything on Windows.
+//! Currently this crate requires mio 0.6.2.
+//!
+//! On Windows, mio is implemented with an IOCP object at the heart of its
+//! `Poll` implementation. For named pipes, this means that all I/O is done in
+//! an overlapped fashion and the named pipes themselves are registered with
+//! mio's internal IOCP object. Essentially, this crate is using IOCP for
+//! bindings with named pipes.
+//!
+//! Note, though, that IOCP is a *completion* based model whereas mio expects a
+//! *readiness* based model. As a result this crate, like with TCP objects in
+//! mio, has internal buffering to translate the completion model to a readiness
+//! model. This means that this crate is not a zero-cost binding over named
+//! pipes on Windows, but rather approximates the performance of mio's TCP
+//! implementation on Windows.
+//!
+//! # Trait implementations
+//!
+//! The `Read` and `Write` traits are implemented for `NamedPipe` and for
+//! `&NamedPipe`. This represents that a named pipe can be concurrently read and
+//! written to and also can be read and written to at all. Typically a named
+//! pipe needs to be connected to a client before it can be read or written,
+//! however.
+//!
+//! Note that for I/O operations on a named pipe to succeed then the named pipe
+//! needs to be associated with an event loop. Until this happens all I/O
+//! operations will return a "would block" error.
+//!
+//! # Managing connections
+//!
+//! The `NamedPipe` type supports a `connect` method to connect to a client and
+//! a `disconnect` method to disconnect from that client. These two methods only
+//! work once a named pipe is associated with an event loop.
+//!
+//! The `connect` method will succeed asynchronously and a completion can be
+//! detected once the object receives a writable notification.
+//!
+//! # Named pipe clients
+//!
+//! Currently to create a client of a named pipe server then you can use the
+//! `OpenOptions` type in the standard library to create a `File` that connects
+//! to a named pipe. Afterwards you can use the `into_raw_handle` method coupled
+//! with the `NamedPipe::from_raw_handle` method to convert that to a named pipe
+//! that can operate asynchronously. Don't forget to pass the
+//! `FILE_FLAG_OVERLAPPED` flag when opening the `File`.
+
+use crate::{poll, Registry, Token};
+
+use std::cell::UnsafeCell;
+use std::ffi::OsStr;
+use std::fmt;
+use std::io::{self, Read};
+use std::mem;
+use std::os::windows::io::*;
+use std::slice;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering::SeqCst;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+
+// use mio::windows;
+// use mio::{Evented, Poll, PollOpt, Ready, Registration, SetReadiness, Token};
+use miow::iocp::CompletionStatus;
+use miow::pipe;
+use winapi::shared::winerror::*;
+use winapi::um::ioapiset::*;
+use winapi::um::minwinbase::*;
+
+macro_rules! offset_of {
+    ($t:ty, $($field:ident).+) => (
+        &(*(0 as *const $t)).$($field).+ as *const _ as usize
+    )
+}
+
+macro_rules! overlapped2arc {
+    ($e:expr, $t:ty, $($field:ident).+) => ({
+        let offset = offset_of!($t, $($field).+);
+        debug_assert!(offset < mem::size_of::<$t>());
+        Arc::from_raw(($e as usize - offset) as *mut $t)
+    })
+}
+
+fn would_block() -> io::Error {
+    io::ErrorKind::WouldBlock.into()
+}
+
+/// Representation of a named pipe on Windows.
+///
+/// This structure internally contains a `HANDLE` which represents the named
+/// pipe, and also maintains state associated with the mio event loop and active
+/// I/O operations that have been scheduled to translate IOCP to a readiness
+/// model.
+pub struct NamedPipe {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    handle: pipe::NamedPipe,
+
+    connect: Overlapped,
+    connecting: AtomicBool,
+
+    read: Overlapped,
+    write: Overlapped,
+
+    io: Mutex<Io>,
+
+    pool: Mutex<BufferPool>,
+}
+
+struct Io {
+    read: State,
+    read_waker: Option<Waker>,
+    write: State,
+    write_waker: Option<Waker>,
+    connect_error: Option<io::Error>,
+}
+
+enum State {
+    None,
+    Pending(Vec<u8>, usize),
+    Ok(Vec<u8>, usize),
+    Err(io::Error),
+}
+
+fn _assert_kinds() {
+    fn _assert_send<T: Send>() {}
+    fn _assert_sync<T: Sync>() {}
+    _assert_send::<NamedPipe>();
+    _assert_sync::<NamedPipe>();
+}
+
+impl NamedPipe {
+    /// Creates a new named pipe at the specified `addr` given a "reasonable
+    /// set" of initial configuration options.
+    pub fn new<A: AsRef<OsStr>>(addr: A, registry: &Registry, token: Token) -> io::Result<NamedPipe> {
+        let pipe = pipe::NamedPipe::new(addr)?;
+        NamedPipe::from_raw_handle(pipe.into_raw_handle(), registry, token)
+    }
+
+    /// TODO: Dox
+    pub fn from_raw_handle(handle: RawHandle, registry: &Registry, token: Token) -> io::Result<NamedPipe> {
+        // Create the pipe
+        let pipe = NamedPipe {
+            inner: Arc::new(Inner {
+                // Safety: not really unsafe
+                handle: unsafe { pipe::NamedPipe::from_raw_handle(handle) },
+                // transmutes to straddle winapi versions (mio 0.6 is on an
+                // older winapi)
+                connect: Overlapped::new(connect_done),
+                connecting: AtomicBool::new(false),
+                read: Overlapped::new(read_done),
+                write: Overlapped::new(write_done),
+                io: Mutex::new(Io {
+                    read: State::None,
+                    read_waker: None,
+                    write: State::None,
+                    write_waker: None,
+                    connect_error: None,
+                }),
+                pool: Mutex::new(BufferPool::with_capacity(2)),
+            }),
+        };
+
+        // Register the handle w/ the IOCP handle
+        poll::selector(registry).inner.cp.add_handle(usize::from(token), &pipe.inner.handle)?;
+
+        // Queue the initial read
+        pipe.inner.post_register();
+
+        Ok(pipe)
+    }
+
+    /// Attempts to call `ConnectNamedPipe`, if possible.
+    ///
+    /// This function will attempt to connect this pipe to a client in an
+    /// asynchronous fashion. If the function immediately establishes a
+    /// connection to a client then `Ok(())` is returned. Otherwise if a
+    /// connection attempt was issued and is now in progress then a "would
+    /// block" error is returned.
+    ///
+    /// When the connection is finished then this object will be flagged as
+    /// being ready for a write, or otherwise in the writable state.
+    ///
+    /// # Errors
+    ///
+    /// This function will return a "would block" error if the pipe has not yet
+    /// been registered with an event loop, if the connection operation has
+    /// previously been issued but has not yet completed, or if the connect
+    /// itself was issued and didn't finish immediately.
+    ///
+    /// Normal I/O errors from the call to `ConnectNamedPipe` are returned
+    /// immediately.
+    pub fn connect(&self) -> io::Result<()> {
+        // "Acquire the connecting lock" or otherwise just make sure we're the
+        // only operation that's using the `connect` overlapped instance.
+        if self.inner.connecting.swap(true, SeqCst) {
+            return Err(would_block());
+        }
+
+        // Now that we've flagged ourselves in the connecting state, issue the
+        // connection attempt. Afterwards interpret the return value and set
+        // internal state accordingly.
+        let res = unsafe {
+            let overlapped = self.inner.connect.as_mut_ptr() as *mut _;
+            self.inner.handle.connect_overlapped(overlapped)
+        };
+
+        match res {
+            // The connection operation finished immediately, so let's schedule
+            // reads/writes and such.
+            Ok(true) => {
+                self.inner.connecting.store(false, SeqCst);
+                Inner::post_register(&self.inner);
+                Ok(())
+            }
+
+            // If the overlapped operation was successful and didn't finish
+            // immediately then we forget a copy of the arc we hold
+            // internally. This ensures that when the completion status comes
+            // in for the I/O operation finishing it'll have a reference
+            // associated with it and our data will still be valid. The
+            // `connect_done` function will "reify" this forgotten pointer to
+            // drop the refcount on the other side.
+            Ok(false) => {
+                mem::forget(self.inner.clone());
+                Err(would_block())
+            }
+
+            // TODO: are we sure no IOCP notification comes in here?
+            Err(e) => {
+                self.inner.connecting.store(false, SeqCst);
+                Err(e)
+            }
+        }
+    }
+
+    /// Takes any internal error that has happened after the last I/O operation
+    /// which hasn't been retrieved yet.
+    ///
+    /// This is particularly useful when detecting failed attempts to `connect`.
+    /// After a completed `connect` flags this pipe as writable then callers
+    /// must invoke this method to determine whether the connection actually
+    /// succeeded. If this function returns `None` then a client is connected,
+    /// otherwise it returns an error of what happened and a client shouldn't be
+    /// connected.
+    pub fn take_error(&self) -> io::Result<Option<io::Error>> {
+        Ok(self.inner.io.lock().unwrap().connect_error.take())
+    }
+
+    /// Disconnects this named pipe from a connected client.
+    ///
+    /// This function will disconnect the pipe from a connected client, if any,
+    /// transitively calling the `DisconnectNamedPipe` function. If the
+    /// disconnection is successful then this object will no longer be readable
+    /// or writable.
+    ///
+    /// After a `disconnect` is issued, then a `connect` may be called again to
+    /// connect to another client.
+    pub fn disconnect(&self) -> io::Result<()> {
+        self.inner.handle.disconnect()
+    }
+
+    /// TODO: dox
+    pub fn read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<io::Result<usize>> {
+        let mut state = self.inner.io.lock().unwrap();
+        match mem::replace(&mut state.read, State::None) {
+            // In theory not possible with `ready_registration` checked above,
+            // but return would block for now.
+            State::None => {
+                state.read_waker = Some(cx.waker().clone());
+                Poll::Pending
+            }
+
+            // A read is in flight, still waiting for it to finish
+            State::Pending(buf, amt) => {
+                state.read = State::Pending(buf, amt);
+                state.read_waker = Some(cx.waker().clone());
+                Poll::Pending
+            }
+
+            // We previously read something into `data`, try to copy out some
+            // data. If we copy out all the data schedule a new read and
+            // otherwise store the buffer to get read later.
+            State::Ok(data, cur) => {
+                let n = {
+                    let mut remaining = &data[cur..];
+                    remaining.read(buf)?
+                };
+                let next = cur + n;
+                if next != data.len() {
+                    state.read = State::Ok(data, next);
+                } else {
+                    self.inner.put_buffer(data);
+                    Inner::schedule_read(&self.inner, &mut state);
+                }
+                Poll::Ready(Ok(n))
+            }
+
+            // Looks like an in-flight read hit an error, return that here while
+            // we schedule a new one.
+            State::Err(e) => {
+                Inner::schedule_read(&self.inner, &mut state);
+                if e.raw_os_error() == Some(ERROR_BROKEN_PIPE as i32) {
+                    Poll::Ready(Ok(0))
+                } else {
+                    Poll::Ready(Err(e))
+                }
+            }
+        }
+    }
+
+    /// TODO: dox
+    pub fn write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+        // Make sure there's no writes pending
+        let mut io = self.inner.io.lock().unwrap();
+        match io.write {
+            State::None => {}
+            _ => {
+                io.write_waker = Some(cx.waker().clone());
+                return Poll::Pending;
+            }
+        }
+
+        // Move `buf` onto the heap and fire off the write
+        let mut owned_buf = self.inner.get_buffer();
+        owned_buf.extend(buf);
+        Inner::schedule_write(&self.inner, owned_buf, 0, &mut io);
+        Poll::Ready(Ok(buf.len()))
+    }
+}
+
+impl AsRawHandle for NamedPipe {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.inner.handle.as_raw_handle()
+    }
+}
+
+impl fmt::Debug for NamedPipe {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.handle.fmt(f)
+    }
+}
+
+impl Drop for NamedPipe {
+    fn drop(&mut self) {
+        // Cancel pending reads/connects, but don't cancel writes to ensure that
+        // everything is flushed out.
+        unsafe {
+            if self.inner.connecting.load(SeqCst) {
+                drop(cancel(&self.inner.handle, &self.inner.connect));
+            }
+
+            let io = self.inner.io.lock().unwrap();
+
+            match io.read {
+                State::Pending(..) => {
+                    drop(cancel(&self.inner.handle, &self.inner.read));
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl Inner {
+    /// Schedules a read to happen in the background, executing an overlapped
+    /// operation.
+    ///
+    /// This function returns `true` if a normal error happens or if the read
+    /// is scheduled in the background. If the pipe is no longer connected
+    /// (ERROR_PIPE_LISTENING) then `false` is returned and no read is
+    /// scheduled.
+    fn schedule_read(me: &Arc<Inner>, io: &mut Io) -> bool {
+        // Check to see if a read is already scheduled/completed
+        match io.read {
+            State::None => {}
+            _ => return true,
+        }
+
+        // Allocate a buffer and schedule the read.
+        let mut buf = me.get_buffer();
+        let e = unsafe {
+            let overlapped = me.read.as_mut_ptr() as *mut _;
+            let slice = slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.capacity());
+            me.handle.read_overlapped(slice, overlapped)
+        };
+
+        match e {
+            // See `connect` above for the rationale behind `forget`
+            Ok(_) => {
+                io.read = State::Pending(buf, 0); // 0 is ignored on read side
+                mem::forget(me.clone());
+                true
+            }
+
+            // If ERROR_PIPE_LISTENING happens then it's not a real read error,
+            // we just need to wait for a connect.
+            Err(ref e) if e.raw_os_error() == Some(ERROR_PIPE_LISTENING as i32) => false,
+
+            // If some other error happened, though, we're now readable to give
+            // out the error.
+            Err(e) => {
+                io.read = State::Err(e);
+                if let Some(waker) = io.read_waker.take() {
+                    waker.wake();
+                }
+                true
+            }
+        }
+    }
+
+    fn schedule_write(me: &Arc<Inner>, buf: Vec<u8>, pos: usize, io: &mut Io) {
+        // Very similar to `schedule_read` above, just done for the write half.
+        let e = unsafe {
+            let overlapped = me.write.as_mut_ptr() as *mut _;
+            me.handle.write_overlapped(&buf[pos..], overlapped)
+        };
+
+        match e {
+            // See `connect` above for the rationale behind `forget`
+            Ok(_) => {
+                io.write = State::Pending(buf, pos);
+                mem::forget(me.clone())
+            }
+            Err(e) => {
+                io.write = State::Err(e);
+                if let Some(waker) = io.write_waker.take() {
+                    waker.wake();
+                }
+            }
+        }
+    }
+
+    fn post_register(self: &Arc<Inner>) {
+        let mut io = self.io.lock().unwrap();
+        if Inner::schedule_read(&self, &mut io) {
+            if let State::None = io.write {
+                if let Some(waker) = io.write_waker.take() {
+                    waker.wake();
+                }
+            }
+        }
+    }
+
+    fn get_buffer(&self) -> Vec<u8> {
+        self.pool.lock().unwrap().get(8 * 1024)
+    }
+
+    fn put_buffer(&self, buf: Vec<u8>) {
+        self.pool.lock().unwrap().put(buf)
+    }
+}
+
+unsafe fn cancel<T: AsRawHandle>(handle: &T, overlapped: &Overlapped) -> io::Result<()> {
+    let ret = CancelIoEx(handle.as_raw_handle(), overlapped.as_mut_ptr() as *mut _);
+    if ret == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+fn connect_done(status: &OVERLAPPED_ENTRY) {
+    let status = CompletionStatus::from_entry(status);
+
+    // Acquire the `Arc<Inner>`. Note that we should be guaranteed that
+    // the refcount is available to us due to the `mem::forget` in
+    // `connect` above.
+    let me = unsafe { overlapped2arc!(status.overlapped(), Inner, connect) };
+
+    // Flag ourselves as no longer using the `connect` overlapped instances.
+    let prev = me.connecting.swap(false, SeqCst);
+    assert!(prev, "wasn't previously connecting");
+
+    // Stash away our connect error if one happened
+    debug_assert_eq!(status.bytes_transferred(), 0);
+    unsafe {
+        match me.handle.result(status.overlapped()) {
+            Ok(n) => debug_assert_eq!(n, 0),
+            Err(e) => me.io.lock().unwrap().connect_error = Some(e),
+        }
+    }
+
+    // We essentially just finished a registration, so kick off a
+    // read and register write readiness.
+    Inner::post_register(&me);
+}
+
+fn read_done(status: &OVERLAPPED_ENTRY) {
+    let status = CompletionStatus::from_entry(status);
+
+    // Acquire the `FromRawArc<Inner>`. Note that we should be guaranteed that
+    // the refcount is available to us due to the `mem::forget` in
+    // `schedule_read` above.
+    let me = unsafe { overlapped2arc!(status.overlapped(), Inner, read) };
+
+    // Move from the `Pending` to `Ok` state.
+    let mut io = me.io.lock().unwrap();
+    let mut buf = match mem::replace(&mut io.read, State::None) {
+        State::Pending(buf, _) => buf,
+        _ => unreachable!(),
+    };
+    unsafe {
+        match me.handle.result(status.overlapped()) {
+            Ok(n) => {
+                debug_assert_eq!(status.bytes_transferred() as usize, n);
+                buf.set_len(status.bytes_transferred() as usize);
+                io.read = State::Ok(buf, 0);
+            }
+            Err(e) => {
+                debug_assert_eq!(status.bytes_transferred(), 0);
+                io.read = State::Err(e);
+            }
+        }
+    }
+
+    // Flag our readiness that we've got data.
+    if let Some(waker) = io.read_waker.take() {
+        waker.wake();
+    }
+}
+
+fn write_done(status: &OVERLAPPED_ENTRY) {
+    let status = CompletionStatus::from_entry(status);
+
+    // Acquire the `Arc<Inner>`. Note that we should be guaranteed that
+    // the refcount is available to us due to the `mem::forget` in
+    // `schedule_write` above.
+    let me = unsafe { overlapped2arc!(status.overlapped(), Inner, write) };
+
+    // Make the state change out of `Pending`. If we wrote the entire buffer
+    // then we're writable again and otherwise we schedule another write.
+    let mut io = me.io.lock().unwrap();
+    let (buf, pos) = match mem::replace(&mut io.write, State::None) {
+        State::Pending(buf, pos) => (buf, pos),
+        _ => unreachable!(),
+    };
+
+    unsafe {
+        match me.handle.result(status.overlapped()) {
+            Ok(n) => {
+                debug_assert_eq!(status.bytes_transferred() as usize, n);
+                let new_pos = pos + (status.bytes_transferred() as usize);
+                if new_pos == buf.len() {
+                    me.put_buffer(buf);
+                    if let Some(waker) = io.write_waker.take() {
+                        waker.wake();
+                    }
+                } else {
+                    Inner::schedule_write(&me, buf, new_pos, &mut io);
+                }
+            }
+            Err(e) => {
+                debug_assert_eq!(status.bytes_transferred(), 0);
+                io.write = State::Err(e);
+                if let Some(waker) = io.write_waker.take() {
+                    waker.wake();
+                }
+            }
+        }
+    }
+}
+
+// Based on https://github.com/tokio-rs/mio/blob/13d5fc9/src/sys/windows/buffer_pool.rs
+struct BufferPool {
+    pool: Vec<Vec<u8>>,
+}
+
+impl BufferPool {
+    fn with_capacity(cap: usize) -> BufferPool {
+        BufferPool {
+            pool: Vec::with_capacity(cap),
+        }
+    }
+
+    fn get(&mut self, default_cap: usize) -> Vec<u8> {
+        self.pool
+            .pop()
+            .unwrap_or_else(|| Vec::with_capacity(default_cap))
+    }
+
+    fn put(&mut self, mut buf: Vec<u8>) {
+        if self.pool.len() < self.pool.capacity() {
+            unsafe {
+                buf.set_len(0);
+            }
+            self.pool.push(buf);
+        }
+    }
+}
+
+// See sys::windows module docs for why this exists.
+//
+// The gist of it is that `Selector` assumes that all `OVERLAPPED` pointers are
+// actually inside one of these structures so it can use the `Callback` stored
+// right after it.
+//
+// We use repr(C) here to ensure that we can assume the overlapped pointer is
+// at the start of the structure so we can just do a cast.
+/// A wrapper around an internal instance over `miow::Overlapped` which is in
+/// turn a wrapper around the Windows type `OVERLAPPED`.
+///
+/// This type is required to be used for all IOCP operations on handles that are
+/// registered with an event loop. The event loop will receive notifications
+/// over `OVERLAPPED` pointers that have completed, and it will cast that
+/// pointer to a pointer to this structure and invoke the associated callback.
+#[repr(C)]
+pub struct Overlapped {
+    inner: UnsafeCell<miow::Overlapped>,
+    callback: fn(&OVERLAPPED_ENTRY),
+}
+
+impl Overlapped {
+    /// Creates a new `Overlapped` which will invoke the provided `cb` callback
+    /// whenever it's triggered.
+    ///
+    /// The returned `Overlapped` must be used as the `OVERLAPPED` passed to all
+    /// I/O operations that are registered with mio's event loop. When the I/O
+    /// operation associated with an `OVERLAPPED` pointer completes the event
+    /// loop will invoke the function pointer provided by `cb`.
+    pub fn new(cb: fn(&OVERLAPPED_ENTRY)) -> Overlapped {
+        Overlapped {
+            inner: UnsafeCell::new(miow::Overlapped::zero()),
+            callback: cb,
+        }
+    }
+
+    /// Get the underlying `Overlapped` instance as a raw pointer.
+    ///
+    /// This can be useful when only a shared borrow is held and the overlapped
+    /// pointer needs to be passed down to winapi.
+    pub fn as_mut_ptr(&self) -> *mut OVERLAPPED {
+        unsafe {
+            (*self.inner.get()).raw()
+        }
+    }
+}
+
+impl fmt::Debug for Overlapped {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Overlapped")
+            .finish()
+    }
+}
+
+// Overlapped's APIs are marked as unsafe Overlapped's APIs are marked as
+// unsafe as they must be used with caution to ensure thread safety. The
+// structure itself is safe to send across threads.
+unsafe impl Send for Overlapped {}
+unsafe impl Sync for Overlapped {}

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -121,13 +121,6 @@ enum State {
 // Odd tokens are for named pipes
 static NEXT_TOKEN: AtomicUsize = AtomicUsize::new(1);
 
-fn _assert_kinds() {
-    fn _assert_send<T: Send>() {}
-    fn _assert_sync<T: Sync>() {}
-    _assert_send::<NamedPipe>();
-    _assert_sync::<NamedPipe>();
-}
-
 fn would_block() -> io::Error {
     io::ErrorKind::WouldBlock.into()
 }

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -119,6 +119,7 @@ struct Io {
     connect_error: Option<io::Error>,
 }
 
+#[derive(Debug)]
 enum State {
     None,
     Pending(Vec<u8>, usize),
@@ -456,6 +457,9 @@ impl Inner {
 
     fn post_register(me: &Arc<Inner>) {
         let mut io = me.io.lock().unwrap();
+        println!(" ... post_register");
+        println!(" {:?}", io.read);
+        println!(" {:?}", io.write);
         if Inner::schedule_read(&me, &mut io) {
             if let State::None = io.write {
                 if let Some(waker) = io.write_waker.take() {

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -48,8 +48,8 @@
 //! `FILE_FLAG_OVERLAPPED` flag when opening the `File`.
 
 use crate::{poll, Registry};
+use crate::sys::windows::Overlapped;
 
-use std::cell::UnsafeCell;
 use std::ffi::OsStr;
 use std::fmt;
 use std::io::{self, Read};
@@ -608,60 +608,3 @@ impl BufferPool {
         }
     }
 }
-
-// See sys::windows module docs for why this exists.
-//
-// The gist of it is that `Selector` assumes that all `OVERLAPPED` pointers are
-// actually inside one of these structures so it can use the `Callback` stored
-// right after it.
-//
-// We use repr(C) here to ensure that we can assume the overlapped pointer is
-// at the start of the structure so we can just do a cast.
-/// A wrapper around an internal instance over `miow::Overlapped` which is in
-/// turn a wrapper around the Windows type `OVERLAPPED`.
-///
-/// This type is required to be used for all IOCP operations on handles that are
-/// registered with an event loop. The event loop will receive notifications
-/// over `OVERLAPPED` pointers that have completed, and it will cast that
-/// pointer to a pointer to this structure and invoke the associated callback.
-#[repr(C)]
-pub(crate) struct Overlapped {
-    inner: UnsafeCell<miow::Overlapped>,
-    pub(crate) callback: fn(&OVERLAPPED_ENTRY),
-}
-
-impl Overlapped {
-    /// Creates a new `Overlapped` which will invoke the provided `cb` callback
-    /// whenever it's triggered.
-    ///
-    /// The returned `Overlapped` must be used as the `OVERLAPPED` passed to all
-    /// I/O operations that are registered with mio's event loop. When the I/O
-    /// operation associated with an `OVERLAPPED` pointer completes the event
-    /// loop will invoke the function pointer provided by `cb`.
-    pub fn new(cb: fn(&OVERLAPPED_ENTRY)) -> Overlapped {
-        Overlapped {
-            inner: UnsafeCell::new(miow::Overlapped::zero()),
-            callback: cb,
-        }
-    }
-
-    /// Get the underlying `Overlapped` instance as a raw pointer.
-    ///
-    /// This can be useful when only a shared borrow is held and the overlapped
-    /// pointer needs to be passed down to winapi.
-    pub fn as_mut_ptr(&self) -> *mut OVERLAPPED {
-        unsafe { (*self.inner.get()).raw() }
-    }
-}
-
-impl fmt::Debug for Overlapped {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Overlapped").finish()
-    }
-}
-
-// Overlapped's APIs are marked as unsafe Overlapped's APIs are marked as
-// unsafe as they must be used with caution to ensure thread safety. The
-// structure itself is safe to send across threads.
-unsafe impl Send for Overlapped {}
-unsafe impl Sync for Overlapped {}

--- a/src/sys/windows/overlapped.rs
+++ b/src/sys/windows/overlapped.rs
@@ -7,21 +7,6 @@ use winapi::um::minwinbase::OVERLAPPED_ENTRY;
 #[cfg(feature = "os-util")]
 use winapi::um::minwinbase::OVERLAPPED;
 
-// See sys::windows module docs for why this exists.
-//
-// The gist of it is that `Selector` assumes that all `OVERLAPPED` pointers are
-// actually inside one of these structures so it can use the `Callback` stored
-// right after it.
-//
-// We use repr(C) here to ensure that we can assume the overlapped pointer is
-// at the start of the structure so we can just do a cast.
-/// A wrapper around an internal instance over `miow::Overlapped` which is in
-/// turn a wrapper around the Windows type `OVERLAPPED`.
-///
-/// This type is required to be used for all IOCP operations on handles that are
-/// registered with an event loop. The event loop will receive notifications
-/// over `OVERLAPPED` pointers that have completed, and it will cast that
-/// pointer to a pointer to this structure and invoke the associated callback.
 #[repr(C)]
 pub(crate) struct Overlapped {
     inner: UnsafeCell<miow::Overlapped>,
@@ -30,25 +15,14 @@ pub(crate) struct Overlapped {
 
 #[cfg(feature = "os-util")]
 impl Overlapped {
-    /// Creates a new `Overlapped` which will invoke the provided `cb` callback
-    /// whenever it's triggered.
-    ///
-    /// The returned `Overlapped` must be used as the `OVERLAPPED` passed to all
-    /// I/O operations that are registered with mio's event loop. When the I/O
-    /// operation associated with an `OVERLAPPED` pointer completes the event
-    /// loop will invoke the function pointer provided by `cb`.
-    pub fn new(cb: fn(&OVERLAPPED_ENTRY, Option<&mut Vec<Event>>)) -> Overlapped {
+    pub(crate) fn new(cb: fn(&OVERLAPPED_ENTRY, Option<&mut Vec<Event>>)) -> Overlapped {
         Overlapped {
             inner: UnsafeCell::new(miow::Overlapped::zero()),
             callback: cb,
         }
     }
 
-    /// Get the underlying `Overlapped` instance as a raw pointer.
-    ///
-    /// This can be useful when only a shared borrow is held and the overlapped
-    /// pointer needs to be passed down to winapi.
-    pub fn as_mut_ptr(&self) -> *mut OVERLAPPED {
+    pub(crate) fn as_ptr(&self) -> *const OVERLAPPED {
         unsafe { (*self.inner.get()).raw() }
     }
 }
@@ -59,8 +33,5 @@ impl fmt::Debug for Overlapped {
     }
 }
 
-// Overlapped's APIs are marked as unsafe Overlapped's APIs are marked as
-// unsafe as they must be used with caution to ensure thread safety. The
-// structure itself is safe to send across threads.
 unsafe impl Send for Overlapped {}
 unsafe impl Sync for Overlapped {}

--- a/src/sys/windows/overlapped.rs
+++ b/src/sys/windows/overlapped.rs
@@ -1,0 +1,64 @@
+use std::cell::UnsafeCell;
+use std::fmt;
+
+use winapi::um::minwinbase::OVERLAPPED_ENTRY;
+#[cfg(feature = "os-util")]
+use winapi::um::minwinbase::OVERLAPPED;
+
+// See sys::windows module docs for why this exists.
+//
+// The gist of it is that `Selector` assumes that all `OVERLAPPED` pointers are
+// actually inside one of these structures so it can use the `Callback` stored
+// right after it.
+//
+// We use repr(C) here to ensure that we can assume the overlapped pointer is
+// at the start of the structure so we can just do a cast.
+/// A wrapper around an internal instance over `miow::Overlapped` which is in
+/// turn a wrapper around the Windows type `OVERLAPPED`.
+///
+/// This type is required to be used for all IOCP operations on handles that are
+/// registered with an event loop. The event loop will receive notifications
+/// over `OVERLAPPED` pointers that have completed, and it will cast that
+/// pointer to a pointer to this structure and invoke the associated callback.
+#[repr(C)]
+pub(crate) struct Overlapped {
+    inner: UnsafeCell<miow::Overlapped>,
+    pub(crate) callback: fn(&OVERLAPPED_ENTRY),
+}
+
+#[cfg(feature = "os-util")]
+impl Overlapped {
+    /// Creates a new `Overlapped` which will invoke the provided `cb` callback
+    /// whenever it's triggered.
+    ///
+    /// The returned `Overlapped` must be used as the `OVERLAPPED` passed to all
+    /// I/O operations that are registered with mio's event loop. When the I/O
+    /// operation associated with an `OVERLAPPED` pointer completes the event
+    /// loop will invoke the function pointer provided by `cb`.
+    pub fn new(cb: fn(&OVERLAPPED_ENTRY)) -> Overlapped {
+        Overlapped {
+            inner: UnsafeCell::new(miow::Overlapped::zero()),
+            callback: cb,
+        }
+    }
+
+    /// Get the underlying `Overlapped` instance as a raw pointer.
+    ///
+    /// This can be useful when only a shared borrow is held and the overlapped
+    /// pointer needs to be passed down to winapi.
+    pub fn as_mut_ptr(&self) -> *mut OVERLAPPED {
+        unsafe { (*self.inner.get()).raw() }
+    }
+}
+
+impl fmt::Debug for Overlapped {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Overlapped").finish()
+    }
+}
+
+// Overlapped's APIs are marked as unsafe Overlapped's APIs are marked as
+// unsafe as they must be used with caution to ensure thread safety. The
+// structure itself is safe to send across threads.
+unsafe impl Send for Overlapped {}
+unsafe impl Sync for Overlapped {}

--- a/src/sys/windows/overlapped.rs
+++ b/src/sys/windows/overlapped.rs
@@ -1,3 +1,5 @@
+use crate::sys::windows::Event;
+
 use std::cell::UnsafeCell;
 use std::fmt;
 
@@ -23,7 +25,7 @@ use winapi::um::minwinbase::OVERLAPPED;
 #[repr(C)]
 pub(crate) struct Overlapped {
     inner: UnsafeCell<miow::Overlapped>,
-    pub(crate) callback: fn(&OVERLAPPED_ENTRY),
+    pub(crate) callback: fn(&OVERLAPPED_ENTRY, Option<&mut Vec<Event>>),
 }
 
 #[cfg(feature = "os-util")]
@@ -35,7 +37,7 @@ impl Overlapped {
     /// I/O operations that are registered with mio's event loop. When the I/O
     /// operation associated with an `OVERLAPPED` pointer completes the event
     /// loop will invoke the function pointer provided by `cb`.
-    pub fn new(cb: fn(&OVERLAPPED_ENTRY)) -> Overlapped {
+    pub fn new(cb: fn(&OVERLAPPED_ENTRY, Option<&mut Vec<Event>>)) -> Overlapped {
         Overlapped {
             inner: UnsafeCell::new(miow::Overlapped::zero()),
             callback: cb,

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -369,6 +369,7 @@ impl Selector {
         self.inner.cp.clone()
     }
 
+    #[cfg(feature = "os-util")]
     pub(super) fn same_port(&self, other: &Arc<CompletionPort>) -> bool {
         Arc::ptr_eq(&self.inner.cp, other)
     }

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -498,7 +498,7 @@ impl SelectorInner {
                 continue;
             } else if iocp_event.token() % 2 == 1 {
                 // Handle is a named pipe. This could be extended to be any non-AFD event.
-                let callback = (*(iocp_event.overlapped() as *mut super::named_pipe::Overlapped)).callback;
+                let callback = (*(iocp_event.overlapped() as *mut super::Overlapped)).callback;
     
                 callback(iocp_event.entry());                
                 continue;
@@ -697,7 +697,7 @@ impl Drop for SelectorInner {
                         } else if iocp_event.token() % 2 == 1 {
                             // Named pipe, dispatch the event so it can release resources
                             let callback = unsafe {
-                                (*(iocp_event.overlapped() as *mut super::named_pipe::Overlapped)).callback
+                                (*(iocp_event.overlapped() as *mut super::Overlapped)).callback
                             };
                 
                             callback(iocp_event.entry());

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -500,7 +500,9 @@ impl SelectorInner {
                 // Handle is a named pipe. This could be extended to be any non-AFD event.
                 let callback = (*(iocp_event.overlapped() as *mut super::Overlapped)).callback;
     
-                callback(iocp_event.entry(), Some(events));                
+                let len = events.len();
+                callback(iocp_event.entry(), Some(events));
+                n += events.len() - len;
                 continue;
             }
 

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -368,6 +368,10 @@ impl Selector {
     pub(super) fn clone_port(&self) -> Arc<CompletionPort> {
         self.inner.cp.clone()
     }
+
+    pub(super) fn same_port(&self, other: &Arc<CompletionPort>) -> bool {
+        Arc::ptr_eq(&self.inner.cp, other)
+    }
 }
 
 cfg_net! {

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -339,7 +339,7 @@ pub struct Selector {
     #[cfg(debug_assertions)]
     id: usize,
 
-    inner: Arc<SelectorInner>,
+    pub(super) inner: Arc<SelectorInner>,
 }
 
 impl Selector {
@@ -408,7 +408,7 @@ cfg_net! {
 
 #[derive(Debug)]
 pub struct SelectorInner {
-    cp: Arc<CompletionPort>,
+    pub(super) cp: Arc<CompletionPort>,
     update_queue: Mutex<VecDeque<Pin<Arc<Mutex<SockState>>>>>,
     afd_group: AfdGroup,
     is_polling: AtomicBool,

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -432,8 +432,18 @@ impl SelectorInner {
     pub fn select(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<()> {
         events.clear();
 
-        self.select2(&mut events.statuses, &mut events.events, timeout)?;
-        return Ok(());
+        if timeout.is_none() {
+            loop {
+                let len = self.select2(&mut events.statuses, &mut events.events, None)?;
+                if len == 0 {
+                    continue;
+                }
+                return Ok(());
+            }
+        } else {
+            self.select2(&mut events.statuses, &mut events.events, timeout)?;
+            return Ok(());
+        }
     }
 
     pub fn select2(

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -8,7 +8,6 @@ use crate::sys::Events;
 use crate::Interest;
 
 use miow::iocp::{CompletionPort, CompletionStatus};
-use miow::Overlapped;
 use std::collections::VecDeque;
 use std::marker::PhantomPinned;
 use std::os::windows::io::RawSocket;
@@ -18,17 +17,12 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use std::{io, ptr};
+use std::io;
 use winapi::shared::ntdef::NT_SUCCESS;
 use winapi::shared::ntdef::{HANDLE, PVOID};
 use winapi::shared::ntstatus::STATUS_CANCELLED;
 use winapi::shared::winerror::{ERROR_INVALID_HANDLE, ERROR_IO_PENDING, WAIT_TIMEOUT};
 use winapi::um::minwinbase::OVERLAPPED;
-
-/// Overlapped value to indicate a `Waker` event.
-//
-// Note: this must be null, `SelectorInner::feed_events` depends on it.
-pub const WAKER_OVERLAPPED: *mut Overlapped = ptr::null_mut();
 
 #[derive(Debug)]
 struct AfdGroup {
@@ -489,18 +483,14 @@ impl SelectorInner {
         let mut update_queue = self.update_queue.lock().unwrap();
         for iocp_event in iocp_events.iter() {
             if iocp_event.overlapped().is_null() {
-                // `Waker` event, we'll add a readable event to match the other platforms.
-                events.push(Event {
-                    flags: afd::POLL_RECEIVE,
-                    data: iocp_event.token() as u64,
-                });
+                events.push(Event::from_completion_status(iocp_event));
                 n += 1;
                 continue;
             } else if iocp_event.token() % 2 == 1 {
                 // Handle is a named pipe. This could be extended to be any non-AFD event.
                 let callback = (*(iocp_event.overlapped() as *mut super::Overlapped)).callback;
     
-                callback(iocp_event.entry());                
+                callback(iocp_event.entry(), Some(events));                
                 continue;
             }
 
@@ -693,14 +683,14 @@ impl Drop for SelectorInner {
                     events_num = iocp_events.iter().len();
                     for iocp_event in iocp_events.iter() {
                         if iocp_event.overlapped().is_null() {
-                            // Waker
+                            // Custom event
                         } else if iocp_event.token() % 2 == 1 {
                             // Named pipe, dispatch the event so it can release resources
                             let callback = unsafe {
                                 (*(iocp_event.overlapped() as *mut super::Overlapped)).callback
                             };
                 
-                            callback(iocp_event.entry());
+                            callback(iocp_event.entry(), None);
                         } else {
                             // drain sock state to release memory of Arc reference
                             let _sock_state = from_overlapped(iocp_event.overlapped());

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -453,7 +453,6 @@ impl SelectorInner {
         unsafe { self.update_sockets_events() }?;
 
         let result = self.cp.get_many(statuses, timeout);
-        println!(" + post get_many");
 
         self.is_polling.store(false, Ordering::Relaxed);
 
@@ -489,7 +488,6 @@ impl SelectorInner {
         let mut n = 0;
         let mut update_queue = self.update_queue.lock().unwrap();
         for iocp_event in iocp_events.iter() {
-            println!(" IOCP TOKEN {}", iocp_event.token());
             if iocp_event.overlapped().is_null() {
                 // `Waker` event, we'll add a readable event to match the other platforms.
                 events.push(Event {
@@ -506,7 +504,6 @@ impl SelectorInner {
                 continue;
             }
 
-            println!(" + TRYING TO GET FROM EVENT");
             let sock_state = from_overlapped(iocp_event.overlapped());
             let mut sock_guard = sock_state.lock().unwrap();
             match sock_guard.feed_event() {

--- a/src/sys/windows/waker.rs
+++ b/src/sys/windows/waker.rs
@@ -1,8 +1,8 @@
-use crate::sys::windows::selector::WAKER_OVERLAPPED;
+use crate::sys::windows::Event;
 use crate::sys::windows::Selector;
 use crate::Token;
 
-use miow::iocp::{CompletionPort, CompletionStatus};
+use miow::iocp::CompletionPort;
 use std::io;
 use std::sync::Arc;
 
@@ -21,8 +21,9 @@ impl Waker {
     }
 
     pub fn wake(&self) -> io::Result<()> {
-        // Keep NULL as Overlapped value to notify waking.
-        let status = CompletionStatus::new(0, self.token.0, WAKER_OVERLAPPED);
-        self.port.post(status)
+        let mut ev = Event::new(self.token);
+        ev.set_readable();
+
+        self.port.post(ev.to_completion_status())
     }
 }

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -61,6 +61,7 @@ fn issue_776() {
 }
 
 #[test]
+#[ignore]
 fn issue_1205() {
     let (mut poll, mut events) = init_with_poll();
 

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -61,7 +61,6 @@ fn issue_776() {
 }
 
 #[test]
-#[ignore]
 fn issue_1205() {
     let (mut poll, mut events) = init_with_poll();
 

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -6,8 +6,8 @@ use std::os::windows::fs::*;
 use std::os::windows::io::*;
 use std::time::Duration;
 
-use mio::{Events, Poll, Interest, Token};
 use mio::windows::NamedPipe;
+use mio::{Events, Interest, Poll, Token};
 use rand::Rng;
 use winapi::um::winbase::*;
 
@@ -54,7 +54,9 @@ fn writable_after_register() {
         Token(0),
         Interest::WRITABLE | Interest::READABLE,
     ));
-    t!(poll.registry().register(&mut client, Token(1), Interest::WRITABLE));
+    t!(poll
+        .registry()
+        .register(&mut client, Token(1), Interest::WRITABLE));
 
     let mut events = Events::with_capacity(128);
     t!(poll.poll(&mut events, None));
@@ -216,11 +218,9 @@ fn connect_twice() {
         Token(0),
         Interest::READABLE | Interest::WRITABLE,
     ));
-    t!(poll.registry().register(
-        &mut c1,
-        Token(1),
-        Interest::READABLE | Interest::WRITABLE,
-    ));
+    t!(poll
+        .registry()
+        .register(&mut c1, Token(1), Interest::READABLE | Interest::WRITABLE,));
     drop(c1);
 
     let mut events = Events::with_capacity(128);
@@ -248,11 +248,9 @@ fn connect_twice() {
     );
 
     let mut c2 = client(&name);
-    t!(poll.registry().register(
-        &mut c2,
-        Token(2),
-        Interest::READABLE | Interest::WRITABLE,
-    ));
+    t!(poll
+        .registry()
+        .register(&mut c2, Token(2), Interest::READABLE | Interest::WRITABLE,));
 
     loop {
         t!(poll.poll(&mut events, None));

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -60,7 +60,6 @@ fn writable_after_register() {
     let (waker, count) = new_count_waker();
     let mut cx = Context::from_waker(&waker);
 
-
     // Server is writable
     let res = server.write(&mut cx, b"hello");
     assert!(res.is_ready());

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -196,8 +196,7 @@ fn write_then_drop() {
 
     let mut events = Events::with_capacity(128);
 
-    'outer:
-    loop {
+    'outer: loop {
         t!(poll.poll(&mut events, None));
         let events = events.iter().collect::<Vec<_>>();
 
@@ -257,11 +256,10 @@ fn connect_twice() {
         .registry()
         .register(&mut c2, Token(2), Interest::READABLE | Interest::WRITABLE,));
 
-    'outer:
-    loop {
+    'outer: loop {
         t!(poll.poll(&mut events, None));
         let events = events.iter().collect::<Vec<_>>();
-        
+
         for event in &events {
             if event.is_writable() && event.token() == Token(0) {
                 break 'outer;

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -11,6 +11,13 @@ use mio::{Events, Interest, Poll, Token};
 use rand::Rng;
 use winapi::um::winbase::FILE_FLAG_OVERLAPPED;
 
+fn _assert_kinds() {
+    fn _assert_send<T: Send>() {}
+    fn _assert_sync<T: Sync>() {}
+    _assert_send::<NamedPipe>();
+    _assert_sync::<NamedPipe>();
+}
+
 macro_rules! t {
     ($e:expr) => {
         match $e {

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -272,11 +272,10 @@ fn reregister_deregister_before_register() {
     let poll = t!(Poll::new());
 
     assert_eq!(
-        poll.registry().reregister(
-            &mut pipe,
-            Token(0),
-            Interest::READABLE,
-        ).unwrap_err().kind(),
+        poll.registry()
+            .reregister(&mut pipe, Token(0), Interest::READABLE,)
+            .unwrap_err()
+            .kind(),
         io::ErrorKind::NotFound,
     );
 
@@ -292,14 +291,16 @@ fn reregister_deregister_different_poll() {
     let poll2 = t!(Poll::new());
 
     // Register with 1
-    t!(poll1.registry().register(&mut pipe, Token(0), Interest::READABLE));
+    t!(poll1
+        .registry()
+        .register(&mut pipe, Token(0), Interest::READABLE));
 
     assert_eq!(
-        poll2.registry().reregister(
-            &mut pipe,
-            Token(0),
-            Interest::READABLE,
-        ).unwrap_err().kind(),
+        poll2
+            .registry()
+            .reregister(&mut pipe, Token(0), Interest::READABLE,)
+            .unwrap_err()
+            .kind(),
         io::ErrorKind::AlreadyExists,
     );
 

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -1,0 +1,280 @@
+#![cfg(windows)]
+
+use std::fs::OpenOptions;
+use std::io;
+use std::io::prelude::*;
+use std::os::windows::fs::*;
+use std::os::windows::io::*;
+use std::time::Duration;
+
+// use mio::{Events, Poll, PollOpt, Ready, Token};
+use mio::windows::NamedPipe;
+// use rand::Rng;
+use winapi::um::winbase::*;
+
+macro_rules! t {
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => panic!("{} failed with {}", stringify!($e), e),
+        }
+    };
+}
+
+fn server(registry: &mio::Registry) -> (NamedPipe, String) {
+    let num: u64 = 188923014239;
+    let name = format!(r"\\.\pipe\my-pipe-{}", num);
+    let pipe = t!(NamedPipe::new(&name, registry, mio::Token(0)));
+    (pipe, name)
+}
+
+fn client(name: &str, registry: &mio::Registry) -> NamedPipe {
+    let mut opts = OpenOptions::new();
+    opts.read(true)
+        .write(true)
+        .custom_flags(FILE_FLAG_OVERLAPPED);
+    let file = t!(opts.open(name));
+    t!(NamedPipe::from_raw_handle(file.into_raw_handle(), registry, mio::Token(1)))
+}
+
+fn pipe(registry: &mio::Registry) -> (NamedPipe, NamedPipe) {
+    let (pipe, name) = server(registry);
+    (pipe, client(&name, registry))
+}
+
+#[test]
+fn writable_after_register() {
+    let mut poll = t!(mio::Poll::new());
+    let (server, client) = pipe(poll.registry());
+    let mut events = mio::Events::with_capacity(128);
+
+    t!(poll.poll(&mut events, None));
+
+    let events = events.iter().collect::<Vec<_>>();
+
+    /*
+    assert!(events
+        .iter()
+        .any(|e| { e.token() == Token(0) && e.readiness() == Ready::writable() }));
+
+    assert!(events
+        .iter()
+        .any(|e| { e.token() == Token(1) && e.readiness() == Ready::writable() }));
+        */
+}
+
+/*
+#[test]
+fn write_then_read() {
+    drop(env_logger::init());
+
+    let (mut server, mut client) = pipe();
+    let poll = t!(Poll::new());
+    t!(poll.register(
+        &server,
+        Token(0),
+        Ready::readable() | Ready::writable(),
+        PollOpt::edge()
+    ));
+    t!(poll.register(
+        &client,
+        Token(1),
+        Ready::readable() | Ready::writable(),
+        PollOpt::edge()
+    ));
+
+    let mut events = Events::with_capacity(128);
+    t!(poll.poll(&mut events, None));
+
+    assert_eq!(t!(client.write(b"1234")), 4);
+
+    loop {
+        t!(poll.poll(&mut events, None));
+        let events = events.iter().collect::<Vec<_>>();
+        if let Some(event) = events.iter().find(|e| e.token() == Token(0)) {
+            if event.readiness().is_readable() {
+                break;
+            }
+        }
+    }
+
+    let mut buf = [0; 10];
+    assert_eq!(t!(server.read(&mut buf)), 4);
+    assert_eq!(&buf[..4], b"1234");
+}
+
+#[test]
+fn connect_before_client() {
+    drop(env_logger::init());
+
+    let (server, name) = server();
+    let poll = t!(Poll::new());
+    t!(poll.register(
+        &server,
+        Token(0),
+        Ready::readable() | Ready::writable(),
+        PollOpt::edge()
+    ));
+
+    let mut events = Events::with_capacity(128);
+    t!(poll.poll(&mut events, Some(Duration::new(0, 0))));
+    let e = events.iter().collect::<Vec<_>>();
+    assert_eq!(e.len(), 0);
+    assert_eq!(
+        server.connect().err().unwrap().kind(),
+        io::ErrorKind::WouldBlock
+    );
+
+    let client = client(&name);
+    t!(poll.register(
+        &client,
+        Token(1),
+        Ready::readable() | Ready::writable(),
+        PollOpt::edge()
+    ));
+    loop {
+        t!(poll.poll(&mut events, None));
+        let e = events.iter().collect::<Vec<_>>();
+        if let Some(event) = e.iter().find(|e| e.token() == Token(0)) {
+            if event.readiness().is_writable() {
+                break;
+            }
+        }
+    }
+}
+
+#[test]
+fn connect_after_client() {
+    drop(env_logger::init());
+
+    let (server, name) = server();
+    let poll = t!(Poll::new());
+    t!(poll.register(
+        &server,
+        Token(0),
+        Ready::readable() | Ready::writable(),
+        PollOpt::edge()
+    ));
+
+    let mut events = Events::with_capacity(128);
+    t!(poll.poll(&mut events, Some(Duration::new(0, 0))));
+    let e = events.iter().collect::<Vec<_>>();
+    assert_eq!(e.len(), 0);
+
+    let client = client(&name);
+    t!(poll.register(
+        &client,
+        Token(1),
+        Ready::readable() | Ready::writable(),
+        PollOpt::edge()
+    ));
+    t!(server.connect());
+    loop {
+        t!(poll.poll(&mut events, None));
+        let e = events.iter().collect::<Vec<_>>();
+        if let Some(event) = e.iter().find(|e| e.token() == Token(0)) {
+            if event.readiness().is_writable() {
+                break;
+            }
+        }
+    }
+}
+
+#[test]
+fn write_then_drop() {
+    drop(env_logger::init());
+
+    let (mut server, mut client) = pipe();
+    let poll = t!(Poll::new());
+    t!(poll.register(
+        &server,
+        Token(0),
+        Ready::readable() | Ready::writable(),
+        PollOpt::edge()
+    ));
+    t!(poll.register(
+        &client,
+        Token(1),
+        Ready::readable() | Ready::writable(),
+        PollOpt::edge()
+    ));
+    assert_eq!(t!(client.write(b"1234")), 4);
+    drop(client);
+
+    let mut events = Events::with_capacity(128);
+
+    loop {
+        t!(poll.poll(&mut events, None));
+        let events = events.iter().collect::<Vec<_>>();
+        if let Some(event) = events.iter().find(|e| e.token() == Token(0)) {
+            if event.readiness().is_readable() {
+                break;
+            }
+        }
+    }
+
+    let mut buf = [0; 10];
+    assert_eq!(t!(server.read(&mut buf)), 4);
+    assert_eq!(&buf[..4], b"1234");
+}
+
+#[test]
+fn connect_twice() {
+    drop(env_logger::init());
+
+    let (mut server, name) = server();
+    let c1 = client(&name);
+    let poll = t!(Poll::new());
+    t!(poll.register(
+        &server,
+        Token(0),
+        Ready::readable() | Ready::writable(),
+        PollOpt::edge()
+    ));
+    t!(poll.register(
+        &c1,
+        Token(1),
+        Ready::readable() | Ready::writable(),
+        PollOpt::edge()
+    ));
+    drop(c1);
+
+    let mut events = Events::with_capacity(128);
+
+    loop {
+        t!(poll.poll(&mut events, None));
+        let events = events.iter().collect::<Vec<_>>();
+        if let Some(event) = events.iter().find(|e| e.token() == Token(0)) {
+            if event.readiness().is_readable() {
+                break;
+            }
+        }
+    }
+
+    let mut buf = [0; 10];
+    assert_eq!(t!(server.read(&mut buf)), 0);
+    t!(server.disconnect());
+    assert_eq!(
+        server.connect().err().unwrap().kind(),
+        io::ErrorKind::WouldBlock
+    );
+
+    let c2 = client(&name);
+    t!(poll.register(
+        &c2,
+        Token(2),
+        Ready::readable() | Ready::writable(),
+        PollOpt::edge()
+    ));
+
+    loop {
+        t!(poll.poll(&mut events, None));
+        let events = events.iter().collect::<Vec<_>>();
+        if let Some(event) = events.iter().find(|e| e.token() == Token(0)) {
+            if event.readiness().is_writable() {
+                break;
+            }
+        }
+    }
+}
+*/

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -1,13 +1,12 @@
 #![cfg(windows)]
 
 use std::fs::OpenOptions;
-use std::io;
+use std::io::{self, Read, Write};
 use std::os::windows::fs::*;
 use std::os::windows::io::*;
-use std::task::{Context, Poll};
 use std::time::Duration;
 
-// use mio::{Events, Poll, PollOpt, Ready, Token};
+use mio::{Events, Poll, Interest, Token};
 use mio::windows::NamedPipe;
 use rand::Rng;
 use winapi::um::winbase::*;
@@ -23,91 +22,99 @@ macro_rules! t {
     };
 }
 
-fn server(registry: &mio::Registry) -> (NamedPipe, String) {
+fn server() -> (NamedPipe, String) {
     let num: u64 = rand::thread_rng().gen();
     let name = format!(r"\\.\pipe\my-pipe-{}", num);
-    let pipe = t!(NamedPipe::new(&name, registry));
+    let pipe = t!(NamedPipe::new(&name));
     (pipe, name)
 }
 
-fn client(name: &str, registry: &mio::Registry) -> NamedPipe {
+fn client(name: &str) -> NamedPipe {
     let mut opts = OpenOptions::new();
     opts.read(true)
         .write(true)
         .custom_flags(FILE_FLAG_OVERLAPPED);
     let file = t!(opts.open(name));
-    t!(NamedPipe::from_raw_handle(file.into_raw_handle(), registry,))
+    NamedPipe::from_raw_handle(file.into_raw_handle())
 }
 
-fn pipe(registry: &mio::Registry) -> (NamedPipe, NamedPipe) {
-    let (pipe, name) = server(registry);
-    (pipe, client(&name, registry))
+fn pipe() -> (NamedPipe, NamedPipe) {
+    let (pipe, name) = server();
+    (pipe, client(&name))
 }
 
 static data: &[u8] = &[100; 4096];
 
 #[test]
 fn writable_after_register() {
-    let mut poll = t!(mio::Poll::new());
-    let (mut server, mut client) = pipe(poll.registry());
-    let mut events = mio::Events::with_capacity(128);
+    let (mut server, mut client) = pipe();
+    let mut poll = t!(Poll::new());
+    t!(poll.registry().register(
+        &mut server,
+        Token(0),
+        Interest::WRITABLE | Interest::READABLE,
+    ));
+    t!(poll.registry().register(&mut client, Token(1), Interest::WRITABLE));
 
-    let (wk1, cnt1) = new_count_waker();
-    let mut cx1 = Context::from_waker(&wk1);
-    let (wk2, cnt2) = new_count_waker();
-    let mut cx2 = Context::from_waker(&wk2);
+    let mut events = Events::with_capacity(128);
+    t!(poll.poll(&mut events, None));
 
-    let mut dst = [0; 1024];
+    let events = events.iter().collect::<Vec<_>>();
+    assert!(events
+        .iter()
+        .any(|e| { e.token() == Token(0) && e.is_writable() }));
+    assert!(events
+        .iter()
+        .any(|e| { e.token() == Token(1) && e.is_writable() }));
+}
 
-    t!(server.connect());
+#[test]
+fn write_then_read() {
+    let (mut server, mut client) = pipe();
+    let mut poll = t!(Poll::new());
+    t!(poll.registry().register(
+        &mut server,
+        Token(0),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
+    t!(poll.registry().register(
+        &mut client,
+        Token(1),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
 
-    // Server is writable
-    let res = server.write(&mut cx2, b"hello");
-    assert!(res.is_ready());
+    let mut events = Events::with_capacity(128);
+    t!(poll.poll(&mut events, None));
 
-    // Server is **not** readable
-    assert!(server.read(&mut cx2, &mut dst).is_pending());
+    assert_eq!(t!(client.write(b"1234")), 4);
 
-    // Client is writable
-    let res = client.write(&mut cx1, b"hello");
-    assert!(res.is_ready());
-
-    // Saturate the client
     loop {
-        if client.write(&mut cx1, data).is_pending() {
-            break;
+        t!(poll.poll(&mut events, None));
+        let events = events.iter().collect::<Vec<_>>();
+        if let Some(event) = events.iter().find(|e| e.token() == Token(0)) {
+            if event.is_readable() {
+                break;
+            }
         }
     }
 
-    // Wait for readable
-    while cnt2.get() == 0 {
-        t!(poll.poll(&mut events, None));
-    }
-
-    // Read some data
-    let mut n = 0;
-
-    while server.read(&mut cx2, &mut dst).is_ready() {
-        n += 1;
-    }
-
-    assert!(n > 0);
-
-    // Wait for the write side to be notified
-    while cnt1.get() == 0 {
-        t!(poll.poll(&mut events, None));
-    }
+    let mut buf = [0; 10];
+    assert_eq!(t!(server.read(&mut buf)), 4);
+    assert_eq!(&buf[..4], b"1234");
 }
 
 #[test]
 fn connect_before_client() {
-    let mut poll = t!(mio::Poll::new());
+    let (mut server, name) = server();
+    let mut poll = t!(Poll::new());
+    t!(poll.registry().register(
+        &mut server,
+        Token(0),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
 
-    let (server, name) = server(poll.registry());
-
-    let mut events = mio::Events::with_capacity(128);
+    let mut events = Events::with_capacity(128);
     t!(poll.poll(&mut events, Some(Duration::new(0, 0))));
-
     let e = events.iter().collect::<Vec<_>>();
     assert_eq!(e.len(), 0);
     assert_eq!(
@@ -115,97 +122,123 @@ fn connect_before_client() {
         io::ErrorKind::WouldBlock
     );
 
-    let mut client = client(&name, poll.registry());
-    let (wk, cnt) = new_count_waker();
-    let mut cx = Context::from_waker(&wk);
-
-    assert!(client.write(&mut cx, b"hello").is_ready());
+    let mut client = client(&name);
+    t!(poll.registry().register(
+        &mut client,
+        Token(1),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
+    loop {
+        t!(poll.poll(&mut events, None));
+        let e = events.iter().collect::<Vec<_>>();
+        if let Some(event) = e.iter().find(|e| e.token() == Token(0)) {
+            if event.is_writable() {
+                break;
+            }
+        }
+    }
 }
 
 #[test]
 fn connect_after_client() {
-    let mut poll = t!(mio::Poll::new());
+    let (mut server, name) = server();
+    let mut poll = t!(Poll::new());
+    t!(poll.registry().register(
+        &mut server,
+        Token(0),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
 
-    let (server, name) = server(poll.registry());
-
-    let mut events = mio::Events::with_capacity(128);
+    let mut events = Events::with_capacity(128);
     t!(poll.poll(&mut events, Some(Duration::new(0, 0))));
-
     let e = events.iter().collect::<Vec<_>>();
     assert_eq!(e.len(), 0);
 
-    let mut client = client(&name, poll.registry());
-    let (wk, cnt) = new_count_waker();
-    let mut cx = Context::from_waker(&wk);
-
-    assert!(server.connect().is_ok());
-
-    assert!(client.write(&mut cx, b"hello").is_ready());
+    let mut client = client(&name);
+    t!(poll.registry().register(
+        &mut client,
+        Token(1),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
+    t!(server.connect());
+    loop {
+        t!(poll.poll(&mut events, None));
+        let e = events.iter().collect::<Vec<_>>();
+        if let Some(event) = e.iter().find(|e| e.token() == Token(0)) {
+            if event.is_writable() {
+                break;
+            }
+        }
+    }
 }
 
 #[test]
 fn write_then_drop() {
-    let mut poll = t!(mio::Poll::new());
-    let (mut server, mut client) = pipe(poll.registry());
-
-    let (wk1, cnt1) = new_count_waker();
-    let mut cx1 = Context::from_waker(&wk1);
-    let (wk2, cnt2) = new_count_waker();
-    let mut cx2 = Context::from_waker(&wk2);
-
-    t!(server.connect());
-
-    let mut dst = [0; 1024];
-
-    assert!(server.read(&mut cx2, &mut dst).is_pending());
-
-    match client.write(&mut cx1, b"1234") {
-        Poll::Ready(res) => assert_eq!(t!(res), 4),
-        _ => panic!(),
-    }
-
+    let (mut server, mut client) = pipe();
+    let mut poll = t!(Poll::new());
+    t!(poll.registry().register(
+        &mut server,
+        Token(0),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
+    t!(poll.registry().register(
+        &mut client,
+        Token(1),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
+    assert_eq!(t!(client.write(b"1234")), 4);
     drop(client);
 
-    let mut events = mio::Events::with_capacity(128);
+    let mut events = Events::with_capacity(128);
 
-    // Wait for readable
-    while cnt2.get() == 0 {
+    loop {
         t!(poll.poll(&mut events, None));
+        let events = events.iter().collect::<Vec<_>>();
+        if let Some(event) = events.iter().find(|e| e.token() == Token(0)) {
+            if event.is_readable() {
+                break;
+            }
+        }
     }
 
-    match server.read(&mut cx2, &mut dst) {
-        Poll::Ready(res) => assert_eq!(t!(res), 4),
-        _ => panic!(),
-    }
-
-    assert_eq!(&dst[..4], b"1234");
+    let mut buf = [0; 10];
+    assert_eq!(t!(server.read(&mut buf)), 4);
+    assert_eq!(&buf[..4], b"1234");
 }
 
 #[test]
 fn connect_twice() {
-    let mut poll = t!(mio::Poll::new());
-
-    let (mut server, name) = server(poll.registry());
-    let mut c1 = client(&name, poll.registry());
-
-    let (wk1, cnt1) = new_count_waker();
-    let mut cx1 = Context::from_waker(&wk1);
-
-    let mut dst = [0; 1024];
-    assert!(server.read(&mut cx1, &mut dst).is_pending());
-
-    t!(server.connect());
-
+    let (mut server, name) = server();
+    let mut c1 = client(&name);
+    let mut poll = t!(Poll::new());
+    t!(poll.registry().register(
+        &mut server,
+        Token(0),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
+    t!(poll.registry().register(
+        &mut c1,
+        Token(1),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
     drop(c1);
-    let mut events = mio::Events::with_capacity(128);
 
-    while cnt1.get() == 0 {
+    let mut events = Events::with_capacity(128);
+
+    loop {
         t!(poll.poll(&mut events, None));
-    }
+        let events = events.iter().collect::<Vec<_>>();
+        if let Some(event) = events.iter().find(|e| e.token() == Token(0)) {
+            if event.is_readable() {
+                let mut buf = [0; 10];
 
-    match server.read(&mut cx1, &mut dst) {
-        Poll::Ready(Ok(0)) => {}
-        res => panic!("{:?}", res),
+                match server.read(&mut buf) {
+                    Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                    Ok(0) => break,
+                    res => panic!("{:?}", res),
+                }
+            }
+        }
     }
 
     t!(server.disconnect());
@@ -214,11 +247,20 @@ fn connect_twice() {
         io::ErrorKind::WouldBlock
     );
 
-    assert_eq!(
-        server.connect().err().unwrap().kind(),
-        io::ErrorKind::WouldBlock
-    );
+    let mut c2 = client(&name);
+    t!(poll.registry().register(
+        &mut c2,
+        Token(2),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
 
-    assert!(server.write(&mut cx1, b"hello").is_ready());
-    assert!(server.write(&mut cx1, b"hello").is_pending());
+    loop {
+        t!(poll.poll(&mut events, None));
+        let events = events.iter().collect::<Vec<_>>();
+        if let Some(event) = events.iter().find(|e| e.token() == Token(0)) {
+            if event.is_writable() {
+                break;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Tokio needs windows named pipe support in order to upgrade to Mio 0.7.  I thought I would take a quick initial stab at this.

It is based on https://github.com/bbqsrc/mio-named-pipes, but simplified some. Instead of shoehorning this into the `Source` trait, I dod registration in `new`. Also, since the `Registration` internal queue is gone in Mio 0.6, I built the API on top of `std::task::Waker` instead. As this is essentially adding an IOCP based API on top of Mio in order to power Tokio, it seemed silly to add a shim to make the API "seem" like epoll and then layer wakers back on.