### PR TITLE
Use accept() instead of accept4() on x86 Android

### DIFF
--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -423,7 +423,12 @@ pub fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream, Socket
     // On platforms that support it we can use `accept4(2)` to set `NONBLOCK`
     // and `CLOEXEC` in the call to accept the connection.
     #[cfg(any(
-        target_os = "android",
+        // Android x86's seccomp profile forbids calls to `accept4(2)`
+        // See https://github.com/tokio-rs/mio/issues/1445 for details
+        all(
+            not(target_arch="x86"),
+            target_os = "android"
+        ),
         target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "illumos",
@@ -444,7 +449,15 @@ pub fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream, Socket
     // But not all platforms have the `accept4(2)` call. Luckily BSD (derived)
     // OSes inherit the non-blocking flag from the listener, so we just have to
     // set `CLOEXEC`.
-    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "solaris"))]
+    #[cfg(any(
+        all(
+            target_arch = "x86",
+            target_os = "android"
+        ),
+        target_os = "ios", 
+        target_os = "macos", 
+        target_os = "solaris"
+    ))]
     let stream = {
         syscall!(accept(
             listener.as_raw_fd(),

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -42,7 +42,13 @@ pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, So
         target_os = "ios",
         target_os = "macos",
         target_os = "netbsd",
-        target_os = "solaris"
+        target_os = "solaris",
+        // Android x86's seccomp profile forbids calls to `accept4(2)`
+        // See https://github.com/tokio-rs/mio/issues/1445 for details
+        all(
+            target_arch = "x86",
+            target_os = "android"
+        )
     )))]
     let socket = {
         let flags = libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
@@ -59,7 +65,11 @@ pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, So
         target_os = "ios",
         target_os = "macos",
         target_os = "netbsd",
-        target_os = "solaris"
+        target_os = "solaris",
+        all(
+            target_arch = "x86",
+            target_os = "android"
+        )
     ))]
     let socket = syscall!(accept(
         listener.as_raw_fd(),


### PR DESCRIPTION
See #1445 for details. I can confirm that this change _does_ work on x86 android emulator, where it did not before. 