### PR TITLE
net: add SO_LINGER option for TcpStream

### DIFF
--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -334,6 +334,20 @@ impl Drop for TcpSocket {
     }
 }
 
+impl From<&TcpStream> for TcpSocket {
+    fn from(stream: &TcpStream) -> TcpSocket {
+        #[cfg(unix)]
+            {
+                unsafe { TcpSocket::from_raw_fd(stream.as_raw_fd()) }
+            }
+
+        #[cfg(windows)]
+            {
+                unsafe { TcpSocket::from_raw_socket(stream.as_raw_socket())}
+            }
+    }
+}
+
 #[cfg(unix)]
 impl IntoRawFd for TcpSocket {
     fn into_raw_fd(self) -> RawFd {

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -806,3 +806,16 @@ fn set_linger_zero(socket: &TcpStream) {
     s.set_linger(Some(Duration::from_millis(0))).unwrap();
     std::mem::drop(s);
 }
+
+#[test]
+fn set_linger() {
+    let listener = net::TcpListener::bind(any_local_address()).unwrap();
+
+    let stream = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+
+    stream.set_linger(Some(Duration::from_secs(1))).unwrap();
+    assert_eq!(stream.linger().unwrap().unwrap().as_secs(), 1);
+
+    stream.set_linger(None).unwrap();
+    assert!(stream.linger().unwrap().is_none());
+}


### PR DESCRIPTION
It was requested in a [tokio PR](https://github.com/tokio-rs/tokio/pull/3143) that Mio TcpStream support setting linger option. This is so that the logic for converting a mio TcpStream into a TcpSocket stays within mio.