### PR TITLE
Report EPOLLERR as is_read_closed

### DIFF
--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -79,6 +79,7 @@ impl Event {
     /// | [OS selector] | Flag(s) checked |
     /// |---------------|-----------------|
     /// | [epoll]       | `EPOLLHUP`, or  |
+    /// |               | only `EPOLLERR`, or |
     /// |               | `EPOLLIN` and `EPOLLRDHUP` |
     /// | [kqueue]      | `EV_EOF`        |
     ///

--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -175,6 +175,8 @@ pub mod event {
             // Socket has received FIN or called shutdown(SHUT_RD)
             || (event.events as libc::c_int & libc::EPOLLIN != 0
                 && event.events as libc::c_int & libc::EPOLLRDHUP != 0)
+            // The peer end lost and the local end did not receive FIN.
+            || event.events as libc::c_int == libc::EPOLLERR
     }
 
     pub fn is_write_closed(event: &Event) -> bool {


### PR DESCRIPTION
The description of EPOLLOUT in the epoll_ctl(2) manual only covers
part of it. In fact, if the peer is interrupted abnormally
(such as disconnection, shutdown), the local read and write will
receive this event.