### PR TITLE
Support setting SO_LINGER on TcpSocket

### DIFF
--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -106,6 +106,11 @@ impl TcpSocket {
         sys::tcp::set_linger(self.sys, dur)
     }
 
+    /// Gets the value of `SO_LINGER` on this socket
+    pub fn get_linger(&self) -> io::Result<Option<Duration>> {
+        sys::tcp::get_linger(self.sys)
+    }
+
     /// Sets the value of `SO_RCVBUF` on this socket.
     pub fn set_recv_buffer_size(&self, size: u32) -> io::Result<()> {
         sys::tcp::set_recv_buffer_size(self.sys, size)

--- a/src/sys/shell/tcp.rs
+++ b/src/sys/shell/tcp.rs
@@ -50,6 +50,10 @@ pub(crate) fn set_linger(_: TcpSocket, _: Option<Duration>) -> io::Result<()> {
     os_required!();
 }
 
+pub(crate) fn get_linger(_: TcpSocket) -> io::Result<Option<Duration>> {
+    os_required!();
+}
+
 pub(crate) fn set_recv_buffer_size(_: TcpSocket, _: u32) -> io::Result<()> {
     os_required!();
 }

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -128,8 +128,6 @@ pub(crate) fn get_localaddr(socket: TcpSocket) -> io::Result<SocketAddr> {
             }
         },
     }
-
-
 }
 
 pub(crate) fn set_linger(socket: TcpSocket, dur: Option<Duration>) -> io::Result<()> {
@@ -147,6 +145,28 @@ pub(crate) fn set_linger(socket: TcpSocket, dur: Option<Duration>) -> io::Result
     ) } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => Ok(()),
+    }
+}
+
+pub(crate) fn get_linger(socket: TcpSocket) -> io::Result<Option<Duration>> {
+    let mut val: linger = unsafe { std::mem::zeroed() };
+    let mut len = size_of::<linger>() as c_int;
+
+    match unsafe { getsockopt(
+        socket,
+        SOL_SOCKET,
+        SO_LINGER,
+        &mut val as *mut _ as *mut _,
+        &mut len,
+    ) } {
+        SOCKET_ERROR => Err(io::Error::last_os_error()),
+        _ => {
+            if val.l_onoff == 0 {
+                Ok(None)
+            } else {
+                Ok(Some(Duration::from_secs(val.l_linger as u64)))
+            }
+        },
     }
 }
 

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -2,6 +2,7 @@
 
 use mio::net::TcpSocket;
 use std::io;
+use std::time::Duration;
 
 #[test]
 fn is_send_and_sync() {
@@ -54,6 +55,22 @@ fn get_localaddr() {
 
     assert_eq!(expected_addr.ip(), actual_addr.ip());
     assert!(actual_addr.port() > 0);
+
+    let _ = socket.listen(128).unwrap();
+}
+
+#[test]
+fn set_linger() {
+    let addr = "127.0.0.1:0".parse().unwrap();
+
+    let socket = TcpSocket::new_v4().unwrap();
+    socket.set_linger(Some(Duration::from_secs(1))).unwrap();
+    assert_eq!(socket.get_linger().unwrap().unwrap().as_secs(), 1);
+
+    let _ = socket.set_linger(None);
+    assert_eq!(socket.get_linger().unwrap(), None);
+
+    socket.bind(addr).unwrap();
 
     let _ = socket.listen(128).unwrap();
 }


### PR DESCRIPTION
Because tokio `TcpStream` and mio `TcpStream` now use `std::net::TcpStream` as the underlying stream, there isn't a way to set linger options.

I'm aware of #1381 and the dislike of duplicating features. This is the last functionality I need.

The plan is to convert the stream by calling `as_raw_fd()` and set the linger option.  