### PR TITLE
DragonFlyBSD: refine kqueue-related types and values

### DIFF
--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -19,7 +19,11 @@ type Count = libc::c_int;
 type Count = libc::size_t;
 
 // Type of the `filter` field in the `kevent` structure.
-#[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "openbsd"
+))]
 type Filter = libc::c_short;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 type Filter = i16;
@@ -27,7 +31,11 @@ type Filter = i16;
 type Filter = u32;
 
 // Type of the `flags` field in the `kevent` structure.
-#[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "openbsd"
+))]
 type Flags = libc::c_ushort;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 type Flags = u16;
@@ -651,7 +659,7 @@ pub mod event {
             libc::NOTE_LEEWAY,
             #[cfg(any(target_os = "ios", target_os = "macos"))]
             libc::NOTE_CRITICAL,
-            #[cfg(any(target_os = "dragonfly"))]
+            #[cfg(any(target_os = "ios", target_os = "macos"))]
             libc::NOTE_BACKGROUND,
         );
 

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -19,11 +19,7 @@ type Count = libc::c_int;
 type Count = libc::size_t;
 
 // Type of the `filter` field in the `kevent` structure.
-#[cfg(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "openbsd"
-))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 type Filter = libc::c_short;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 type Filter = i16;
@@ -31,11 +27,7 @@ type Filter = i16;
 type Filter = u32;
 
 // Type of the `flags` field in the `kevent` structure.
-#[cfg(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "openbsd"
-))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 type Flags = libc::c_ushort;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 type Flags = u16;


### PR DESCRIPTION
- Make sure that Filter and Flag types are defined. The sizes
  for these kevent fields are the same as on FreeBSD and OpenBSD

- Don't define the NOTE_BACKGROUND EVFILT_TIMER flag. This flag
  value is exclusive to Apple platforms.