### PR TITLE
`accept()`d socket needs to be set to `O_NONBLOCK`

### DIFF
--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -465,7 +465,15 @@ pub fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream, Socket
             &mut length
         ))
         .map(|socket| unsafe { net::TcpStream::from_raw_fd(socket) })
-        .and_then(|s| syscall!(fcntl(s.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC)).map(|_| s))
+        .and_then(|s| {
+            syscall!(fcntl(s.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC))?;
+    
+            // See https://github.com/tokio-rs/mio/issues/1450
+            #[cfg(all(target_arch = "x86",target_os = "android"))]
+            syscall!(fcntl(s.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK))?;
+            
+            Ok(s)
+        })
     }?;
 
     // This is safe because `accept` calls above ensures the address

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -80,7 +80,13 @@ pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, So
         // Ensure the socket is closed if either of the `fcntl` calls
         // error below.
         let s = unsafe { net::UnixStream::from_raw_fd(socket) };
-        syscall!(fcntl(socket, libc::F_SETFD, libc::FD_CLOEXEC)).map(|_| s)
+        syscall!(fcntl(socket, libc::F_SETFD, libc::FD_CLOEXEC))?;
+
+        // See https://github.com/tokio-rs/mio/issues/1450
+        #[cfg(all(target_arch = "x86",target_os = "android"))]
+        syscall!(fcntl(socket, libc::F_SETFL, libc::O_NONBLOCK))?;
+        
+        Ok(s)
     });
 
     socket


### PR DESCRIPTION
I also copied the fail-handling logic from `sys/unix/net.rs` to actually close the socket on error, as described by the comment.

Closes #1450