### PR TITLE
Remove unsound offset_of macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ targets = [
   "aarch64-linux-android",
   "x86_64-apple-darwin",
   "x86_64-pc-windows-msvc",
-  "x86_64-sun-solaris",
+  "x86_64-pc-solaris",
   "x86_64-unknown-dragonfly",
   "x86_64-unknown-freebsd",
   "x86_64-unknown-linux-gnu",

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Targets available via Rustup that are supported.
-TARGETS ?= "aarch64-apple-ios" "aarch64-linux-android" "x86_64-apple-darwin" "x86_64-pc-windows-msvc" "x86_64-sun-solaris" "x86_64-unknown-freebsd" "x86_64-unknown-linux-gnu" "x86_64-unknown-netbsd"
+TARGETS ?= "aarch64-apple-ios" "aarch64-linux-android" "x86_64-apple-darwin" "x86_64-pc-windows-msvc" "x86_64-pc-solaris" "x86_64-unknown-freebsd" "x86_64-unknown-linux-gnu" "x86_64-unknown-netbsd"
 
 test:
 	cargo test --all-features

--- a/ci/azure-cross-compile.yml
+++ b/ci/azure-cross-compile.yml
@@ -32,7 +32,7 @@ jobs:
 
         Solaris:
           vmImage: ubuntu-16.04
-          target: x86_64-sun-solaris
+          target: x86_64-pc-solaris
 
     pool:
       vmImage: $(vmImage)

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -70,23 +70,19 @@ pub struct NamedPipe {
 /// constants depend on it, see the `offset_constants` test.
 #[repr(C)]
 struct Inner {
-    handle: pipe::NamedPipe,
-
     connect: Overlapped,
-    connecting: AtomicBool,
-
     read: Overlapped,
     write: Overlapped,
-
+    handle: pipe::NamedPipe,
+    connecting: AtomicBool,
     io: Mutex<Io>,
-
     pool: Mutex<BufferPool>,
 }
 
 /// Offsets from a pointer to `Inner` to the `connect`, `read` and `write`
 /// fields.
-const CONNECT_OFFSET: usize = size_of::<pipe::NamedPipe>(); // `handle` field.
-const READ_OFFSET: usize = CONNECT_OFFSET + size_of::<Overlapped>() + size_of::<usize>(); // `connect`, `connecting` (`bool` + padding) fields.
+const CONNECT_OFFSET: usize = 0;
+const READ_OFFSET: usize = CONNECT_OFFSET + size_of::<Overlapped>(); // `connect` fields.
 const WRITE_OFFSET: usize = READ_OFFSET + size_of::<Overlapped>(); // `read` fields.
 
 #[test]

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -65,8 +65,8 @@ pub struct NamedPipe {
 
 /// # Notes
 ///
-/// The memory layout of this structure must be fixed as the `*_OFFSET`
-/// constants depend on it, see the `offset_constants` test.
+/// The memory layout of this structure must be fixed as the
+/// `ptr_from_*_overlapped` methods depend on it, see the `ptr_from` test.
 #[repr(C)]
 struct Inner {
     // NOTE: careful modifying the order of these three fields, the `ptr_from_*`

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -9,7 +9,7 @@ use mio::net::{TcpListener, TcpStream};
 use mio::{Events, Interest, Poll, Token, Waker};
 
 mod util;
-use util::{any_local_address, init, init_with_poll, temp_file};
+use util::{any_local_address, init, init_with_poll};
 
 const ID1: Token = Token(1);
 const WAKE_TOKEN: Token = Token(10);
@@ -109,6 +109,7 @@ fn issue_1205() {
 #[cfg(unix)]
 fn issue_1403() {
     use mio::net::UnixDatagram;
+    use util::temp_file;
 
     init();
 


### PR DESCRIPTION
And replace it with constants that define the offsets to the fields.
It's not a pretty solution, but it's one without UB.

Closes #1483.