### PR TITLE
Drop net2 dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ ntapi  = "0.3"
 
 [dev-dependencies]
 env_logger = { version = "0.6.2", default-features = false }
-net2       = "0.2.33"
 rand = "0.4"
 
 [package.metadata.docs.rs]

--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -4,6 +4,7 @@ use crate::sys;
 use std::io;
 use std::mem;
 use std::net::SocketAddr;
+use std::time::Duration;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd, FromRawFd};
 #[cfg(windows)]
@@ -79,6 +80,11 @@ impl TcpSocket {
     /// Sets the value of `SO_REUSEADDR` on this socket.
     pub fn set_reuseaddr(&self, reuseaddr: bool) -> io::Result<()> {
         sys::tcp::set_reuseaddr(self.sys, reuseaddr)
+    }
+
+    /// Sets the value of `SO_LINGER` on this socket.
+    pub fn set_linger(&self, dur: Option<Duration>) -> io::Result<()> {
+        sys::tcp::set_linger(self.sys, dur)
     }
 }
 

--- a/src/sys/shell/tcp.rs
+++ b/src/sys/shell/tcp.rs
@@ -1,5 +1,6 @@
 use std::io;
 use std::net::{self, SocketAddr};
+use std::time::Duration;
 
 pub(crate) type TcpSocket = i32;
 
@@ -28,6 +29,10 @@ pub(crate) fn close(_: TcpSocket) {
 }
 
 pub(crate) fn set_reuseaddr(_: TcpSocket, _: bool) -> io::Result<()> {
+    os_required!();
+}
+
+pub(crate) fn set_linger(_: TcpSocket, _: Option<Duration>) -> io::Result<()> {
     os_required!();
 }
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -55,8 +55,7 @@ pub(crate) fn set_reuseaddr(socket: TcpSocket, reuseaddr: bool) -> io::Result<()
         libc::SO_REUSEADDR,
         &val as *const libc::c_int as *const libc::c_void,
         size_of::<libc::c_int>() as libc::socklen_t,
-    ))?;
-    Ok(())
+    )).map(|_| ())
 }
 
 pub(crate) fn set_linger(socket: TcpSocket, dur: Option<Duration>) -> io::Result<()> {
@@ -70,8 +69,7 @@ pub(crate) fn set_linger(socket: TcpSocket, dur: Option<Duration>) -> io::Result
         libc::SO_LINGER,
         &val as *const libc::linger as *const libc::c_void,
         size_of::<libc::linger>() as libc::socklen_t,
-    ))?;
-    Ok(())
+    )).map(|_| ())
 }
 
 pub fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream, SocketAddr)> {

--- a/src/sys/unix/uds/socketaddr.rs
+++ b/src/sys/unix/uds/socketaddr.rs
@@ -74,6 +74,8 @@ cfg_os_poll! {
         /// Documentation reflected in [`SocketAddr`]
         ///
         /// [`SocketAddr`]: std::os::unix::net::SocketAddr
+        // FIXME: The matches macro requires rust 1.42.0 and we still support 1.39.0
+        #[allow(clippy::match_like_matches_macro)]
         pub fn is_unnamed(&self) -> bool {
             if let AddressKind::Unnamed = self.address() {
                 true

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -82,9 +82,8 @@ pub(crate) fn set_reuseaddr(socket: TcpSocket, reuseaddr: bool) -> io::Result<()
         &val as *const _ as *const c_char,
         size_of::<BOOL>() as c_int,
     ) } {
-        0 => Ok(()),
         SOCKET_ERROR => Err(io::Error::last_os_error()),
-        _ => panic!("unexpected return value"),
+        _ => Ok(()),
     }
 }
 
@@ -101,9 +100,8 @@ pub(crate) fn set_linger(socket: TcpSocket, dur: Option<Duration>) -> io::Result
         &val as *const _ as *const c_char,
         size_of::<linger>() as c_int,
     ) } {
-        0 => Ok(()),
         SOCKET_ERROR => Err(io::Error::last_os_error()),
-        _ => panic!("unexpected return value"),
+        _ => Ok(()),
     }
 }
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -1,8 +1,6 @@
 #![cfg(all(feature = "os-poll", feature = "tcp"))]
 
-#[cfg(unix)]
-use mio::net::TcpSocket;
-use mio::net::{TcpListener, TcpStream};
+use mio::net::{TcpListener, TcpSocket, TcpStream};
 use mio::{Events, Interest, Poll, Token};
 use std::io::{self, Read, Write};
 use std::net::{self, Shutdown};
@@ -457,7 +455,6 @@ fn multiple_writes_immediate_success() {
     handle.join().unwrap();
 }
 
-#[cfg(unix)]
 #[test]
 fn connection_reset_by_peer() {
     init();


### PR DESCRIPTION
Now that we have out own TcpSocket builder inside of mio, just add a set_linger method to it and switch away from net2.

This doesn't bring socket2 in and hopefully will stop all the recurring "please switch from net2 to socket2" reports