### PR TITLE
Release v0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.7.8
+
+## Fixes
+
+* Fix `TcpStream::set_linger` on macOS
+  (https://github.com/tokio-rs/mio/commit/175773ce02e85977db81224c782c8d140aba8543).
+* Fix compilation on DragonFlyBSD
+  (https://github.com/tokio-rs/mio/commit/b51af46b28871f8dd3233b490ee62237ffed6a26).
+
 # 0.7.7
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ os-util = ["os-ext"]# Replaced with "os-ext" feature.
 log = "0.4.8"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.82"
+libc = "0.2.86"
 
 [target.'cfg(windows)'.dependencies]
 miow   = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "mio"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create git tag
-version       = "0.7.7"
+version       = "0.7.8"
 license       = "MIT"
 authors       = [
   "Carl Lerche <me@carllerche.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/mio/0.7.7")]
+#![doc(html_root_url = "https://docs.rs/mio/0.7.8")]
 #![deny(
     missing_docs,
     missing_debug_implementations,

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -140,6 +140,9 @@ pub(crate) fn set_linger(socket: TcpSocket, dur: Option<Duration>) -> io::Result
     syscall!(setsockopt(
         socket,
         libc::SOL_SOCKET,
+        #[cfg(target_vendor = "apple")]
+        libc::SO_LINGER_SEC,
+        #[cfg(not(target_vendor = "apple"))]
         libc::SO_LINGER,
         &val as *const libc::linger as *const libc::c_void,
         size_of::<libc::linger>() as libc::socklen_t,
@@ -154,6 +157,9 @@ pub(crate) fn get_linger(socket: TcpSocket) -> io::Result<Option<Duration>> {
     syscall!(getsockopt(
         socket,
         libc::SOL_SOCKET,
+        #[cfg(target_vendor = "apple")]
+        libc::SO_LINGER_SEC,
+        #[cfg(not(target_vendor = "apple"))]
         libc::SO_LINGER,
         &mut val as *mut _ as *mut _,
         &mut len,


### PR DESCRIPTION
Includes a backport of  #1455.