### PR TITLE
Rollback #1434 to v0.7.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ os-util = ["os-ext"]# Replaced with "os-ext" feature.
 log = "0.4.8"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.69"
+libc = "0.2.82"
 
 [target.'cfg(windows)'.dependencies]
 miow   = "0.3.6"


### PR DESCRIPTION
As mentioned in #1433 downstream crates building on macOS fail to compile due to missing constants in `libc` prior to `0.2.71`. This PR fixes this problem by updating the `libc` dependency to `0.2.82`