### PR TITLE
net: add `TcpSocket::set_{send, recv}_buffer_size`

### DIFF
--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -106,12 +106,12 @@ impl TcpSocket {
         sys::tcp::set_linger(self.sys, dur)
     }
 
-    /// Sets the value of `SO_RECVBUF` on this socket.
+    /// Sets the value of `SO_RCVBUF` on this socket.
     pub fn set_recv_buffer_size(&self, size: u32) -> io::Result<()> {
         sys::tcp::set_recv_buffer_size(self.sys, size)
     }
 
-    /// Get the value of `SO_RECVBUF` set on this socket.
+    /// Get the value of `SO_RCVBUF` set on this socket.
     pub fn get_recv_buffer_size(&self) -> io::Result<u32> {
         sys::tcp::get_recv_buffer_size(self.sys)
     }

--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -106,6 +106,16 @@ impl TcpSocket {
         sys::tcp::set_linger(self.sys, dur)
     }
 
+    /// Sets the value of `SO_RECVBUF` on this socket.
+    pub fn set_recv_buffer_size(&self, size: u32) -> io::Result<()> {
+        sys::tcp::set_recv_buffer_size(self.sys, size)
+    }
+
+    /// Sets the value of `SO_SNDBUF` on this socket.
+    pub fn set_send_buffer_size(&self, size: u32) -> io::Result<()> {
+        sys::tcp::set_send_buffer_size(self.sys, size)
+    }
+
     /// Returns the local address of this socket
     ///
     /// Will return `Err` result in windows if called before calling `bind`

--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -112,6 +112,25 @@ impl TcpSocket {
     }
 
     /// Get the value of `SO_RCVBUF` set on this socket.
+    ///
+    /// Note that if [`set_recv_buffer_size`] has been called on this socket
+    /// previously, the value returned by this function may not be the same as
+    /// the argument provided to `set_recv_buffer_size`. This is for the
+    /// following reasons:
+    ///
+    /// * Most operating systems have minimum and maximum allowed sizes for the
+    ///   receive buffer, and will clamp the provided value if it is below the
+    ///   minimum or above the maximum. The minimum and maximum buffer sizes are
+    ///   OS-dependent.
+    /// * Linux will double the buffer size to account for internal bookkeeping
+    ///   data, and returns the doubled value from `getsockopt(2)`. As per `man
+    ///   7 socket`:
+    ///   > Sets or gets the maximum socket receive buffer in bytes. The
+    ///   > kernel doubles this value (to allow space for bookkeeping
+    ///   > overhead) when it is set using `setsockopt(2)`, and this doubled
+    ///   > value is returned by `getsockopt(2)`.
+    ///
+    /// [`set_recv_buffer_size`]: #method.set_recv_buffer_size
     pub fn get_recv_buffer_size(&self) -> io::Result<u32> {
         sys::tcp::get_recv_buffer_size(self.sys)
     }
@@ -122,6 +141,25 @@ impl TcpSocket {
     }
 
     /// Get the value of `SO_SNDBUF` set on this socket.
+    ///
+    /// Note that if [`set_send_buffer_size`] has been called on this socket
+    /// previously, the value returned by this function may not be the same as
+    /// the argument provided to `set_send_buffer_size`. This is for the
+    /// following reasons:
+    ///
+    /// * Most operating systems have minimum and maximum allowed sizes for the
+    ///   receive buffer, and will clamp the provided value if it is below the
+    ///   minimum or above the maximum. The minimum and maximum buffer sizes are
+    ///   OS-dependent.
+    /// * Linux will double the buffer size to account for internal bookkeeping
+    ///   data, and returns the doubled value from `getsockopt(2)`. As per `man
+    ///   7 socket`:
+    ///   > Sets or gets the maximum socket send buffer in bytes. The
+    ///   > kernel doubles this value (to allow space for bookkeeping
+    ///   > overhead) when it is set using `setsockopt(2)`, and this doubled
+    ///   > value is returned by `getsockopt(2)`.
+    ///
+    /// [`set_send_buffer_size`]: #method.set_send_buffer_size
     pub fn get_send_buffer_size(&self) -> io::Result<u32> {
         sys::tcp::get_send_buffer_size(self.sys)
     }

--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -111,11 +111,21 @@ impl TcpSocket {
         sys::tcp::set_recv_buffer_size(self.sys, size)
     }
 
+    /// Get the value of `SO_RECVBUF` set on this socket.
+    pub fn get_recv_buffer_size(&self) -> io::Result<u32> {
+        sys::tcp::get_recv_buffer_size(self.sys)
+    }
+
     /// Sets the value of `SO_SNDBUF` on this socket.
     pub fn set_send_buffer_size(&self, size: u32) -> io::Result<()> {
         sys::tcp::set_send_buffer_size(self.sys, size)
     }
 
+    /// Get the value of `SO_SNDBUF` set on this socket.
+    pub fn get_send_buffer_size(&self) -> io::Result<u32> {
+        sys::tcp::get_send_buffer_size(self.sys)
+    }
+    
     /// Returns the local address of this socket
     ///
     /// Will return `Err` result in windows if called before calling `bind`

--- a/src/sys/shell/tcp.rs
+++ b/src/sys/shell/tcp.rs
@@ -50,6 +50,14 @@ pub(crate) fn set_linger(_: TcpSocket, _: Option<Duration>) -> io::Result<()> {
     os_required!();
 }
 
+pub(crate) fn set_recv_buffer_size(_: TcpSocket, _: u32) -> io::Result<()> {
+    os_required!();
+}
+
+pub(crate) fn set_send_buffer_size(_: TcpSocket, _: u32) -> io::Result<()> {
+    os_required!();
+}
+
 pub fn accept(_: &net::TcpListener) -> io::Result<(net::TcpStream, SocketAddr)> {
     os_required!();
 }

--- a/src/sys/shell/tcp.rs
+++ b/src/sys/shell/tcp.rs
@@ -54,7 +54,15 @@ pub(crate) fn set_recv_buffer_size(_: TcpSocket, _: u32) -> io::Result<()> {
     os_required!();
 }
 
+pub(crate) fn get_recv_buffer_size(_: TcpSocket) -> io::Result<u32> {
+    os_required!();
+}
+
 pub(crate) fn set_send_buffer_size(_: TcpSocket, _: u32) -> io::Result<()> {
+    os_required!();
+}
+
+pub(crate) fn get_send_buffer_size(_: TcpSocket) -> io::Result<u32> {
     os_required!();
 }
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::convert::TryInto;
 use std::mem;
 use std::mem::{size_of, MaybeUninit};
 use std::net::{self, SocketAddr};
@@ -37,8 +38,6 @@ pub(crate) fn connect(socket: TcpSocket, addr: SocketAddr) -> io::Result<net::Tc
 }
 
 pub(crate) fn listen(socket: TcpSocket, backlog: u32) -> io::Result<net::TcpListener> {
-    use std::convert::TryInto;
-
     let backlog = backlog.try_into().unwrap_or(i32::max_value());
     syscall!(listen(socket, backlog))?;
     Ok(unsafe { net::TcpListener::from_raw_fd(socket) })
@@ -128,6 +127,30 @@ pub(crate) fn set_linger(socket: TcpSocket, dur: Option<Duration>) -> io::Result
         &val as *const libc::linger as *const libc::c_void,
         size_of::<libc::linger>() as libc::socklen_t,
     )).map(|_| ())
+}
+
+pub(crate) fn set_recv_buffer_size(socket: TcpSocket, size: u32) -> io::Result<()> {
+    let size = size.try_into().unwrap_or_else(i32::max_value);
+    syscall!(setsockopt(
+        socket,
+        libc::SOL_SOCKET,
+        libc::SO_RECVBUF,
+        &size as *const _ as *const libc::c_void,
+        size_of::<libc::c_int>() as libc::socklen_t
+    ))
+    .map(|_| ())
+}
+
+pub(crate) fn set_send_buffer_size(socket: TcpSocket, size: u32) -> io::Result<()> {
+    let size = size.try_into().unwrap_or_else(i32::max_value);
+    syscall!(setsockopt(
+        socket,
+        libc::SOL_SOCKET,
+        libc::SO_SNDBUF,
+        &size as *const _ as *const libc::c_void,
+        size_of::<libc::c_int>() as libc::socklen_t
+    ))
+    .map(|_| ())
 }
 
 pub fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream, SocketAddr)> {

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -130,11 +130,11 @@ pub(crate) fn set_linger(socket: TcpSocket, dur: Option<Duration>) -> io::Result
 }
 
 pub(crate) fn set_recv_buffer_size(socket: TcpSocket, size: u32) -> io::Result<()> {
-    let size = size.try_into().unwrap_or_else(i32::max_value);
+    let size = size.try_into().ok().unwrap_or_else(i32::max_value);
     syscall!(setsockopt(
         socket,
         libc::SOL_SOCKET,
-        libc::SO_RECVBUF,
+        libc::SO_RCVBUF,
         &size as *const _ as *const libc::c_void,
         size_of::<libc::c_int>() as libc::socklen_t
     ))
@@ -148,16 +148,16 @@ pub(crate) fn get_recv_buffer_size(socket: TcpSocket) -> io::Result<u32> {
     syscall!(getsockopt(
         socket,
         libc::SOL_SOCKET,
-        libc::SO_RECVBUF,
+        libc::SO_RCVBUF,
         &mut optval as *mut _ as *mut _,
         &mut optlen,
     ))?;
 
-    Ok(optval)
+    Ok(optval as u32)
 }
 
 pub(crate) fn set_send_buffer_size(socket: TcpSocket, size: u32) -> io::Result<()> {
-    let size = size.try_into().unwrap_or_else(i32::max_value);
+    let size = size.try_into().ok().unwrap_or_else(i32::max_value);
     syscall!(setsockopt(
         socket,
         libc::SOL_SOCKET,
@@ -180,7 +180,7 @@ pub(crate) fn get_send_buffer_size(socket: TcpSocket) -> io::Result<u32> {
         &mut optlen,
     ))?;
 
-    Ok(optval)
+    Ok(optval as u32)
 }
 
 pub fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream, SocketAddr)> {

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -141,6 +141,21 @@ pub(crate) fn set_recv_buffer_size(socket: TcpSocket, size: u32) -> io::Result<(
     .map(|_| ())
 }
 
+pub(crate) fn get_recv_buffer_size(socket: TcpSocket) -> io::Result<u32> {    
+    let mut optval: libc::c_int = 0;
+    let mut optlen = size_of::<libc::c_int>() as libc::socklen_t;
+
+    syscall!(getsockopt(
+        socket,
+        libc::SOL_SOCKET,
+        libc::SO_RECVBUF,
+        &mut optval as *mut _ as *mut _,
+        &mut optlen,
+    ))?;
+
+    Ok(optval)
+}
+
 pub(crate) fn set_send_buffer_size(socket: TcpSocket, size: u32) -> io::Result<()> {
     let size = size.try_into().unwrap_or_else(i32::max_value);
     syscall!(setsockopt(
@@ -151,6 +166,21 @@ pub(crate) fn set_send_buffer_size(socket: TcpSocket, size: u32) -> io::Result<(
         size_of::<libc::c_int>() as libc::socklen_t
     ))
     .map(|_| ())
+}
+
+pub(crate) fn get_send_buffer_size(socket: TcpSocket) -> io::Result<u32> {    
+    let mut optval: libc::c_int = 0;
+    let mut optlen = size_of::<libc::c_int>() as libc::socklen_t;
+
+    syscall!(getsockopt(
+        socket,
+        libc::SOL_SOCKET,
+        libc::SO_SNDBUF,
+        &mut optval as *mut _ as *mut _,
+        &mut optlen,
+    ))?;
+
+    Ok(optval)
 }
 
 pub fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream, SocketAddr)> {

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -172,7 +172,7 @@ pub(crate) fn get_recv_buffer_size(socket: TcpSocket) -> io::Result<u32> {
         socket,
         SOL_SOCKET,
         SO_RCVBUF,
-        &mut optval as *mut _,
+        &mut optval as *mut _ as *mut _,
         &mut optlen as *mut _,
     ) } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
@@ -201,7 +201,7 @@ pub(crate) fn get_send_buffer_size(socket: TcpSocket) -> io::Result<u32> {
         socket,
         SOL_SOCKET,
         SO_SNDBUF,
-        &mut optval as *mut _,
+        &mut optval as *mut _ as *mut _,
         &mut optlen as *mut _,
     ) } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::mem::size_of;
 use std::net::{self, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::time::Duration;
+use std::convert::TryInto;
 use std::os::windows::io::FromRawSocket;
 use std::os::windows::raw::SOCKET as StdSocket; // winapi uses usize, stdlib uses u32/u64.
 
@@ -171,8 +172,8 @@ pub(crate) fn get_recv_buffer_size(socket: TcpSocket) -> io::Result<u32> {
         socket,
         SOL_SOCKET,
         SO_RCVBUF,
-        &size as *const _ as *const c_char,
-        size_of::<c_int>() as c_int
+        &mut optval as *mut _,
+        &mut optlen as *mut _,
     ) } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => Ok(optval as u32),
@@ -200,8 +201,8 @@ pub(crate) fn get_send_buffer_size(socket: TcpSocket) -> io::Result<u32> {
         socket,
         SOL_SOCKET,
         SO_SNDBUF,
-        &size as *const _ as *const c_char,
-        size_of::<c_int>() as c_int
+        &mut optval as *mut _,
+        &mut optlen as *mut _,
     ) } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => Ok(optval as u32),

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -149,9 +149,25 @@ pub(crate) fn set_linger(socket: TcpSocket, dur: Option<Duration>) -> io::Result
     }
 }
 
+
 pub(crate) fn set_recv_buffer_size(socket: TcpSocket, size: u32) -> io::Result<()> {
     let size = size.try_into().unwrap_or_else(i32::max_value);
     match unsafe { setsockopt(
+        socket,
+        SOL_SOCKET,
+        SO_RECVBUF,
+        &size as *const _ as *const c_char,
+        size_of::<c_int>() as c_int
+    ) } {
+        SOCKET_ERROR => Err(io::Error::last_os_error()),
+        _ => Ok(()),
+    }
+}
+
+pub(crate) fn get_recv_buffer_size(socket: TcpSocket) -> io::Result<u32> {
+    let mut optval: c_int = 0;
+    let mut optlen = size_of::<c_int>() as c_int;
+    match unsafe { getsockopt(
         socket,
         SOL_SOCKET,
         SO_RECVBUF,
@@ -175,6 +191,23 @@ pub(crate) fn set_send_buffer_size(socket: TcpSocket, size: u32) -> io::Result<(
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => Ok(()),
     }
+}
+
+pub(crate) fn get_send_buffer_size(socket: TcpSocket) -> io::Result<u32> {
+    let mut optval: c_int = 0;
+    let mut optlen = size_of::<c_int>() as c_int;
+    match unsafe { getsockopt(
+        socket,
+        SOL_SOCKET,
+        SO_SNDBUF,
+        &size as *const _ as *const c_char,
+        size_of::<c_int>() as c_int
+    ) } {
+        SOCKET_ERROR => Err(io::Error::last_os_error()),
+        _ => Ok(()),
+    }
+}
+
 
 pub(crate) fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream, SocketAddr)> {
     // The non-blocking state of `listener` is inherited. See

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -60,19 +60,24 @@ fn get_localaddr() {
 
 #[test]
 fn send_buffer_size_roundtrips() {
-    test_buffer_sizes(TcpSocket::set_send_buffer_size, TcpSocket::get_send_buffer_size)
+    test_buffer_sizes(
+        TcpSocket::set_send_buffer_size,
+        TcpSocket::get_send_buffer_size,
+    )
 }
-
 
 #[test]
 fn recv_buffer_size_roundtrips() {
-    test_buffer_sizes(TcpSocket::set_recv_buffer_size, TcpSocket::get_recv_buffer_size)
+    test_buffer_sizes(
+        TcpSocket::set_recv_buffer_size,
+        TcpSocket::get_recv_buffer_size,
+    )
 }
 
 // Helper for testing send/recv buffer size.
 fn test_buffer_sizes(
     set: impl Fn(&TcpSocket, u32) -> io::Result<()>,
-    get: impl Fn(&TcpSocket) -> io::Result<u32>
+    get: impl Fn(&TcpSocket) -> io::Result<u32>,
 ) {
     let test = |size: u32| {
         println!("testing buffer size: {}", size);

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -56,3 +56,39 @@ fn get_localaddr() {
 
     let _ = socket.listen(128).unwrap();
 }
+
+#[test]
+fn send_buffer_size_roundtrips() {
+    fn test(size: u32) {
+        println!("testing send buffer size: {}", size);
+        let socket = TcpSocket::new_v4().unwrap();
+        socket.set_send_buffer_size(size).unwrap();
+        // As per `man socket(7)`:
+        // > Sets or gets the maximum socket send buffer in bytes.  The
+        // > kernel doubles this value (to allow space for bookkeeping
+        // > overhead) when it is set using setsockopt(2), and this doubled
+        // > value is returned by getsockopt(2).
+        assert_eq!(size * 2, socket.get_send_buffer_size().unwrap());
+    }
+
+    test(4096);
+    test(65512);
+}
+
+#[test]
+fn recv_buffer_size_roundtrips() {
+    fn test(size: u32) {
+        println!("testing recv buffer size: {}", size);
+        let socket = TcpSocket::new_v4().unwrap();
+        socket.set_recv_buffer_size(size).unwrap();
+        // As per `man socket(7)`:
+        // > Sets or gets the maximum socket receive buffer in bytes.  The
+        // > kernel doubles this value (to allow space for bookkeeping
+        // > overhead) when it is set using setsockopt(2), and this doubled
+        // > value is returned by getsockopt(2).
+        assert_eq!(size * 2, socket.get_recv_buffer_size().unwrap());
+    }
+
+    test(4096);
+    test(65512);
+}

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -1,6 +1,7 @@
 #![cfg(all(feature = "os-poll", feature = "tcp"))]
 
 use mio::net::TcpSocket;
+use std::io;
 
 #[test]
 fn is_send_and_sync() {
@@ -59,36 +60,39 @@ fn get_localaddr() {
 
 #[test]
 fn send_buffer_size_roundtrips() {
-    fn test(size: u32) {
-        println!("testing send buffer size: {}", size);
+    test_buffer_sizes(TcpSocket::set_send_buffer_size, TcpSocket::get_send_buffer_size)
+}
+
+
+#[test]
+fn recv_buffer_size_roundtrips() {
+    test_buffer_sizes(TcpSocket::set_recv_buffer_size, TcpSocket::get_recv_buffer_size)
+}
+
+// Helper for testing send/recv buffer size.
+fn test_buffer_sizes(
+    set: impl Fn(&TcpSocket, u32) -> io::Result<()>,
+    get: impl Fn(&TcpSocket) -> io::Result<u32>
+) {
+    let test = |size: u32| {
+        println!("testing buffer size: {}", size);
         let socket = TcpSocket::new_v4().unwrap();
-        socket.set_send_buffer_size(size).unwrap();
-        // As per `man socket(7)`:
+        set(&socket, size).unwrap();
+        // Note that this doesn't assert that the values are equal: on Linux,
+        // the kernel doubles the requested buffer size, and returns the doubled
+        // value from `getsockopt`. As per `man socket(7)`:
         // > Sets or gets the maximum socket send buffer in bytes.  The
         // > kernel doubles this value (to allow space for bookkeeping
         // > overhead) when it is set using setsockopt(2), and this doubled
         // > value is returned by getsockopt(2).
-        assert_eq!(size * 2, socket.get_send_buffer_size().unwrap());
-    }
+        //
+        // Additionally, the buffer size may be clamped above a minimum value,
+        // and this minimum value is OS-dependent.
+        let actual = get(&socket).unwrap();
+        assert!(actual >= size, "\tactual: {}\n\texpected: {}", actual, size);
+    };
 
-    test(4096);
-    test(65512);
-}
-
-#[test]
-fn recv_buffer_size_roundtrips() {
-    fn test(size: u32) {
-        println!("testing recv buffer size: {}", size);
-        let socket = TcpSocket::new_v4().unwrap();
-        socket.set_recv_buffer_size(size).unwrap();
-        // As per `man socket(7)`:
-        // > Sets or gets the maximum socket receive buffer in bytes.  The
-        // > kernel doubles this value (to allow space for bookkeeping
-        // > overhead) when it is set using setsockopt(2), and this doubled
-        // > value is returned by getsockopt(2).
-        assert_eq!(size * 2, socket.get_recv_buffer_size().unwrap());
-    }
-
+    test(256);
     test(4096);
     test(65512);
 }


### PR DESCRIPTION
This commit adds methods for setting `SO_RECVBUF` and `SO_SNDBUF` to
Mio's `TcpSocket` type. It would be nice to eventually expose these in
Tokio, so adding them to Mio is the first step. 

See tokio-rs/tokio#3082 for details.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>