### PR TITLE
test(sys) Doctest imports `unix::SourceFd` which is behind the `os-ext` feature

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
       name: nightly
       displayName: Nightly
       # Pin nightly to avoid being impacted by breakage
-      rust_version: nightly-2020-12-31
+      rust_version: nightly-2020-03-24
       benches: true
 
   # This represents the minimum Rust version supported by

--- a/src/sys/unix/sourcefd.rs
+++ b/src/sys/unix/sourcefd.rs
@@ -25,8 +25,14 @@ use std::os::unix::io::RawFd;
 ///
 /// Basic usage.
 ///
-#[cfg_attr(all(feature = "os-poll", feature = "net"), doc = "```")]
-#[cfg_attr(not(all(feature = "os-poll", feature = "net")), doc = "```ignore")]
+#[cfg_attr(
+    all(feature = "os-poll", feature = "net", feature = "os-ext"),
+    doc = "```"
+)]
+#[cfg_attr(
+    not(all(feature = "os-poll", feature = "net", feature = "os-ext")),
+    doc = "```ignore"
+)]
 /// # use std::error::Error;
 /// # fn main() -> Result<(), Box<dyn Error>> {
 /// use mio::{Interest, Poll, Token};

--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -132,7 +132,7 @@ fn drop_cancels_interest_and_shuts_down() {
             Ok(_) => (),
             Err(err) => {
                 if err.kind() != io::ErrorKind::UnexpectedEof {
-                    panic!(err);
+                    panic!("{}", err);
                 }
             }
         }


### PR DESCRIPTION
This patch fixes this doctest. It imports `mio::unix::SourceFd`, but
the `mio::unix` module exists if and only if the `os-ext` feature is
enabled.

To reproduce:

```sh
$ # without this patch
$ cargo test --features os-poll,net --doc -- sourcefd
<fails>
$ cargo test --features os-poll,os-ext,net --doc -- sourcefd
<fails>
$
$ # with this patch
$ cargo test --features os-poll,net --doc -- sourcefd
<success>
$ cargo test --features os-poll,os-ext,net --doc -- sourcefd
<success>
```