### PR TITLE
Fix a typo in example code

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -528,7 +528,7 @@ impl Registry {
     /// // the token is the same it must be specified.
     /// poll.registry().reregister(
     ///     &mut socket,
-    ///     Token(2),
+    ///     Token(0),
     ///     Interest::WRITABLE)?;
     /// #     Ok(())
     /// # }


### PR DESCRIPTION
Since the comment above the `reregister` call says "Even though the token is the same", I'm guessing the author intended to pass the same Token as the call to `register` above.