### PR TITLE
Add Event::hint

### DIFF
--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -5,6 +5,6 @@ mod event;
 mod events;
 mod source;
 
-pub use self::event::Event;
+pub use self::event::{Event, Hint};
 pub use self::events::{Events, Iter};
 pub use self::source::Source;

--- a/src/sys/shell/selector.rs
+++ b/src/sys/shell/selector.rs
@@ -66,6 +66,8 @@ pub mod event {
     use crate::Token;
     use std::fmt;
 
+    use crate::event::Hint;
+
     pub fn token(_: &Event) -> Token {
         os_required!();
     }
@@ -100,6 +102,10 @@ pub mod event {
 
     pub fn is_lio(_: &Event) -> bool {
         os_required!();
+    }
+
+    pub fn hint(_: &Event) -> Option<Hint> {
+        None
     }
 
     pub fn debug_details(_: &mut fmt::Formatter<'_>, _: &Event) -> fmt::Result {

--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -149,6 +149,7 @@ pub type Events = Vec<Event>;
 pub mod event {
     use std::fmt;
 
+    use crate::event::Hint;
     use crate::sys::Event;
     use crate::Token;
 
@@ -199,6 +200,10 @@ pub mod event {
     pub fn is_lio(_: &Event) -> bool {
         // Not supported.
         false
+    }
+
+    pub fn hint(_: &Event) -> Option<Hint> {
+        None
     }
 
     pub fn debug_details(f: &mut fmt::Formatter<'_>, event: &Event) -> fmt::Result {

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -360,6 +360,7 @@ unsafe impl Sync for Events {}
 pub mod event {
     use std::fmt;
 
+    use crate::event::Hint;
     use crate::sys::Event;
     use crate::Token;
 
@@ -440,6 +441,14 @@ pub mod event {
         #[cfg(not(target_os = "freebsd"))]
         {
             false
+        }
+    }
+
+    pub fn hint(event: &Event) -> Option<Hint> {
+        match event.filter {
+            libc::EVFILT_READ => Some(Hint::Readable(event.data as usize)),
+            libc::EVFILT_WRITE => Some(Hint::Writable(event.data as usize)),
+            _ => None,
         }
     }
 

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use miow::iocp::CompletionStatus;
 
 use super::afd;
+use crate::event::Hint;
 use crate::Token;
 
 #[derive(Clone)]
@@ -87,6 +88,10 @@ pub fn is_aio(_: &Event) -> bool {
 pub fn is_lio(_: &Event) -> bool {
     // Not supported.
     false
+}
+
+pub fn hint(_: &Event) -> Option<Hint> {
+    None
 }
 
 pub fn debug_details(f: &mut fmt::Formatter<'_>, event: &Event) -> fmt::Result {


### PR DESCRIPTION
This exposes some of the additional data provided in kevent structures,
specifically amount of data that can be read or written and the size of
a listening socket's backlog.