### PR TITLE
accept4 is not defined in libc for android

### DIFF
--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -424,12 +424,6 @@ pub fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream, Socket
     // On platforms that support it we can use `accept4(2)` to set `NONBLOCK`
     // and `CLOEXEC` in the call to accept the connection.
     #[cfg(any(
-        // Android x86's seccomp profile forbids calls to `accept4(2)`
-        // See https://github.com/tokio-rs/mio/issues/1445 for details
-        all(
-            not(target_arch="x86"),
-            target_os = "android"
-        ),
         target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "illumos",
@@ -451,7 +445,7 @@ pub fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream, Socket
     // OSes inherit the non-blocking flag from the listener, so we just have to
     // set `CLOEXEC`.
     #[cfg(any(
-        all(target_arch = "x86", target_os = "android"),
+        target_os = "android",
         target_os = "ios",
         target_os = "macos",
         target_os = "solaris"

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -43,12 +43,7 @@ pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, So
         target_os = "macos",
         target_os = "netbsd",
         target_os = "solaris",
-        // Android x86's seccomp profile forbids calls to `accept4(2)`
-        // See https://github.com/tokio-rs/mio/issues/1445 for details
-        all(
-            target_arch = "x86",
-            target_os = "android"
-        )
+        target_os = "android",
     )))]
     let socket = {
         let flags = libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
@@ -66,7 +61,7 @@ pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, So
         target_os = "macos",
         target_os = "netbsd",
         target_os = "solaris",
-        all(target_arch = "x86", target_os = "android")
+        target_os = "android",
     ))]
     let socket = syscall!(accept(
         listener.as_raw_fd(),


### PR DESCRIPTION
In libc 0.2.87 there's no `accept4` in [unix/linux_like/android/mod.rs](https://github.com/rust-lang/libc/blob/master/src/unix/linux_like/android/mod.rs).
It is defined in [unix/linux_like/linux/mod.rs](https://github.com/rust-lang/libc/blob/master/src/unix/linux_like/linux/mod.rs#L3129), but this module is [not loaded](https://github.com/rust-lang/libc/blob/master/src/unix/linux_like/mod.rs#L1711) on android
