### PR TITLE
Fix rustfmt on CI

### DIFF
--- a/ci/azure-rustfmt.yml
+++ b/ci/azure-rustfmt.yml
@@ -12,5 +12,8 @@ jobs:
           rustup component add rustfmt
         displayName: Install rustfmt
       - script: |
-          cargo fmt --all -- --check
+          # FIXME: for some reason this doesn't actually check all files.
+          # So instead we run `rustfmt` directly on each file.
+          #cargo fmt --all -- --check
+          find src tests examples -type f -iname "*.rs" | xargs rustfmt --check
         displayName: Check formatting

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -8,7 +8,7 @@
 //! [portability guidelines]: ../struct.Poll.html#portability
 
 mod tcp;
-pub use self::tcp::{TcpListener, TcpSocket, TcpStream, TcpKeepalive};
+pub use self::tcp::{TcpKeepalive, TcpListener, TcpSocket, TcpStream};
 
 mod udp;
 pub use self::udp::UdpSocket;

--- a/src/net/tcp/mod.rs
+++ b/src/net/tcp/mod.rs
@@ -2,7 +2,7 @@ mod listener;
 pub use self::listener::TcpListener;
 
 mod socket;
-pub use self::socket::{TcpSocket, TcpKeepalive};
+pub use self::socket::{TcpKeepalive, TcpSocket};
 
 mod stream;
 pub use self::stream::TcpStream;

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -66,10 +66,7 @@ pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, So
         target_os = "macos",
         target_os = "netbsd",
         target_os = "solaris",
-        all(
-            target_arch = "x86",
-            target_os = "android"
-        )
+        all(target_arch = "x86", target_os = "android")
     ))]
     let socket = syscall!(accept(
         listener.as_raw_fd(),
@@ -83,9 +80,9 @@ pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, So
         syscall!(fcntl(socket, libc::F_SETFD, libc::FD_CLOEXEC))?;
 
         // See https://github.com/tokio-rs/mio/issues/1450
-        #[cfg(all(target_arch = "x86",target_os = "android"))]
+        #[cfg(all(target_arch = "x86", target_os = "android"))]
         syscall!(fcntl(socket, libc::F_SETFL, libc::O_NONBLOCK))?;
-        
+
         Ok(s)
     });
 

--- a/src/sys/windows/net.rs
+++ b/src/sys/windows/net.rs
@@ -4,10 +4,10 @@ use std::net::SocketAddr;
 use std::sync::Once;
 
 use winapi::ctypes::c_int;
-use winapi::shared::inaddr::{in_addr_S_un, IN_ADDR};
 use winapi::shared::in6addr::{in6_addr_u, IN6_ADDR};
-use winapi::shared::ws2def::{AF_INET, AF_INET6, ADDRESS_FAMILY, SOCKADDR, SOCKADDR_IN};
-use winapi::shared::ws2ipdef::{SOCKADDR_IN6_LH, SOCKADDR_IN6_LH_u};
+use winapi::shared::inaddr::{in_addr_S_un, IN_ADDR};
+use winapi::shared::ws2def::{ADDRESS_FAMILY, AF_INET, AF_INET6, SOCKADDR, SOCKADDR_IN};
+use winapi::shared::ws2ipdef::{SOCKADDR_IN6_LH_u, SOCKADDR_IN6_LH};
 use winapi::um::winsock2::{ioctlsocket, socket, FIONBIO, INVALID_SOCKET, SOCKET};
 
 /// Initialise the network stack for Windows.
@@ -80,7 +80,7 @@ pub(crate) fn socket_addr(addr: &SocketAddr) -> (SocketAddrCRepr, c_int) {
 
             let sockaddr = SocketAddrCRepr { v4: sockaddr_in };
             (sockaddr, mem::size_of::<SOCKADDR_IN>() as c_int)
-        },
+        }
         SocketAddr::V6(ref addr) => {
             let sin6_addr = unsafe {
                 let mut u = mem::zeroed::<in6_addr_u>();

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -1,25 +1,26 @@
-use std::io;
 use std::convert::TryInto;
+use std::io;
 use std::mem::size_of;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
-use std::time::Duration;
-use std::ptr;
 use std::os::windows::io::FromRawSocket;
-use std::os::windows::raw::SOCKET as StdSocket; // winapi uses usize, stdlib uses u32/u64.
+use std::os::windows::raw::SOCKET as StdSocket;
+use std::ptr;
+use std::time::Duration; // winapi uses usize, stdlib uses u32/u64.
 
-use winapi::ctypes::{c_char, c_int, c_ushort, c_ulong};
-use winapi::shared::ws2def::{SOCKADDR_STORAGE, AF_INET, AF_INET6, SOCKADDR_IN};
-use winapi::shared::ws2ipdef::SOCKADDR_IN6_LH;
+use winapi::ctypes::{c_char, c_int, c_ulong, c_ushort};
 use winapi::shared::mstcpip;
+use winapi::shared::ws2def::{AF_INET, AF_INET6, SOCKADDR_IN, SOCKADDR_STORAGE};
+use winapi::shared::ws2ipdef::SOCKADDR_IN6_LH;
 
-use winapi::shared::minwindef::{BOOL, TRUE, FALSE, DWORD, LPVOID, LPDWORD};
+use winapi::shared::minwindef::{BOOL, DWORD, FALSE, LPDWORD, LPVOID, TRUE};
 use winapi::um::winsock2::{
-    self, closesocket, linger, setsockopt, getsockopt, getsockname, PF_INET, PF_INET6, SOCKET, SOCKET_ERROR,
-    SOCK_STREAM, SOL_SOCKET, SO_LINGER, SO_REUSEADDR, SO_RCVBUF, SO_SNDBUF, SO_KEEPALIVE, WSAIoctl, LPWSAOVERLAPPED,
+    self, closesocket, getsockname, getsockopt, linger, setsockopt, WSAIoctl, LPWSAOVERLAPPED,
+    PF_INET, PF_INET6, SOCKET, SOCKET_ERROR, SOCK_STREAM, SOL_SOCKET, SO_KEEPALIVE, SO_LINGER,
+    SO_RCVBUF, SO_REUSEADDR, SO_SNDBUF,
 };
 
-use crate::sys::windows::net::{init, new_socket, socket_addr};
 use crate::net::TcpKeepalive;
+use crate::sys::windows::net::{init, new_socket, socket_addr};
 
 pub(crate) type TcpSocket = SOCKET;
 
@@ -57,18 +58,14 @@ pub(crate) fn connect(socket: TcpSocket, addr: SocketAddr) -> io::Result<net::Tc
     );
 
     match res {
-        Err(err) if err.kind() != io::ErrorKind::WouldBlock => {
-            Err(err)
-        }
-        _ => {
-            Ok(unsafe { net::TcpStream::from_raw_socket(socket as StdSocket) })
-        }
+        Err(err) if err.kind() != io::ErrorKind::WouldBlock => Err(err),
+        _ => Ok(unsafe { net::TcpStream::from_raw_socket(socket as StdSocket) }),
     }
 }
 
 pub(crate) fn listen(socket: TcpSocket, backlog: u32) -> io::Result<net::TcpListener> {
-    use winsock2::listen;
     use std::convert::TryInto;
+    use winsock2::listen;
 
     let backlog = backlog.try_into().unwrap_or(i32::max_value());
     syscall!(listen(socket, backlog), PartialEq::eq, SOCKET_ERROR)?;
@@ -82,13 +79,15 @@ pub(crate) fn close(socket: TcpSocket) {
 pub(crate) fn set_reuseaddr(socket: TcpSocket, reuseaddr: bool) -> io::Result<()> {
     let val: BOOL = if reuseaddr { TRUE } else { FALSE };
 
-    match unsafe { setsockopt(
-        socket,
-        SOL_SOCKET,
-        SO_REUSEADDR,
-        &val as *const _ as *const c_char,
-        size_of::<BOOL>() as c_int,
-    ) } {
+    match unsafe {
+        setsockopt(
+            socket,
+            SOL_SOCKET,
+            SO_REUSEADDR,
+            &val as *const _ as *const c_char,
+            size_of::<BOOL>() as c_int,
+        )
+    } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => Ok(()),
     }
@@ -98,13 +97,15 @@ pub(crate) fn get_reuseaddr(socket: TcpSocket) -> io::Result<bool> {
     let mut optval: c_char = 0;
     let mut optlen = size_of::<BOOL>() as c_int;
 
-    match unsafe { getsockopt(
-        socket,
-        SOL_SOCKET,
-        SO_REUSEADDR,
-        &mut optval as *mut _ as *mut _,
-        &mut optlen,
-    ) } {
+    match unsafe {
+        getsockopt(
+            socket,
+            SOL_SOCKET,
+            SO_REUSEADDR,
+            &mut optval as *mut _ as *mut _,
+            &mut optlen,
+        )
+    } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => Ok(optval != 0),
     }
@@ -114,31 +115,34 @@ pub(crate) fn get_localaddr(socket: TcpSocket) -> io::Result<SocketAddr> {
     let mut storage: SOCKADDR_STORAGE = unsafe { std::mem::zeroed() };
     let mut length = std::mem::size_of_val(&storage) as c_int;
 
-    match unsafe { getsockname(
-        socket,
-        &mut storage as *mut _ as *mut _,
-        &mut length
-    ) } {
+    match unsafe { getsockname(socket, &mut storage as *mut _ as *mut _, &mut length) } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => {
             if storage.ss_family as c_int == AF_INET {
                 // Safety: if the ss_family field is AF_INET then storage must be a sockaddr_in.
                 let addr: &SOCKADDR_IN = unsafe { &*(&storage as *const _ as *const SOCKADDR_IN) };
                 let ip_bytes = unsafe { addr.sin_addr.S_un.S_un_b() };
-                let ip = Ipv4Addr::from([ip_bytes.s_b1, ip_bytes.s_b2, ip_bytes.s_b3, ip_bytes.s_b4]);
+                let ip =
+                    Ipv4Addr::from([ip_bytes.s_b1, ip_bytes.s_b2, ip_bytes.s_b3, ip_bytes.s_b4]);
                 let port = u16::from_be(addr.sin_port);
                 Ok(SocketAddr::V4(SocketAddrV4::new(ip, port)))
             } else if storage.ss_family as c_int == AF_INET6 {
                 // Safety: if the ss_family field is AF_INET6 then storage must be a sockaddr_in6.
-                let addr: &SOCKADDR_IN6_LH = unsafe { &*(&storage as *const _ as *const SOCKADDR_IN6_LH) };
+                let addr: &SOCKADDR_IN6_LH =
+                    unsafe { &*(&storage as *const _ as *const SOCKADDR_IN6_LH) };
                 let ip = Ipv6Addr::from(*unsafe { addr.sin6_addr.u.Byte() });
                 let port = u16::from_be(addr.sin6_port);
                 let scope_id = unsafe { *addr.u.sin6_scope_id() };
-                Ok(SocketAddr::V6(SocketAddrV6::new(ip, port, addr.sin6_flowinfo, scope_id)))
+                Ok(SocketAddr::V6(SocketAddrV6::new(
+                    ip,
+                    port,
+                    addr.sin6_flowinfo,
+                    scope_id,
+                )))
             } else {
                 Err(std::io::ErrorKind::InvalidInput.into())
             }
-        },
+        }
     }
 }
 
@@ -148,13 +152,15 @@ pub(crate) fn set_linger(socket: TcpSocket, dur: Option<Duration>) -> io::Result
         l_linger: dur.map(|dur| dur.as_secs() as c_ushort).unwrap_or_default(),
     };
 
-    match unsafe { setsockopt(
-        socket,
-        SOL_SOCKET,
-        SO_LINGER,
-        &val as *const _ as *const c_char,
-        size_of::<linger>() as c_int,
-    ) } {
+    match unsafe {
+        setsockopt(
+            socket,
+            SOL_SOCKET,
+            SO_LINGER,
+            &val as *const _ as *const c_char,
+            size_of::<linger>() as c_int,
+        )
+    } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => Ok(()),
     }
@@ -164,13 +170,15 @@ pub(crate) fn get_linger(socket: TcpSocket) -> io::Result<Option<Duration>> {
     let mut val: linger = unsafe { std::mem::zeroed() };
     let mut len = size_of::<linger>() as c_int;
 
-    match unsafe { getsockopt(
-        socket,
-        SOL_SOCKET,
-        SO_LINGER,
-        &mut val as *mut _ as *mut _,
-        &mut len,
-    ) } {
+    match unsafe {
+        getsockopt(
+            socket,
+            SOL_SOCKET,
+            SO_LINGER,
+            &mut val as *mut _ as *mut _,
+            &mut len,
+        )
+    } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => {
             if val.l_onoff == 0 {
@@ -178,20 +186,21 @@ pub(crate) fn get_linger(socket: TcpSocket) -> io::Result<Option<Duration>> {
             } else {
                 Ok(Some(Duration::from_secs(val.l_linger as u64)))
             }
-        },
+        }
     }
 }
 
-
 pub(crate) fn set_recv_buffer_size(socket: TcpSocket, size: u32) -> io::Result<()> {
     let size = size.try_into().ok().unwrap_or_else(i32::max_value);
-    match unsafe { setsockopt(
-        socket,
-        SOL_SOCKET,
-        SO_RCVBUF,
-        &size as *const _ as *const c_char,
-        size_of::<c_int>() as c_int
-    ) } {
+    match unsafe {
+        setsockopt(
+            socket,
+            SOL_SOCKET,
+            SO_RCVBUF,
+            &size as *const _ as *const c_char,
+            size_of::<c_int>() as c_int,
+        )
+    } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => Ok(()),
     }
@@ -200,13 +209,15 @@ pub(crate) fn set_recv_buffer_size(socket: TcpSocket, size: u32) -> io::Result<(
 pub(crate) fn get_recv_buffer_size(socket: TcpSocket) -> io::Result<u32> {
     let mut optval: c_int = 0;
     let mut optlen = size_of::<c_int>() as c_int;
-    match unsafe { getsockopt(
-        socket,
-        SOL_SOCKET,
-        SO_RCVBUF,
-        &mut optval as *mut _ as *mut _,
-        &mut optlen as *mut _,
-    ) } {
+    match unsafe {
+        getsockopt(
+            socket,
+            SOL_SOCKET,
+            SO_RCVBUF,
+            &mut optval as *mut _ as *mut _,
+            &mut optlen as *mut _,
+        )
+    } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => Ok(optval as u32),
     }
@@ -214,13 +225,15 @@ pub(crate) fn get_recv_buffer_size(socket: TcpSocket) -> io::Result<u32> {
 
 pub(crate) fn set_send_buffer_size(socket: TcpSocket, size: u32) -> io::Result<()> {
     let size = size.try_into().ok().unwrap_or_else(i32::max_value);
-    match unsafe { setsockopt(
-        socket,
-        SOL_SOCKET,
-        SO_SNDBUF,
-        &size as *const _ as *const c_char,
-        size_of::<c_int>() as c_int
-    ) } {
+    match unsafe {
+        setsockopt(
+            socket,
+            SOL_SOCKET,
+            SO_SNDBUF,
+            &size as *const _ as *const c_char,
+            size_of::<c_int>() as c_int,
+        )
+    } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => Ok(()),
     }
@@ -229,13 +242,15 @@ pub(crate) fn set_send_buffer_size(socket: TcpSocket, size: u32) -> io::Result<(
 pub(crate) fn get_send_buffer_size(socket: TcpSocket) -> io::Result<u32> {
     let mut optval: c_int = 0;
     let mut optlen = size_of::<c_int>() as c_int;
-    match unsafe { getsockopt(
-        socket,
-        SOL_SOCKET,
-        SO_SNDBUF,
-        &mut optval as *mut _ as *mut _,
-        &mut optlen as *mut _,
-    ) } {
+    match unsafe {
+        getsockopt(
+            socket,
+            SOL_SOCKET,
+            SO_SNDBUF,
+            &mut optval as *mut _ as *mut _,
+            &mut optlen as *mut _,
+        )
+    } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => Ok(optval as u32),
     }
@@ -243,13 +258,15 @@ pub(crate) fn get_send_buffer_size(socket: TcpSocket) -> io::Result<u32> {
 
 pub(crate) fn set_keepalive(socket: TcpSocket, keepalive: bool) -> io::Result<()> {
     let val: BOOL = if keepalive { TRUE } else { FALSE };
-    match unsafe { setsockopt(
-        socket,
-        SOL_SOCKET,
-        SO_KEEPALIVE,
-        &val as *const _ as *const c_char,
-        size_of::<BOOL>() as c_int
-    ) } {
+    match unsafe {
+        setsockopt(
+            socket,
+            SOL_SOCKET,
+            SO_KEEPALIVE,
+            &val as *const _ as *const c_char,
+            size_of::<BOOL>() as c_int,
+        )
+    } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => Ok(()),
     }
@@ -259,13 +276,15 @@ pub(crate) fn get_keepalive(socket: TcpSocket) -> io::Result<bool> {
     let mut optval: c_char = 0;
     let mut optlen = size_of::<BOOL>() as c_int;
 
-    match unsafe { getsockopt(
-        socket,
-        SOL_SOCKET,
-        SO_KEEPALIVE,
-        &mut optval as *mut _ as *mut _,
-        &mut optlen,
-    ) } {
+    match unsafe {
+        getsockopt(
+            socket,
+            SOL_SOCKET,
+            SO_KEEPALIVE,
+            &mut optval as *mut _ as *mut _,
+            &mut optlen,
+        )
+    } {
         SOCKET_ERROR => Err(io::Error::last_os_error()),
         _ => Ok(optval != FALSE as c_char),
     }
@@ -274,7 +293,10 @@ pub(crate) fn get_keepalive(socket: TcpSocket) -> io::Result<bool> {
 pub(crate) fn set_keepalive_params(socket: TcpSocket, keepalive: TcpKeepalive) -> io::Result<()> {
     /// Windows configures keepalive time/interval in a u32 of milliseconds.
     fn dur_to_ulong_ms(dur: Duration) -> c_ulong {
-        dur.as_millis().try_into().ok().unwrap_or_else(u32::max_value)
+        dur.as_millis()
+            .try_into()
+            .ok()
+            .unwrap_or_else(u32::max_value)
     }
 
     // If any of the fields on the `tcp_keepalive` struct were not provided by
@@ -302,19 +324,21 @@ pub(crate) fn set_keepalive_params(socket: TcpSocket, keepalive: TcpKeepalive) -
     };
 
     let mut out = 0;
-    match unsafe { WSAIoctl(
-        socket,
-        mstcpip::SIO_KEEPALIVE_VALS,
-        &mut keepalive as *mut _ as LPVOID,
-        size_of::<mstcpip::tcp_keepalive>() as DWORD,
-        ptr::null_mut() as LPVOID,
-        0 as DWORD,
-        &mut out as *mut _ as LPDWORD,
-        0 as LPWSAOVERLAPPED,
-        None,
-    ) } {
+    match unsafe {
+        WSAIoctl(
+            socket,
+            mstcpip::SIO_KEEPALIVE_VALS,
+            &mut keepalive as *mut _ as LPVOID,
+            size_of::<mstcpip::tcp_keepalive>() as DWORD,
+            ptr::null_mut() as LPVOID,
+            0 as DWORD,
+            &mut out as *mut _ as LPDWORD,
+            0 as LPWSAOVERLAPPED,
+            None,
+        )
+    } {
         0 => Ok(()),
-        _ => Err(io::Error::last_os_error())
+        _ => Err(io::Error::last_os_error()),
     }
 }
 


### PR DESCRIPTION
For some reason running `cargo fmt --all -- --check` doesn't properly check all files, so instead the second commit changes the CI to run `rustfmt` on each file in `src/`, `tests/` and `examples`. The first commit actually runs `rustfmt` directly on all files (using `find src tests examples -type f -iname "*.rs" | xargs rustfmt`).

Closes #1389.