### PR TITLE
Bump net2 and miow to get rid of invalid memory layout assumption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ default = ["with-deprecated"]
 [dependencies]
 log      = "0.4"
 slab     = "0.4.0"
-net2     = "0.2.29"
+net2     = "0.2.36"
 iovec    = "0.1.1"
 cfg-if   = "0.1.9"
 
@@ -44,7 +44,7 @@ libc   = "0.2.54"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2.6"
-miow   = "0.2.1"
+miow   = "0.2.2"
 kernel32-sys = "0.2"
 
 [dev-dependencies]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
   parameters:
     name: minrust
     displayName: Min Rust
-    rust_version: 1.18.0
+    rust_version: 1.31.0
     cmd: check
     cross: true
 


### PR DESCRIPTION
Fixes #1390

After getting [`net2 0.2.36`](https://github.com/deprecrated/net2-rs/pull/106) and [`miow 0.2.2`](https://github.com/yoshuawuyts/miow/pull/40) fixed and published we can bump `mio` so it forces the usage of dependencies not making invalid memory layout assumptions on `std::net::SocketAddr`.