### PR TITLE
feat: Move `std::net` dependencies to `sys::net`.

### DIFF
--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -1,6 +1,5 @@
 use std::io;
 use std::mem;
-use std::net::SocketAddr;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(windows)]
@@ -49,27 +48,27 @@ impl TcpSocket {
     /// Create a new IPv4 TCP socket.
     ///
     /// This calls `socket(2)`.
-    pub fn new_v4() -> io::Result<TcpSocket> {
-        sys::tcp::new_v4_socket().map(|sys| TcpSocket { sys })
+    pub fn new_v4() -> io::Result<Self> {
+        sys::tcp::new_v4_socket().map(|sys| Self { sys })
     }
 
     /// Create a new IPv6 TCP socket.
     ///
     /// This calls `socket(2)`.
-    pub fn new_v6() -> io::Result<TcpSocket> {
-        sys::tcp::new_v6_socket().map(|sys| TcpSocket { sys })
+    pub fn new_v6() -> io::Result<Self> {
+        sys::tcp::new_v6_socket().map(|sys| Self { sys })
     }
 
-    pub(crate) fn new_for_addr(addr: SocketAddr) -> io::Result<TcpSocket> {
+    pub(crate) fn new_for_addr(addr: sys::net::SocketAddr) -> io::Result<Self> {
         if addr.is_ipv4() {
-            TcpSocket::new_v4()
+            Self::new_v4()
         } else {
-            TcpSocket::new_v6()
+            Self::new_v6()
         }
     }
 
     /// Bind `addr` to the TCP socket.
-    pub fn bind(&self, addr: SocketAddr) -> io::Result<()> {
+    pub fn bind(&self, addr: sys::net::SocketAddr) -> io::Result<()> {
         sys::tcp::bind(self.sys, addr)
     }
 
@@ -78,7 +77,7 @@ impl TcpSocket {
     /// This consumes the socket and performs the connect operation. Once the
     /// connection completes, the socket is now a non-blocking `TcpStream` and
     /// can be used as such.
-    pub fn connect(self, addr: SocketAddr) -> io::Result<TcpStream> {
+    pub fn connect(self, addr: sys::net::SocketAddr) -> io::Result<TcpStream> {
         let stream = sys::tcp::connect(self.sys, addr)?;
 
         // Don't close the socket
@@ -324,7 +323,7 @@ impl TcpSocket {
     /// Returns the local address of this socket
     ///
     /// Will return `Err` result in windows if called before calling `bind`
-    pub fn get_localaddr(&self) -> io::Result<SocketAddr> {
+    pub fn get_localaddr(&self) -> io::Result<sys::net::SocketAddr> {
         sys::tcp::get_localaddr(self.sys)
     }
 }
@@ -396,8 +395,8 @@ impl FromRawSocket for TcpSocket {
     ///
     /// The caller is responsible for ensuring that the socket is in
     /// non-blocking mode.
-    unsafe fn from_raw_socket(socket: RawSocket) -> TcpSocket {
-        TcpSocket {
+    unsafe fn from_raw_socket(socket: RawSocket) -> Self {
+        Self {
             sys: socket as sys::tcp::TcpSocket,
         }
     }

--- a/src/net/uds/listener.rs
+++ b/src/net/uds/listener.rs
@@ -3,19 +3,18 @@ use crate::net::{SocketAddr, UnixStream};
 use crate::{event, sys, Interest, Registry, Token};
 
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
-use std::os::unix::net;
 use std::path::Path;
 use std::{fmt, io};
 
 /// A non-blocking Unix domain socket server.
 pub struct UnixListener {
-    inner: IoSource<net::UnixListener>,
+    inner: IoSource<sys::net::UnixListener>,
 }
 
 impl UnixListener {
     /// Creates a new `UnixListener` bound to the specified socket.
-    pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
-        sys::uds::listener::bind(path.as_ref()).map(UnixListener::from_std)
+    pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        sys::uds::listener::bind(path.as_ref()).map(Self::from_std)
     }
 
     /// Creates a new `UnixListener` from a standard `net::UnixListener`.
@@ -24,8 +23,8 @@ impl UnixListener {
     /// standard library in the Mio equivalent. The conversion assumes nothing
     /// about the underlying listener; it is left up to the user to set it in
     /// non-blocking mode.
-    pub fn from_std(listener: net::UnixListener) -> UnixListener {
-        UnixListener {
+    pub fn from_std(listener: sys::net::UnixListener) -> Self {
+        Self {
             inner: IoSource::new(listener),
         }
     }
@@ -39,7 +38,7 @@ impl UnixListener {
     }
 
     /// Returns the local socket address of this listener.
-    pub fn local_addr(&self) -> io::Result<sys::SocketAddr> {
+    pub fn local_addr(&self) -> io::Result<sys::uds::SocketAddr> {
         sys::uds::listener::local_addr(&self.inner)
     }
 
@@ -98,7 +97,7 @@ impl FromRawFd for UnixListener {
     ///
     /// The caller is responsible for ensuring that the socket is in
     /// non-blocking mode.
-    unsafe fn from_raw_fd(fd: RawFd) -> UnixListener {
-        UnixListener::from_std(FromRawFd::from_raw_fd(fd))
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        Self::from_std(FromRawFd::from_raw_fd(fd))
     }
 }

--- a/src/net/uds/mod.rs
+++ b/src/net/uds/mod.rs
@@ -7,4 +7,4 @@ pub use self::listener::UnixListener;
 mod stream;
 pub use self::stream::UnixStream;
 
-pub use crate::sys::SocketAddr;
+pub use crate::sys::uds::SocketAddr;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -75,6 +75,6 @@ cfg_not_os_poll! {
 
     #[cfg(unix)]
     cfg_net! {
-        pub use self::unix::SocketAddr;
+        pub use self::unix::uds::SocketAddr;
     }
 }

--- a/src/sys/shell/mod.rs
+++ b/src/sys/shell/mod.rs
@@ -11,6 +11,7 @@ mod waker;
 pub(crate) use self::waker::Waker;
 
 cfg_net! {
+    pub(crate) mod net;
     pub(crate) mod tcp;
     pub(crate) mod udp;
     #[cfg(unix)]

--- a/src/sys/shell/net.rs
+++ b/src/sys/shell/net.rs
@@ -1,0 +1,3 @@
+pub use std::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr};
+#[cfg(unix)]
+pub use std::os::unix::net::{UnixDatagram, UnixListener, UnixStream};

--- a/src/sys/shell/tcp.rs
+++ b/src/sys/shell/tcp.rs
@@ -1,7 +1,9 @@
 use crate::net::TcpKeepalive;
+use crate::sys::net::SocketAddr;
 use std::io;
-use std::net::{self, SocketAddr};
 use std::time::Duration;
+
+pub use std::net::{TcpListener, TcpStream};
 
 pub(crate) type TcpSocket = i32;
 
@@ -17,11 +19,11 @@ pub(crate) fn bind(_socket: TcpSocket, _addr: SocketAddr) -> io::Result<()> {
     os_required!();
 }
 
-pub(crate) fn connect(_: TcpSocket, _addr: SocketAddr) -> io::Result<net::TcpStream> {
+pub(crate) fn connect(_: TcpSocket, _addr: SocketAddr) -> io::Result<TcpStream> {
     os_required!();
 }
 
-pub(crate) fn listen(_: TcpSocket, _: u32) -> io::Result<net::TcpListener> {
+pub(crate) fn listen(_: TcpSocket, _: u32) -> io::Result<TcpListener> {
     os_required!();
 }
 
@@ -118,7 +120,7 @@ pub(crate) fn get_keepalive_retries(_: TcpSocket) -> io::Result<Option<u32>> {
     os_required!()
 }
 
-pub fn accept(_: &net::TcpListener) -> io::Result<(net::TcpStream, SocketAddr)> {
+pub fn accept(_: &TcpListener) -> io::Result<(TcpStream, SocketAddr)> {
     os_required!();
 }
 

--- a/src/sys/shell/udp.rs
+++ b/src/sys/shell/udp.rs
@@ -1,6 +1,8 @@
 use std::io;
 use std::net::{self, SocketAddr};
 
+pub use std::net::UdpSocket;
+
 pub fn bind(_: SocketAddr) -> io::Result<net::UdpSocket> {
     os_required!()
 }

--- a/src/sys/shell/uds.rs
+++ b/src/sys/shell/uds.rs
@@ -1,3 +1,6 @@
+#[cfg(unix)]
+pub use crate::sys::unix::uds::SocketAddr;
+
 pub(crate) mod datagram {
     use crate::net::SocketAddr;
     use std::io;

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -13,6 +13,10 @@ macro_rules! syscall {
     }};
 }
 
+cfg_net! {
+    pub(crate) mod net;
+}
+
 cfg_os_poll! {
     mod selector;
     pub(crate) use self::selector::{event, Event, Events, Selector};
@@ -24,12 +28,9 @@ cfg_os_poll! {
     pub(crate) use self::waker::Waker;
 
     cfg_net! {
-        mod net;
-
         pub(crate) mod tcp;
         pub(crate) mod udp;
         pub(crate) mod uds;
-        pub use self::uds::SocketAddr;
     }
 
     cfg_io_source! {
@@ -61,8 +62,7 @@ cfg_os_poll! {
 
 cfg_not_os_poll! {
     cfg_net! {
-        mod uds;
-        pub use self::uds::SocketAddr;
+        pub(crate) mod uds;
     }
 
     cfg_any_os_ext! {

--- a/src/sys/unix/net.rs
+++ b/src/sys/unix/net.rs
@@ -1,169 +1,173 @@
-use std::io;
-use std::mem::size_of;
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+pub use std::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, SocketAddrV4, SocketAddrV6};
+pub use std::os::unix::net::{UnixDatagram, UnixListener, UnixStream};
 
-pub(crate) fn new_ip_socket(addr: SocketAddr, socket_type: libc::c_int) -> io::Result<libc::c_int> {
-    let domain = match addr {
-        SocketAddr::V4(..) => libc::AF_INET,
-        SocketAddr::V6(..) => libc::AF_INET6,
-    };
+cfg_os_poll! {
+    use std::io;
+    use std::mem::size_of;
 
-    new_socket(domain, socket_type)
-}
+    pub(crate) fn new_ip_socket(addr: SocketAddr, socket_type: libc::c_int) -> io::Result<libc::c_int> {
+        let domain = match addr {
+            SocketAddr::V4(..) => libc::AF_INET,
+            SocketAddr::V6(..) => libc::AF_INET6,
+        };
 
-/// Create a new non-blocking socket.
-pub(crate) fn new_socket(domain: libc::c_int, socket_type: libc::c_int) -> io::Result<libc::c_int> {
-    #[cfg(any(
-        target_os = "android",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "illumos",
-        target_os = "linux",
-        target_os = "netbsd",
-        target_os = "openbsd"
-    ))]
-    let socket_type = socket_type | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
-
-    // Gives a warning for platforms without SOCK_NONBLOCK.
-    #[allow(clippy::let_and_return)]
-    let socket = syscall!(socket(domain, socket_type, 0));
-
-    // Mimick `libstd` and set `SO_NOSIGPIPE` on apple systems.
-    #[cfg(target_vendor = "apple")]
-    let socket = socket.and_then(|socket| {
-        syscall!(setsockopt(
-            socket,
-            libc::SOL_SOCKET,
-            libc::SO_NOSIGPIPE,
-            &1 as *const libc::c_int as *const libc::c_void,
-            size_of::<libc::c_int>() as libc::socklen_t
-        ))
-        .map(|_| socket)
-    });
-
-    // Darwin doesn't have SOCK_NONBLOCK or SOCK_CLOEXEC. Not sure about
-    // Solaris, couldn't find anything online.
-    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "solaris"))]
-    let socket = socket.and_then(|socket| {
-        // For platforms that don't support flags in socket, we need to
-        // set the flags ourselves.
-        syscall!(fcntl(socket, libc::F_SETFL, libc::O_NONBLOCK))
-            .and_then(|_| syscall!(fcntl(socket, libc::F_SETFD, libc::FD_CLOEXEC)).map(|_| socket))
-            .map_err(|e| {
-                // If either of the `fcntl` calls failed, ensure the socket is
-                // closed and return the error.
-                let _ = syscall!(close(socket));
-                e
-            })
-    });
-
-    socket
-}
-
-/// A type with the same memory layout as `libc::sockaddr`. Used in converting Rust level
-/// SocketAddr* types into their system representation. The benefit of this specific
-/// type over using `libc::sockaddr_storage` is that this type is exactly as large as it
-/// needs to be and not a lot larger. And it can be initialized cleaner from Rust.
-#[repr(C)]
-pub(crate) union SocketAddrCRepr {
-    v4: libc::sockaddr_in,
-    v6: libc::sockaddr_in6,
-}
-
-impl SocketAddrCRepr {
-    pub(crate) fn as_ptr(&self) -> *const libc::sockaddr {
-        self as *const _ as *const libc::sockaddr
+        new_socket(domain, socket_type)
     }
-}
 
-/// Converts a Rust `SocketAddr` into the system representation.
-pub(crate) fn socket_addr(addr: &SocketAddr) -> (SocketAddrCRepr, libc::socklen_t) {
-    match addr {
-        SocketAddr::V4(ref addr) => {
-            // `s_addr` is stored as BE on all machine and the array is in BE order.
-            // So the native endian conversion method is used so that it's never swapped.
-            let sin_addr = libc::in_addr {
-                s_addr: u32::from_ne_bytes(addr.ip().octets()),
-            };
+    /// Create a new non-blocking socket.
+    pub(crate) fn new_socket(domain: libc::c_int, socket_type: libc::c_int) -> io::Result<libc::c_int> {
+        #[cfg(any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "illumos",
+            target_os = "linux",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ))]
+        let socket_type = socket_type | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
 
-            let sockaddr_in = libc::sockaddr_in {
-                sin_family: libc::AF_INET as libc::sa_family_t,
-                sin_port: addr.port().to_be(),
-                sin_addr,
-                sin_zero: [0; 8],
-                #[cfg(any(
-                    target_os = "dragonfly",
-                    target_os = "freebsd",
-                    target_os = "ios",
-                    target_os = "macos",
-                    target_os = "netbsd",
-                    target_os = "openbsd"
-                ))]
-                sin_len: 0,
-            };
+        // Gives a warning for platforms without SOCK_NONBLOCK.
+        #[allow(clippy::let_and_return)]
+        let socket = syscall!(socket(domain, socket_type, 0));
 
-            let sockaddr = SocketAddrCRepr { v4: sockaddr_in };
-            let socklen = size_of::<libc::sockaddr_in>() as libc::socklen_t;
-            (sockaddr, socklen)
-        }
-        SocketAddr::V6(ref addr) => {
-            let sockaddr_in6 = libc::sockaddr_in6 {
-                sin6_family: libc::AF_INET6 as libc::sa_family_t,
-                sin6_port: addr.port().to_be(),
-                sin6_addr: libc::in6_addr {
-                    s6_addr: addr.ip().octets(),
-                },
-                sin6_flowinfo: addr.flowinfo(),
-                sin6_scope_id: addr.scope_id(),
-                #[cfg(any(
-                    target_os = "dragonfly",
-                    target_os = "freebsd",
-                    target_os = "ios",
-                    target_os = "macos",
-                    target_os = "netbsd",
-                    target_os = "openbsd"
-                ))]
-                sin6_len: 0,
-                #[cfg(any(target_os = "solaris", target_os = "illumos"))]
-                __sin6_src_id: 0,
-            };
+        // Mimick `libstd` and set `SO_NOSIGPIPE` on apple systems.
+        #[cfg(target_vendor = "apple")]
+        let socket = socket.and_then(|socket| {
+            syscall!(setsockopt(
+                socket,
+                libc::SOL_SOCKET,
+                libc::SO_NOSIGPIPE,
+                &1 as *const libc::c_int as *const libc::c_void,
+                size_of::<libc::c_int>() as libc::socklen_t
+            ))
+                .map(|_| socket)
+        });
 
-            let sockaddr = SocketAddrCRepr { v6: sockaddr_in6 };
-            let socklen = size_of::<libc::sockaddr_in6>() as libc::socklen_t;
-            (sockaddr, socklen)
+        // Darwin doesn't have SOCK_NONBLOCK or SOCK_CLOEXEC. Not sure about
+        // Solaris, couldn't find anything online.
+        #[cfg(any(target_os = "ios", target_os = "macos", target_os = "solaris"))]
+        let socket = socket.and_then(|socket| {
+            // For platforms that don't support flags in socket, we need to
+            // set the flags ourselves.
+            syscall!(fcntl(socket, libc::F_SETFL, libc::O_NONBLOCK))
+                .and_then(|_| syscall!(fcntl(socket, libc::F_SETFD, libc::FD_CLOEXEC)).map(|_| socket))
+                .map_err(|e| {
+                    // If either of the `fcntl` calls failed, ensure the socket is
+                    // closed and return the error.
+                    let _ = syscall!(close(socket));
+                    e
+                })
+        });
+
+        socket
+    }
+
+    /// A type with the same memory layout as `libc::sockaddr`. Used in converting Rust level
+    /// SocketAddr* types into their system representation. The benefit of this specific
+    /// type over using `libc::sockaddr_storage` is that this type is exactly as large as it
+    /// needs to be and not a lot larger. And it can be initialized cleaner from Rust.
+    #[repr(C)]
+    pub(crate) union SocketAddrCRepr {
+        v4: libc::sockaddr_in,
+        v6: libc::sockaddr_in6,
+    }
+
+    impl SocketAddrCRepr {
+        pub(crate) fn as_ptr(&self) -> *const libc::sockaddr {
+            self as *const _ as *const libc::sockaddr
         }
     }
-}
 
-/// Converts a `libc::sockaddr` compatible struct into a native Rust `SocketAddr`.
-///
-/// # Safety
-///
-/// `storage` must have the `ss_family` field correctly initialized.
-/// `storage` must be initialised to a `sockaddr_in` or `sockaddr_in6`.
-pub(crate) unsafe fn to_socket_addr(
-    storage: *const libc::sockaddr_storage,
-) -> io::Result<SocketAddr> {
-    match (*storage).ss_family as libc::c_int {
-        libc::AF_INET => {
-            // Safety: if the ss_family field is AF_INET then storage must be a sockaddr_in.
-            let addr: &libc::sockaddr_in = &*(storage as *const libc::sockaddr_in);
-            let ip = Ipv4Addr::from(addr.sin_addr.s_addr.to_ne_bytes());
-            let port = u16::from_be(addr.sin_port);
-            Ok(SocketAddr::V4(SocketAddrV4::new(ip, port)))
+    /// Converts a Rust `SocketAddr` into the system representation.
+    pub(crate) fn socket_addr(addr: &SocketAddr) -> (SocketAddrCRepr, libc::socklen_t) {
+        match addr {
+            SocketAddr::V4(ref addr) => {
+                // `s_addr` is stored as BE on all machine and the array is in BE order.
+                // So the native endian conversion method is used so that it's never swapped.
+                let sin_addr = libc::in_addr {
+                    s_addr: u32::from_ne_bytes(addr.ip().octets()),
+                };
+
+                let sockaddr_in = libc::sockaddr_in {
+                    sin_family: libc::AF_INET as libc::sa_family_t,
+                    sin_port: addr.port().to_be(),
+                    sin_addr,
+                    sin_zero: [0; 8],
+                    #[cfg(any(
+                        target_os = "dragonfly",
+                        target_os = "freebsd",
+                        target_os = "ios",
+                        target_os = "macos",
+                        target_os = "netbsd",
+                        target_os = "openbsd"
+                    ))]
+                    sin_len: 0,
+                };
+
+                let sockaddr = SocketAddrCRepr { v4: sockaddr_in };
+                let socklen = size_of::<libc::sockaddr_in>() as libc::socklen_t;
+                (sockaddr, socklen)
+            }
+            SocketAddr::V6(ref addr) => {
+                let sockaddr_in6 = libc::sockaddr_in6 {
+                    sin6_family: libc::AF_INET6 as libc::sa_family_t,
+                    sin6_port: addr.port().to_be(),
+                    sin6_addr: libc::in6_addr {
+                        s6_addr: addr.ip().octets(),
+                    },
+                    sin6_flowinfo: addr.flowinfo(),
+                    sin6_scope_id: addr.scope_id(),
+                    #[cfg(any(
+                        target_os = "dragonfly",
+                        target_os = "freebsd",
+                        target_os = "ios",
+                        target_os = "macos",
+                        target_os = "netbsd",
+                        target_os = "openbsd"
+                    ))]
+                    sin6_len: 0,
+                    #[cfg(any(target_os = "solaris", target_os = "illumos"))]
+                    __sin6_src_id: 0,
+                };
+
+                let sockaddr = SocketAddrCRepr { v6: sockaddr_in6 };
+                let socklen = size_of::<libc::sockaddr_in6>() as libc::socklen_t;
+                (sockaddr, socklen)
+            }
         }
-        libc::AF_INET6 => {
-            // Safety: if the ss_family field is AF_INET6 then storage must be a sockaddr_in6.
-            let addr: &libc::sockaddr_in6 = &*(storage as *const libc::sockaddr_in6);
-            let ip = Ipv6Addr::from(addr.sin6_addr.s6_addr);
-            let port = u16::from_be(addr.sin6_port);
-            Ok(SocketAddr::V6(SocketAddrV6::new(
-                ip,
-                port,
-                addr.sin6_flowinfo,
-                addr.sin6_scope_id,
-            )))
+    }
+
+    /// Converts a `libc::sockaddr` compatible struct into a native Rust `SocketAddr`.
+    ///
+    /// # Safety
+    ///
+    /// `storage` must have the `ss_family` field correctly initialized.
+    /// `storage` must be initialised to a `sockaddr_in` or `sockaddr_in6`.
+    pub(crate) unsafe fn to_socket_addr(
+        storage: *const libc::sockaddr_storage,
+    ) -> io::Result<SocketAddr> {
+        match (*storage).ss_family as libc::c_int {
+            libc::AF_INET => {
+                // Safety: if the ss_family field is AF_INET then storage must be a sockaddr_in.
+                let addr: &libc::sockaddr_in = &*(storage as *const libc::sockaddr_in);
+                let ip = Ipv4Addr::from(addr.sin_addr.s_addr.to_ne_bytes());
+                let port = u16::from_be(addr.sin_port);
+                Ok(SocketAddr::V4(SocketAddrV4::new(ip, port)))
+            }
+            libc::AF_INET6 => {
+                // Safety: if the ss_family field is AF_INET6 then storage must be a sockaddr_in6.
+                let addr: &libc::sockaddr_in6 = &*(storage as *const libc::sockaddr_in6);
+                let ip = Ipv6Addr::from(addr.sin6_addr.s6_addr);
+                let port = u16::from_be(addr.sin6_port);
+                Ok(SocketAddr::V6(SocketAddrV6::new(
+                    ip,
+                    port,
+                    addr.sin6_flowinfo,
+                    addr.sin6_scope_id,
+                )))
+            }
+            _ => Err(io::ErrorKind::InvalidInput.into()),
         }
-        _ => Err(io::ErrorKind::InvalidInput.into()),
     }
 }

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,11 +1,12 @@
-use crate::sys::unix::net::{new_ip_socket, socket_addr};
+use crate::sys::net::{new_ip_socket, socket_addr, SocketAddr};
 
 use std::io;
 use std::mem;
-use std::net::{self, SocketAddr};
 use std::os::unix::io::{AsRawFd, FromRawFd};
 
-pub fn bind(addr: SocketAddr) -> io::Result<net::UdpSocket> {
+pub use std::net::UdpSocket;
+
+pub fn bind(addr: SocketAddr) -> io::Result<UdpSocket> {
     // Gives a warning for non Apple platforms.
     #[allow(clippy::let_and_return)]
     let socket = new_ip_socket(addr, libc::SOCK_DGRAM);
@@ -19,11 +20,11 @@ pub fn bind(addr: SocketAddr) -> io::Result<net::UdpSocket> {
                 let _ = unsafe { libc::close(socket) };
                 err
             })
-            .map(|_| unsafe { net::UdpSocket::from_raw_fd(socket) })
+            .map(|_| unsafe { UdpSocket::from_raw_fd(socket) })
     })
 }
 
-pub(crate) fn only_v6(socket: &net::UdpSocket) -> io::Result<bool> {
+pub(crate) fn only_v6(socket: &UdpSocket) -> io::Result<bool> {
     let mut optval: libc::c_int = 0;
     let mut optlen = mem::size_of::<libc::c_int>() as libc::socklen_t;
 

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -26,8 +26,7 @@ cfg_net! {
         }};
     }
 
-    mod net;
-
+    pub(crate) mod net;
     pub(crate) mod tcp;
     pub(crate) mod udp;
 }

--- a/src/sys/windows/net.rs
+++ b/src/sys/windows/net.rs
@@ -1,7 +1,8 @@
 use std::io;
 use std::mem;
-use std::net::SocketAddr;
 use std::sync::Once;
+
+pub use std::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr};
 
 use winapi::ctypes::c_int;
 use winapi::shared::in6addr::{in6_addr_u, IN6_ADDR};

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -22,6 +22,8 @@ use winapi::um::winsock2::{
 use crate::net::TcpKeepalive;
 use crate::sys::windows::net::{init, new_socket, socket_addr};
 
+pub use std::net::{TcpListener, TcpStream};
+
 pub(crate) type TcpSocket = SOCKET;
 
 pub(crate) fn new_v4_socket() -> io::Result<TcpSocket> {

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -11,6 +11,8 @@ use winapi::um::winsock2::{bind as win_bind, closesocket, getsockopt, SOCKET_ERR
 
 use crate::sys::windows::net::{init, new_ip_socket, socket_addr};
 
+pub use std::net::UdpSocket;
+
 pub fn bind(addr: SocketAddr) -> io::Result<net::UdpSocket> {
     init();
     new_ip_socket(addr, SOCK_DGRAM).and_then(|socket| {


### PR DESCRIPTION
`mio` provides this great architecture where `mio::net` defines
user-friendly wrappers to system backends, i.e. `sys` modules like
`sys::unix`, `sys::windows` and `sys::shell`.

At every step, it's assumed that `std::net` is available. However,
depending on the backend a user would like to implement, `std::net`
might not be present. For example, it's assumed that
`std::net::{TcpListener, TcpStream}` are always available.

That's not always true.

This patch moves the responsability to the backends to _declare_ —or
basically to _re-export_!— some types from `std::net`, such as:

* `std::net::TcpListener`,
* `std::net::TcpStream`,
* `std::net::UdpSocket`,
* `std::net::SocketAddr`,
* `std::net::{SocketAddrV4,SocketAddrV6}`,
* `std::net::{Ipv4Addr, Ipv6Addr}`.

To achieve that, all of those types above related to `std::net` are
now in `sys::net`, those related to TCP are now in `sys::tcp`, and
finally those related to UDP are now in `sys::udp`.

It's actually consistent with types that were previously implemented in
`sys` like `sys::tcp::TcpSocket`.

With this patch, `mio::net` has no more dependency to
`std::net`. Everything comes from `sys`.