### PR TITLE
docs: correct comments in examples

### DIFF
--- a/examples/tcp_server.rs
+++ b/examples/tcp_server.rs
@@ -1,5 +1,5 @@
 // You can run this example from the root of the mio repo:
-// cargo run --example tcp_server --features="os-poll tcp"
+// cargo run --example tcp_server --features="os-poll net"
 use mio::event::Event;
 use mio::net::{TcpListener, TcpStream};
 use mio::{Events, Interest, Poll, Registry, Token};

--- a/examples/udp_server.rs
+++ b/examples/udp_server.rs
@@ -1,5 +1,5 @@
 // You can run this example from the root of the mio repo:
-// cargo run --example udp_server --features="os-poll udp"
+// cargo run --example udp_server --features="os-poll net"
 use log::warn;
 use mio::net::UdpSocket;
 use mio::{Events, Interest, Poll, Token};


### PR DESCRIPTION
When I run the command commented in examples, an error occurred.

```
❯ cargo run --example tcp_server --features="os-poll tcp"
error: Package `mio v0.8.0 (/home/pvon/Documents/mio)` does not have the feature `tcp`
```

This pull request is to fix them.