### PR TITLE
Bump miow to 0.3.6 to get rid of invalid SocketAddr cast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ log = "0.4.8"
 libc = "0.2.69"
 
 [target.'cfg(windows)'.dependencies]
-miow   = "0.3.3"
+miow   = "0.3.6"
 winapi = { version = "0.3", features = ["winsock2", "mswsock"] }
 ntapi  = "0.3"
 


### PR DESCRIPTION
Bump `miow` dependency to 0.3.6 to get rid of the invalid memory layout assumption on `std::net::SocketAddr` (https://github.com/yoshuawuyts/miow/pull/39)

Yes.. I know I publish this PR with a git dependency. I want to see if this passes the CI before I actually publish `miow 0.3.6`.
