### PR TITLE
Fix an instance of not doc(cfg(.*))

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -52,7 +52,7 @@ macro_rules! cfg_io_source {
     ($($item:item)*) => {
         $(
             #[cfg(any(feature = "net", all(unix, feature = "os-ext")))]
-            #[cfg_attr(docsrs, doc(any(feature = "net", all(unix, feature = "os-ext"))))]
+            #[cfg_attr(docsrs, doc(cfg(any(feature = "net", all(unix, feature = "os-ext")))))]
             $item
         )*
     }


### PR DESCRIPTION
This unbreaks the CI in another crates that use
`RUSTDOCFLAGS=--cfg=docsrs` to verify correctness of their own things. I
wonder why docs.rs itself does not fail on this though.