### PR TITLE
Update minimum Rustc version (MSVR) to 1.46.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
       name: nightly
       displayName: Nightly
       # Pin nightly to avoid being impacted by breakage
-      rust_version: nightly-2019-11-14
+      rust_version: nightly-2020-12-31
       benches: true
 
   # This represents the minimum Rust version supported by
@@ -39,7 +39,7 @@ jobs:
     parameters:
       name: minrust
       displayName: Min Rust
-      rust_version: 1.39.0
+      rust_version: 1.46.0
       cmd: check
       cross: true
 

--- a/src/event/source.rs
+++ b/src/event/source.rs
@@ -38,8 +38,8 @@ use std::io;
 ///
 /// Implementing `Source` on a struct containing a socket:
 ///
-#[cfg_attr(all(feature = "os-poll", features = "net"), doc = "```")]
-#[cfg_attr(not(all(feature = "os-poll", features = "net")), doc = "```ignore")]
+#[cfg_attr(all(feature = "os-poll", feature = "net"), doc = "```")]
+#[cfg_attr(not(all(feature = "os-poll", feature = "net")), doc = "```ignore")]
 /// use mio::{Interest, Registry, Token};
 /// use mio::event::Source;
 /// use mio::net::TcpStream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,8 +174,8 @@ pub mod guide {
     //!
     //! [event source]: ../event/trait.Source.html
     //!
-    #![cfg_attr(all(feature = "os-poll", features = "net"), doc = "```")]
-    #![cfg_attr(not(all(feature = "os-poll", features = "net")), doc = "```ignore")]
+    #![cfg_attr(all(feature = "os-poll", feature = "net"), doc = "```")]
+    #![cfg_attr(not(all(feature = "os-poll", feature = "net")), doc = "```ignore")]
     //! # use mio::net::TcpListener;
     //! # use mio::{Poll, Token, Interest};
     //! # fn main() -> std::io::Result<()> {
@@ -213,8 +213,8 @@ pub mod guide {
     //! [poll]: ../struct.Poll.html#method.poll
     //! [event sources]: ../event/trait.Source.html
     //!
-    #![cfg_attr(all(feature = "os-poll", features = "net"), doc = "```")]
-    #![cfg_attr(not(all(feature = "os-poll", features = "net")), doc = "```ignore")]
+    #![cfg_attr(all(feature = "os-poll", feature = "net"), doc = "```")]
+    #![cfg_attr(not(all(feature = "os-poll", feature = "net")), doc = "```ignore")]
     //! # use std::io;
     //! # use std::time::Duration;
     //! # use mio::net::TcpListener;

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -30,8 +30,8 @@ use std::{fmt, io};
 ///
 /// A basic example -- establishing a `TcpStream` connection.
 ///
-#[cfg_attr(all(feature = "os-poll", features = "net"), doc = "```")]
-#[cfg_attr(not(all(feature = "os-poll", features = "net")), doc = "```ignore")]
+#[cfg_attr(all(feature = "os-poll", feature = "net"), doc = "```")]
+#[cfg_attr(not(all(feature = "os-poll", feature = "net")), doc = "```ignore")]
 /// # use std::error::Error;
 /// # fn main() -> Result<(), Box<dyn Error>> {
 /// use mio::{Events, Poll, Interest, Token};
@@ -127,8 +127,8 @@ use std::{fmt, io};
 ///
 /// For example:
 ///
-#[cfg_attr(all(feature = "os-poll", features = "net"), doc = "```")]
-#[cfg_attr(not(all(feature = "os-poll", features = "net")), doc = "```ignore")]
+#[cfg_attr(all(feature = "os-poll", feature = "net"), doc = "```")]
+#[cfg_attr(not(all(feature = "os-poll", feature = "net")), doc = "```ignore")]
 /// # use std::error::Error;
 /// # use std::net;
 /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -260,8 +260,8 @@ impl Poll {
     ///
     /// A basic example -- establishing a `TcpStream` connection.
     ///
-    #[cfg_attr(all(feature = "os-poll", features = "net"), doc = "```")]
-    #[cfg_attr(not(all(feature = "os-poll", features = "net")), doc = "```ignore")]
+    #[cfg_attr(all(feature = "os-poll", feature = "net"), doc = "```")]
+    #[cfg_attr(not(all(feature = "os-poll", feature = "net")), doc = "```ignore")]
     /// # use std::error::Error;
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// use mio::{Events, Poll, Interest, Token};
@@ -425,8 +425,8 @@ impl Registry {
     ///
     /// # Examples
     ///
-    #[cfg_attr(all(feature = "os-poll", features = "net"), doc = "```")]
-    #[cfg_attr(not(all(feature = "os-poll", features = "net")), doc = "```ignore")]
+    #[cfg_attr(all(feature = "os-poll", feature = "net"), doc = "```")]
+    #[cfg_attr(not(all(feature = "os-poll", feature = "net")), doc = "```ignore")]
     /// # use std::error::Error;
     /// # use std::net;
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -503,8 +503,8 @@ impl Registry {
     ///
     /// # Examples
     ///
-    #[cfg_attr(all(feature = "os-poll", features = "net"), doc = "```")]
-    #[cfg_attr(not(all(feature = "os-poll", features = "net")), doc = "```ignore")]
+    #[cfg_attr(all(feature = "os-poll", feature = "net"), doc = "```")]
+    #[cfg_attr(not(all(feature = "os-poll", feature = "net")), doc = "```ignore")]
     /// # use std::error::Error;
     /// # use std::net;
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -570,8 +570,8 @@ impl Registry {
     ///
     /// # Examples
     ///
-    #[cfg_attr(all(feature = "os-poll", features = "net"), doc = "```")]
-    #[cfg_attr(not(all(feature = "os-poll", features = "net")), doc = "```ignore")]
+    #[cfg_attr(all(feature = "os-poll", feature = "net"), doc = "```")]
+    #[cfg_attr(not(all(feature = "os-poll", feature = "net")), doc = "```ignore")]
     /// # use std::error::Error;
     /// # use std::net;
     /// # fn main() -> Result<(), Box<dyn Error>> {

--- a/src/sys/unix/sourcefd.rs
+++ b/src/sys/unix/sourcefd.rs
@@ -25,8 +25,8 @@ use std::os::unix::io::RawFd;
 ///
 /// Basic usage.
 ///
-#[cfg_attr(all(feature = "os-poll", features = "net"), doc = "```")]
-#[cfg_attr(not(all(feature = "os-poll", features = "net")), doc = "```ignore")]
+#[cfg_attr(all(feature = "os-poll", feature = "net"), doc = "```")]
+#[cfg_attr(not(all(feature = "os-poll", feature = "net")), doc = "```ignore")]
 /// # use std::error::Error;
 /// # fn main() -> Result<(), Box<dyn Error>> {
 /// use mio::{Interest, Poll, Token};
@@ -51,8 +51,8 @@ use std::os::unix::io::RawFd;
 ///
 /// Implementing [`event::Source`] for a custom type backed by a [`RawFd`].
 ///
-#[cfg_attr(all(feature = "os-poll", features = "os-ext"), doc = "```")]
-#[cfg_attr(not(all(feature = "os-poll", features = "os-ext")), doc = "```ignore")]
+#[cfg_attr(all(feature = "os-poll", feature = "os-ext"), doc = "```")]
+#[cfg_attr(not(all(feature = "os-poll", feature = "os-ext")), doc = "```ignore")]
 /// use mio::{event, Interest, Registry, Token};
 /// use mio::unix::SourceFd;
 ///

--- a/src/token.rs
+++ b/src/token.rs
@@ -17,8 +17,8 @@
 ///
 /// [`slab`]: https://crates.io/crates/slab
 ///
-#[cfg_attr(all(feature = "os-poll", features = "net"), doc = "```")]
-#[cfg_attr(not(all(feature = "os-poll", features = "net")), doc = "```ignore")]
+#[cfg_attr(all(feature = "os-poll", feature = "net"), doc = "```")]
+#[cfg_attr(not(all(feature = "os-poll", feature = "net")), doc = "```ignore")]
 /// # use std::error::Error;
 /// # fn main() -> Result<(), Box<dyn Error>> {
 /// use mio::{Events, Interest, Poll, Token};


### PR DESCRIPTION
Rustc was release on 27th of August 2020: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1460-2020-08-27, the main benefit was additional support for `const` functions and `#[track_caller]` attribute.

This is also required for socket2, which currently requires 1.42.