### PR TITLE
Add SO_REUSEPORT support for TCP socket

### DIFF
--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -84,12 +84,16 @@ impl TcpSocket {
 
     /// Sets the value of `SO_REUSEPORT` on this socket.
     /// Only supported available in unix
-    #[cfg(all(
-        unix,
-        not(target_os = "solaris")
-    ))]
+    #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
     pub fn set_reuseport(&self, reuseport: bool) -> io::Result<()> {
         sys::tcp::set_reuseport(self.sys, reuseport)
+    }
+
+    /// Get the value of `SO_REUSEPORT` on set for this socket.
+    /// Only supported available in unix
+    #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
+    pub fn get_reuseport(&self) -> io::Result<bool> {
+        sys::tcp::get_reuseport(self.sys)
     }
 
     /// Sets the value of `SO_LINGER` on this socket.

--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -82,6 +82,11 @@ impl TcpSocket {
         sys::tcp::set_reuseaddr(self.sys, reuseaddr)
     }
 
+    /// something
+    pub fn get_reuseaddr(&self) -> io::Result<bool> {
+        sys::tcp::get_reuseaddr(self.sys)
+    }
+
     /// Sets the value of `SO_REUSEPORT` on this socket.
     /// Only supported available in unix
     #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]

--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -84,7 +84,10 @@ impl TcpSocket {
 
     /// Sets the value of `SO_REUSEPORT` on this socket.
     /// Only supported available in unix
-    #[cfg(unix)]
+    #[cfg(all(
+        unix,
+        not(target_os = "solaris")
+    ))]
     pub fn set_reuseport(&self, reuseport: bool) -> io::Result<()> {
         sys::tcp::set_reuseport(self.sys, reuseport)
     }

--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -82,6 +82,13 @@ impl TcpSocket {
         sys::tcp::set_reuseaddr(self.sys, reuseaddr)
     }
 
+    /// Sets the value of `SO_REUSEPORT` on this socket.
+    /// Only supported available in unix
+    #[cfg(unix)]
+    pub fn set_reuseport(&self, reuseport: bool) -> io::Result<()> {
+        sys::tcp::set_reuseport(self.sys, reuseport)
+    }
+
     /// Sets the value of `SO_LINGER` on this socket.
     pub fn set_linger(&self, dur: Option<Duration>) -> io::Result<()> {
         sys::tcp::set_linger(self.sys, dur)

--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -82,7 +82,7 @@ impl TcpSocket {
         sys::tcp::set_reuseaddr(self.sys, reuseaddr)
     }
 
-    /// something
+    /// Get the value of `SO_REUSEADDR` set on this socket.
     pub fn get_reuseaddr(&self) -> io::Result<bool> {
         sys::tcp::get_reuseaddr(self.sys)
     }
@@ -94,7 +94,7 @@ impl TcpSocket {
         sys::tcp::set_reuseport(self.sys, reuseport)
     }
 
-    /// Get the value of `SO_REUSEPORT` on set for this socket.
+    /// Get the value of `SO_REUSEPORT` set on this socket.
     /// Only supported available in unix
     #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
     pub fn get_reuseport(&self) -> io::Result<bool> {

--- a/src/sys/shell/tcp.rs
+++ b/src/sys/shell/tcp.rs
@@ -32,6 +32,10 @@ pub(crate) fn set_reuseaddr(_: TcpSocket, _: bool) -> io::Result<()> {
     os_required!();
 }
 
+pub(crate) fn get_reuseaddr(_: TcpSocket) -> io::Result<bool> {
+    os_required!();
+}
+
 #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
 pub(crate) fn set_reuseport(_: TcpSocket, _: bool) -> io::Result<()> {
     os_required!();

--- a/src/sys/shell/tcp.rs
+++ b/src/sys/shell/tcp.rs
@@ -32,11 +32,13 @@ pub(crate) fn set_reuseaddr(_: TcpSocket, _: bool) -> io::Result<()> {
     os_required!();
 }
 
-#[cfg(all(
-    unix,
-    not(target_os = "solaris")
-))]
+#[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
 pub(crate) fn set_reuseport(_: TcpSocket, _: bool) -> io::Result<()> {
+    os_required!();
+}
+
+#[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
+pub(crate) fn get_reuseport(_: TcpSocket) -> io::Result<bool> {
     os_required!();
 }
 

--- a/src/sys/shell/tcp.rs
+++ b/src/sys/shell/tcp.rs
@@ -32,7 +32,10 @@ pub(crate) fn set_reuseaddr(_: TcpSocket, _: bool) -> io::Result<()> {
     os_required!();
 }
 
-#[cfg(unix)]
+#[cfg(all(
+    unix,
+    not(target_os = "solaris")
+))]
 pub(crate) fn set_reuseport(_: TcpSocket, _: bool) -> io::Result<()> {
     os_required!();
 }

--- a/src/sys/shell/tcp.rs
+++ b/src/sys/shell/tcp.rs
@@ -32,6 +32,11 @@ pub(crate) fn set_reuseaddr(_: TcpSocket, _: bool) -> io::Result<()> {
     os_required!();
 }
 
+#[cfg(unix)]
+pub(crate) fn set_reuseport(_: TcpSocket, _: bool) -> io::Result<()> {
+    os_required!();
+}
+
 pub(crate) fn set_linger(_: TcpSocket, _: Option<Duration>) -> io::Result<()> {
     os_required!();
 }

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -58,6 +58,7 @@ pub(crate) fn set_reuseaddr(socket: TcpSocket, reuseaddr: bool) -> io::Result<()
     )).map(|_| ())
 }
 
+#[cfg(unix)]
 pub(crate) fn set_reuseport(socket: TcpSocket, reuseport: bool) -> io::Result<()> {
     let val: libc::c_int = if reuseport { 1 } else { 0 };
     syscall!(setsockopt(

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -73,16 +73,14 @@ pub(crate) fn set_reuseport(socket: TcpSocket, reuseport: bool) -> io::Result<()
 
 #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
 pub(crate) fn get_reuseport(socket: TcpSocket) -> io::Result<bool> {
-    unsafe {
-        let mut optval: T = mem::zeroed();
-        let mut optlen = mem::size_of::<T>() as libc::socklen_t;
-    }
+    let mut optval: libc::c_int = unsafe { mem::zeroed() };
+    let mut optlen= mem::size_of::<libc::c_int>() as libc::socklen_t;
 
     syscall!(getsockopt(
         socket,
         libc::SOL_SOCKET,
         libc::SO_REUSEPORT,
-        &optval as *mut _ as *mut _,
+        &mut optval as *mut _ as *mut _,
         &mut optlen,
     )).map(|result| result != 0)
 }

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -56,19 +56,37 @@ pub(crate) fn set_reuseaddr(socket: TcpSocket, reuseaddr: bool) -> io::Result<()
         libc::SO_REUSEADDR,
         &val as *const libc::c_int as *const libc::c_void,
         size_of::<libc::c_int>() as libc::socklen_t,
-    )).map(|_| ())
+    )).map(|_| {
+        ()
+    })
+}
+
+pub(crate) fn get_reuseaddr(socket: TcpSocket) -> io::Result<bool> {
+    let mut optval: libc::c_int = unsafe { mem::zeroed() };
+    let mut optlen= mem::size_of::<libc::c_int>() as libc::socklen_t;
+
+    syscall!(getsockopt(
+        socket,
+        libc::SOL_SOCKET,
+        libc::SO_REUSEADDR,
+        &mut optval as *mut _ as *mut _,
+        &mut optlen,
+    )).map(|result| result != 0)
 }
 
 #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
 pub(crate) fn set_reuseport(socket: TcpSocket, reuseport: bool) -> io::Result<()> {
     let val: libc::c_int = if reuseport { 1 } else { 0 };
+
     syscall!(setsockopt(
         socket,
         libc::SOL_SOCKET,
         libc::SO_REUSEPORT,
         &val as *const libc::c_int as *const libc::c_void,
         size_of::<libc::c_int>() as libc::socklen_t,
-    )).map(|_| ())
+    )).map(|_| {
+        ()
+    })
 }
 
 #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -69,7 +69,9 @@ pub(crate) fn get_reuseaddr(socket: TcpSocket) -> io::Result<bool> {
         libc::SO_REUSEADDR,
         &mut optval as *mut _ as *mut _,
         &mut optlen,
-    )).map(|result| result != 0)
+    ))?;
+
+    Ok(optval != 0)
 }
 
 #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
@@ -96,7 +98,9 @@ pub(crate) fn get_reuseport(socket: TcpSocket) -> io::Result<bool> {
         libc::SO_REUSEPORT,
         &mut optval as *mut _ as *mut _,
         &mut optlen,
-    )).map(|result| result != 0)
+    ))?;
+
+    Ok(optval != 0)
 }
 
 pub(crate) fn set_linger(socket: TcpSocket, dur: Option<Duration>) -> io::Result<()> {

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -56,9 +56,7 @@ pub(crate) fn set_reuseaddr(socket: TcpSocket, reuseaddr: bool) -> io::Result<()
         libc::SO_REUSEADDR,
         &val as *const libc::c_int as *const libc::c_void,
         size_of::<libc::c_int>() as libc::socklen_t,
-    )).map(|_| {
-        ()
-    })
+    )).map(|_| ())
 }
 
 pub(crate) fn get_reuseaddr(socket: TcpSocket) -> io::Result<bool> {
@@ -84,9 +82,7 @@ pub(crate) fn set_reuseport(socket: TcpSocket, reuseport: bool) -> io::Result<()
         libc::SO_REUSEPORT,
         &val as *const libc::c_int as *const libc::c_void,
         size_of::<libc::c_int>() as libc::socklen_t,
-    )).map(|_| {
-        ()
-    })
+    )).map(|_| ())
 }
 
 #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -58,7 +58,10 @@ pub(crate) fn set_reuseaddr(socket: TcpSocket, reuseaddr: bool) -> io::Result<()
     )).map(|_| ())
 }
 
-#[cfg(unix)]
+#[cfg(all(
+    unix,
+    not(target_os = "solaris")
+))]
 pub(crate) fn set_reuseport(socket: TcpSocket, reuseport: bool) -> io::Result<()> {
     let val: libc::c_int = if reuseport { 1 } else { 0 };
     syscall!(setsockopt(

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -60,8 +60,8 @@ pub(crate) fn set_reuseaddr(socket: TcpSocket, reuseaddr: bool) -> io::Result<()
 }
 
 pub(crate) fn get_reuseaddr(socket: TcpSocket) -> io::Result<bool> {
-    let mut optval: libc::c_int = unsafe { mem::zeroed() };
-    let mut optlen= mem::size_of::<libc::c_int>() as libc::socklen_t;
+    let mut optval: libc::c_int = 0;
+    let mut optlen = mem::size_of::<libc::c_int>() as libc::socklen_t;
 
     syscall!(getsockopt(
         socket,
@@ -89,8 +89,8 @@ pub(crate) fn set_reuseport(socket: TcpSocket, reuseport: bool) -> io::Result<()
 
 #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
 pub(crate) fn get_reuseport(socket: TcpSocket) -> io::Result<bool> {
-    let mut optval: libc::c_int = unsafe { mem::zeroed() };
-    let mut optlen= mem::size_of::<libc::c_int>() as libc::socklen_t;
+    let mut optval: libc::c_int = 0;
+    let mut optlen = mem::size_of::<libc::c_int>() as libc::socklen_t;
 
     syscall!(getsockopt(
         socket,

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -58,6 +58,17 @@ pub(crate) fn set_reuseaddr(socket: TcpSocket, reuseaddr: bool) -> io::Result<()
     )).map(|_| ())
 }
 
+pub(crate) fn set_reuseport(socket: TcpSocket, reuseport: bool) -> io::Result<()> {
+    let val: libc::c_int = if reuseport { 1 } else { 0 };
+    syscall!(setsockopt(
+        socket,
+        libc::SOL_SOCKET,
+        libc::SO_REUSEPORT,
+        &val as *const libc::c_int as *const libc::c_void,
+        size_of::<libc::c_int>() as libc::socklen_t,
+    )).map(|_| ())
+}
+
 pub(crate) fn set_linger(socket: TcpSocket, dur: Option<Duration>) -> io::Result<()> {
     let val: libc::linger = libc::linger {
         l_onoff: if dur.is_some() { 1 } else { 0 },

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -8,7 +8,7 @@ use std::os::windows::raw::SOCKET as StdSocket; // winapi uses usize, stdlib use
 use winapi::ctypes::{c_char, c_int, c_ushort};
 use winapi::shared::minwindef::{BOOL, TRUE, FALSE};
 use winapi::um::winsock2::{
-    self, closesocket, linger, setsockopt, PF_INET, PF_INET6, SOCKET, SOCKET_ERROR,
+    self, closesocket, linger, setsockopt, getsockopt, PF_INET, PF_INET6, SOCKET, SOCKET_ERROR,
     SOCK_STREAM, SOL_SOCKET, SO_LINGER, SO_REUSEADDR,
 };
 
@@ -84,6 +84,22 @@ pub(crate) fn set_reuseaddr(socket: TcpSocket, reuseaddr: bool) -> io::Result<()
     ) } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => Ok(()),
+    }
+}
+
+pub(crate) fn get_reuseaddr(socket: TcpSocket) -> io::Result<bool> {
+    let mut optval: libc::c_int = unsafe { mem::zeroed() };
+    let mut optlen= mem::size_of::<libc::c_int>() as libc::socklen_t;
+
+    match unsafe { getsockopt(
+        socket,
+        SOL_SOCKET,
+        SO_REUSEADDR,
+        &mut optval as *mut _ as *mut _,
+        &mut optlen,
+    ) } {
+        SOCKET_ERROR => Err(io::Error::last_os_error()),
+        _ => Ok(optval != 0),
     }
 }
 

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -88,8 +88,8 @@ pub(crate) fn set_reuseaddr(socket: TcpSocket, reuseaddr: bool) -> io::Result<()
 }
 
 pub(crate) fn get_reuseaddr(socket: TcpSocket) -> io::Result<bool> {
-    let mut optval: libc::c_int = unsafe { mem::zeroed() };
-    let mut optlen= mem::size_of::<libc::c_int>() as libc::socklen_t;
+    let mut optval: c_char = unsafe { std::mem::zeroed() };
+    let mut optlen = size_of::<BOOL>() as c_int;
 
     match unsafe { getsockopt(
         socket,

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -88,7 +88,7 @@ pub(crate) fn set_reuseaddr(socket: TcpSocket, reuseaddr: bool) -> io::Result<()
 }
 
 pub(crate) fn get_reuseaddr(socket: TcpSocket) -> io::Result<bool> {
-    let mut optval: c_char = unsafe { std::mem::zeroed() };
+    let mut optval: c_char = 0;
     let mut optlen = size_of::<BOOL>() as c_int;
 
     match unsafe { getsockopt(

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -29,7 +29,7 @@ fn set_reuseport() {
 
     let socket = TcpSocket::new_v4().unwrap();
     socket.set_reuseport(true).unwrap();
-    assert!(socket.get_reuseport());
+    assert!(socket.get_reuseport().unwrap());
     socket.bind(addr).unwrap();
 
     let _ = socket.listen(128).unwrap();

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -17,9 +17,9 @@ fn set_reuseaddr() {
 
     let socket = TcpSocket::new_v4().unwrap();
     socket.set_reuseaddr(true).unwrap();
-    socket.bind(addr).unwrap();
-
     assert!(socket.get_reuseaddr().unwrap());
+
+    socket.bind(addr).unwrap();
 
     let _ = socket.listen(128).unwrap();
 }
@@ -31,9 +31,9 @@ fn set_reuseport() {
 
     let socket = TcpSocket::new_v4().unwrap();
     socket.set_reuseport(true).unwrap();
-    socket.bind(addr).unwrap();
-
     assert!(socket.get_reuseport().unwrap());
+
+    socket.bind(addr).unwrap();
 
     let _ = socket.listen(128).unwrap();
 }

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -22,13 +22,14 @@ fn set_reuseaddr() {
     let _ = socket.listen(128).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "solaris")))]
+#[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
 #[test]
 fn set_reuseport() {
     let addr = "127.0.0.1:0".parse().unwrap();
 
     let socket = TcpSocket::new_v4().unwrap();
     socket.set_reuseport(true).unwrap();
+    assert!(socket.get_reuseport());
     socket.bind(addr).unwrap();
 
     let _ = socket.listen(128).unwrap();

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -22,10 +22,7 @@ fn set_reuseaddr() {
     let _ = socket.listen(128).unwrap();
 }
 
-#[cfg(all(
-    unix,
-    not(target_os = "solaris")
-))]
+#[cfg(all(unix, not(target_os = "solaris")))]
 #[test]
 fn set_reuseport() {
     let addr = "127.0.0.1:0".parse().unwrap();

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -21,3 +21,15 @@ fn set_reuseaddr() {
 
     let _ = socket.listen(128).unwrap();
 }
+
+#[cfg(unix)]
+#[test]
+fn set_reuseport() {
+    let addr = "127.0.0.1:0".parse().unwrap();
+
+    let socket = TcpSocket::new_v4().unwrap();
+    socket.set_reuseport(true).unwrap();
+    socket.bind(addr).unwrap();
+
+    let _ = socket.listen(128).unwrap();
+}

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -19,6 +19,8 @@ fn set_reuseaddr() {
     socket.set_reuseaddr(true).unwrap();
     socket.bind(addr).unwrap();
 
+    assert!(socket.get_reuseaddr().unwrap());
+
     let _ = socket.listen(128).unwrap();
 }
 
@@ -29,8 +31,9 @@ fn set_reuseport() {
 
     let socket = TcpSocket::new_v4().unwrap();
     socket.set_reuseport(true).unwrap();
-    assert!(socket.get_reuseport().unwrap());
     socket.bind(addr).unwrap();
+
+    assert!(socket.get_reuseport().unwrap());
 
     let _ = socket.listen(128).unwrap();
 }

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -22,7 +22,10 @@ fn set_reuseaddr() {
     let _ = socket.listen(128).unwrap();
 }
 
-#[cfg(unix)]
+#[cfg(all(
+    unix,
+    not(target_os = "solaris")
+))]
 #[test]
 fn set_reuseport() {
     let addr = "127.0.0.1:0".parse().unwrap();


### PR DESCRIPTION
Tokio's `TcpSocket` doesn't currently support setting SO_REUSEPORT. 

This PR is to add this functionality (talked with @carllerche ).

Only enabling it for unix systems (except Solaris).