### PR TITLE
use unspecified wording in some docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,7 @@
 edition = "2018"
 name = "mio"
 # When releasing to crates.io:
-# - Update html_root_url.
 # - Update CHANGELOG.md.
-# - Update doc URL.
 # - Create git tag
 version       = "0.8.0"
 publish       = false
@@ -15,7 +13,6 @@ authors       = [
   "Tokio Contributors <team@tokio.rs>",
 ]
 description   = "Lightweight non-blocking IO"
-documentation = "https://docs.rs/mio/0.7.7"
 homepage      = "https://github.com/tokio-rs/mio"
 repository    = "https://github.com/tokio-rs/mio"
 readme        = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/mio/0.7.7")]
 #![deny(
     missing_docs,
     missing_debug_implementations,

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -103,7 +103,7 @@ impl TcpStream {
     ///
     /// On Windows make sure the stream is connected before calling this method,
     /// by receiving an (writable) event. Trying to set `nodelay` on an
-    /// unconnected `TcpStream` is undefined behavior.
+    /// unconnected `TcpStream` is unspecified behavior.
     pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
         self.inner.set_nodelay(nodelay)
     }
@@ -118,7 +118,7 @@ impl TcpStream {
     ///
     /// On Windows make sure the stream is connected before calling this method,
     /// by receiving an (writable) event. Trying to get `nodelay` on an
-    /// unconnected `TcpStream` is undefined behavior.
+    /// unconnected `TcpStream` is unspecified behavior.
     pub fn nodelay(&self) -> io::Result<bool> {
         self.inner.nodelay()
     }
@@ -132,7 +132,7 @@ impl TcpStream {
     ///
     /// On Windows make sure the stream is connected before calling this method,
     /// by receiving an (writable) event. Trying to set `ttl` on an
-    /// unconnected `TcpStream` is undefined behavior.
+    /// unconnected `TcpStream` is unspecified behavior.
     pub fn set_ttl(&self, ttl: u32) -> io::Result<()> {
         self.inner.set_ttl(ttl)
     }
@@ -145,7 +145,7 @@ impl TcpStream {
     ///
     /// On Windows make sure the stream is connected before calling this method,
     /// by receiving an (writable) event. Trying to get `ttl` on an
-    /// unconnected `TcpStream` is undefined behavior.
+    /// unconnected `TcpStream` is unspecified behavior.
     ///
     /// [link]: #method.set_ttl
     pub fn ttl(&self) -> io::Result<u32> {

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -409,7 +409,7 @@ impl Registry {
     /// Callers must ensure that if a source being registered with a `Poll`
     /// instance was previously registered with that `Poll` instance, then a
     /// call to [`deregister`] has already occurred. Consecutive calls to
-    /// `register` is undefined behavior.
+    /// `register` is unspecified behavior.
     ///
     /// Unless otherwise specified, the caller should assume that once an event
     /// source is registered with a `Poll` instance, it is bound to that `Poll`
@@ -495,7 +495,7 @@ impl Registry {
     /// requested for the handle.
     ///
     /// The event source must have previously been registered with this instance
-    /// of `Poll`, otherwise the behavior is undefined.
+    /// of `Poll`, otherwise the behavior is unspecified.
     ///
     /// See the [`register`] documentation for details about the function
     /// arguments and see the [`struct`] docs for a high level overview of
@@ -562,11 +562,11 @@ impl Registry {
     /// the poll.
     ///
     /// The event source must have previously been registered with this instance
-    /// of `Poll`, otherwise the behavior is undefined.
+    /// of `Poll`, otherwise the behavior is unspecified.
     ///
     /// A handle can be passed back to `register` after it has been
     /// deregistered; however, it must be passed back to the **same** `Poll`
-    /// instance, otherwise the behavior is undefined.
+    /// instance, otherwise the behavior is unspecified.
     ///
     /// # Examples
     ///

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -19,7 +19,7 @@ use std::io;
 /// Only a single `Waker` can be active per [`Poll`], if multiple threads need
 /// access to the `Waker` it can be shared via for example an `Arc`. What
 /// happens if multiple `Waker`s are registered with the same `Poll` is
-/// undefined.
+/// unspecified.
 ///
 /// # Implementation notes
 ///

--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -393,7 +393,7 @@ fn reregister_interest_token_usage() {
 
 // This test checks the following register constraint:
 // The event source must **not** have been previously registered with this
-// instance of `Poll`, otherwise the behavior is undefined.
+// instance of `Poll`, otherwise the behavior is unspecified.
 //
 // This test is done on Windows and epoll platforms where registering a
 // source twice is defined behavior that fail with an error code.
@@ -484,7 +484,7 @@ fn poll_ok_after_cancelling_pending_ops() {
 
 // This test checks the following reregister constraint:
 // The event source must have previously been registered with this instance
-// of `Poll`, otherwise the behavior is undefined.
+// of `Poll`, otherwise the behavior is unspecified.
 //
 // This test is done on Windows and epoll platforms where reregistering a
 // source without a previous register is defined behavior that fail with an
@@ -508,7 +508,7 @@ fn reregister_without_register() {
 
 // This test checks the following register/deregister constraint:
 // The event source must have previously been registered with this instance
-// of `Poll`, otherwise the behavior is undefined.
+// of `Poll`, otherwise the behavior is unspecified.
 //
 // This test is done on Windows and epoll platforms where deregistering a
 // source without a previous register is defined behavior that fail with an

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -146,7 +146,7 @@ fn set_get_ttl() {
     let mut stream = TcpStream::connect(address).unwrap();
 
     // on Windows: the stream must be connected before setting the ttl, otherwise
-    // it is undefined behavior, register and expect a WRITABLE here to make sure
+    // it is unspecified behavior, register and expect a WRITABLE here to make sure
     // the stream is connected
     poll.registry()
         .register(&mut stream, ID1, Interest::WRITABLE)
@@ -178,7 +178,7 @@ fn get_ttl_without_previous_set() {
     let mut stream = TcpStream::connect(address).unwrap();
 
     // on Windows: the stream must be connected before getting the ttl, otherwise
-    // it is undefined behavior, register and expect a WRITABLE here to make sure
+    // it is unspecified behavior, register and expect a WRITABLE here to make sure
     // the stream is connected
     poll.registry()
         .register(&mut stream, ID1, Interest::WRITABLE)
@@ -208,7 +208,7 @@ fn set_get_nodelay() {
     let mut stream = TcpStream::connect(address).unwrap();
 
     // on Windows: the stream must be connected before setting the nodelay, otherwise
-    // it is undefined behavior, register and expect a WRITABLE here to make sure
+    // it is unspecified behavior, register and expect a WRITABLE here to make sure
     // the stream is connected
     poll.registry()
         .register(&mut stream, ID1, Interest::WRITABLE)
@@ -240,7 +240,7 @@ fn get_nodelay_without_previous_set() {
     let mut stream = TcpStream::connect(address).unwrap();
 
     // on Windows: the stream must be connected before setting the nodelay, otherwise
-    // it is undefined behavior, register and expect a WRITABLE here to make sure
+    // it is unspecified behavior, register and expect a WRITABLE here to make sure
     // the stream is connected
     poll.registry()
         .register(&mut stream, ID1, Interest::WRITABLE)


### PR DESCRIPTION
\+ remove manual doc url versioning