### PR TITLE
Add (set_)?{send,recv}_buffer_size methods for UdpSocket

### DIFF
--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -540,6 +540,64 @@ impl UdpSocket {
         sys::udp::only_v6(&self.inner)
     }
 
+    /// Sets the value of `SO_RCVBUF` on this socket.
+    pub fn set_recv_buffer_size(&self, size: u32) -> io::Result<()> {
+        sys::udp::set_recv_buffer_size(&self.inner, size)
+    }
+
+    /// Get the value of `SO_RCVBUF` set on this socket.
+    ///
+    /// Note that if [`set_recv_buffer_size`] has been called on this socket
+    /// previously, the value returned by this function may not be the same as
+    /// the argument provided to `set_recv_buffer_size`. This is for the
+    /// following reasons:
+    ///
+    /// * Most operating systems have minimum and maximum allowed sizes for the
+    ///   receive buffer, and will clamp the provided value if it is below the
+    ///   minimum or above the maximum. The minimum and maximum buffer sizes are
+    ///   OS-dependent.
+    /// * Linux will double the buffer size to account for internal bookkeeping
+    ///   data, and returns the doubled value from `getsockopt(2)`. As per `man
+    ///   7 socket`:
+    ///   > Sets or gets the maximum socket receive buffer in bytes. The
+    ///   > kernel doubles this value (to allow space for bookkeeping
+    ///   > overhead) when it is set using `setsockopt(2)`, and this doubled
+    ///   > value is returned by `getsockopt(2)`.
+    ///
+    /// [`set_recv_buffer_size`]: #method.set_recv_buffer_size
+    pub fn recv_buffer_size(&self) -> io::Result<u32> {
+        sys::udp::recv_buffer_size(&self.inner)
+    }
+
+    /// Sets the value of `SO_SNDBUF` on this socket.
+    pub fn set_send_buffer_size(&self, size: u32) -> io::Result<()> {
+        sys::udp::set_send_buffer_size(&self.inner, size)
+    }
+
+    /// Get the value of `SO_SNDBUF` set on this socket.
+    ///
+    /// Note that if [`set_send_buffer_size`] has been called on this socket
+    /// previously, the value returned by this function may not be the same as
+    /// the argument provided to `set_send_buffer_size`. This is for the
+    /// following reasons:
+    ///
+    /// * Most operating systems have minimum and maximum allowed sizes for the
+    ///   receive buffer, and will clamp the provided value if it is below the
+    ///   minimum or above the maximum. The minimum and maximum buffer sizes are
+    ///   OS-dependent.
+    /// * Linux will double the buffer size to account for internal bookkeeping
+    ///   data, and returns the doubled value from `getsockopt(2)`. As per `man
+    ///   7 socket`:
+    ///   > Sets or gets the maximum socket send buffer in bytes. The
+    ///   > kernel doubles this value (to allow space for bookkeeping
+    ///   > overhead) when it is set using `setsockopt(2)`, and this doubled
+    ///   > value is returned by `getsockopt(2)`.
+    ///
+    /// [`set_send_buffer_size`]: #method.set_send_buffer_size
+    pub fn send_buffer_size(&self) -> io::Result<u32> {
+        sys::udp::send_buffer_size(&self.inner)
+    }
+
     /// Get the value of the `SO_ERROR` option on this socket.
     ///
     /// This will retrieve the stored error in the underlying socket, clearing

--- a/src/sys/shell/udp.rs
+++ b/src/sys/shell/udp.rs
@@ -8,3 +8,19 @@ pub fn bind(_: SocketAddr) -> io::Result<net::UdpSocket> {
 pub(crate) fn only_v6(_: &net::UdpSocket) -> io::Result<bool> {
     os_required!()
 }
+
+pub(crate) fn set_recv_buffer_size(_: &net::UdpSocket, _: u32) -> io::Result<()> {
+    os_required!()
+}
+
+pub(crate) fn recv_buffer_size(_: &net::UdpSocket) -> io::Result<u32> {
+    os_required!()
+}
+
+pub(crate) fn set_send_buffer_size(_: &net::UdpSocket, _: u32) -> io::Result<()> {
+    os_required!()
+}
+
+pub(crate) fn send_buffer_size(_: &net::UdpSocket) -> io::Result<u32> {
+    os_required!()
+}

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,7 +1,8 @@
 use crate::sys::unix::net::{new_ip_socket, socket_addr};
 
+use std::convert::TryInto;
 use std::io;
-use std::mem;
+use std::mem::{self, MaybeUninit};
 use std::net::{self, SocketAddr};
 use std::os::unix::io::{AsRawFd, FromRawFd};
 
@@ -36,4 +37,68 @@ pub(crate) fn only_v6(socket: &net::UdpSocket) -> io::Result<bool> {
     ))?;
 
     Ok(optval != 0)
+}
+
+pub(crate) fn set_recv_buffer_size(socket: &net::UdpSocket, size: u32) -> io::Result<()> {
+    let size = size.try_into().ok().unwrap_or_else(i32::max_value);
+
+    syscall!(setsockopt(
+        socket.as_raw_fd(),
+        libc::SOL_SOCKET,
+        libc::SO_RCVBUF,
+        &size as *const _ as *const _,
+        mem::size_of::<libc::c_int>() as libc::socklen_t
+    ))?;
+
+    Ok(())
+}
+
+pub(crate) fn recv_buffer_size(socket: &net::UdpSocket) -> io::Result<u32> {
+    let mut optval: MaybeUninit<libc::c_int> = MaybeUninit::uninit();
+    let mut optlen = mem::size_of::<libc::c_int>() as libc::socklen_t;
+
+    syscall!(getsockopt(
+        socket.as_raw_fd(),
+        libc::SOL_SOCKET,
+        libc::SO_RCVBUF,
+        &mut optval as *mut _ as *mut _,
+        &mut optlen,
+    ))?;
+
+    debug_assert_eq!(optlen as usize, mem::size_of::<libc::c_int>());
+    // Safety: `getsockopt` initialised `optval` for us.
+    let optval = unsafe { optval.assume_init() };
+    Ok(optval as u32)
+}
+
+pub(crate) fn set_send_buffer_size(socket: &net::UdpSocket, size: u32) -> io::Result<()> {
+    let size = size.try_into().ok().unwrap_or_else(i32::max_value);
+
+    syscall!(setsockopt(
+        socket.as_raw_fd(),
+        libc::SOL_SOCKET,
+        libc::SO_SNDBUF,
+        &size as *const _ as *const _,
+        mem::size_of::<libc::c_int>() as libc::socklen_t
+    ))?;
+
+    Ok(())
+}
+
+pub(crate) fn send_buffer_size(socket: &net::UdpSocket) -> io::Result<u32> {
+    let mut optval: MaybeUninit<libc::c_int> = MaybeUninit::uninit();
+    let mut optlen = mem::size_of::<libc::c_int>() as libc::socklen_t;
+
+    syscall!(getsockopt(
+        socket.as_raw_fd(),
+        libc::SOL_SOCKET,
+        libc::SO_SNDBUF,
+        &mut optval as *mut _ as *mut _,
+        &mut optlen,
+    ))?;
+
+    debug_assert_eq!(optlen as usize, mem::size_of::<libc::c_int>());
+    // Safety: `getsockopt` initialised `optval` for us.
+    let optval = unsafe { optval.assume_init() };
+    Ok(optval as u32)
 }

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -186,7 +186,7 @@ fn test_buffer_sizes(
         // Note that this doesn't assert that the values are equal: on Linux,
         // the kernel doubles the requested buffer size, and returns the doubled
         // value from `getsockopt`. As per `man socket(7)`:
-        // > Sets or gets the maximum socket send buffer in bytes.  The
+        // > Sets or gets the maximum socket send/receive buffer in bytes. The
         // > kernel doubles this value (to allow space for bookkeeping
         // > overhead) when it is set using setsockopt(2), and this doubled
         // > value is returned by getsockopt(2).


### PR DESCRIPTION
Hey there! I saw in this [issue](https://github.com/tokio-rs/mio/issues/1426) that the `SO_*` options will be introduced with `socket2`, but that you are accepting PRs.

This PR largely duplicates the `SO_SNDBUF`/`SO_RCVBUF`-related methods on `TcpSocket` for `UdpSocket`.

I called these `set_{send/receive}_buffer_size`/`{send/receive}_buffer_size` since most of the methods in this project seem to follow this naming scheme. However, for `TcpSocket` they are currently named `set_{send/receive}_buffer_size`/`get_{send/receive}_buffer_size`. Please let me know if the latter `get_` naming scheme is preferred.

