### PR TITLE
Replace x86_64-sun-solaris with x86_64-pc-solaris

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ targets = [
   "aarch64-linux-android",
   "x86_64-apple-darwin",
   "x86_64-pc-windows-msvc",
-  "x86_64-sun-solaris",
+  "x86_64-pc-solaris",
   "x86_64-unknown-dragonfly",
   "x86_64-unknown-freebsd",
   "x86_64-unknown-linux-gnu",

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Targets available via Rustup that are supported.
-TARGETS ?= "aarch64-apple-ios" "aarch64-linux-android" "x86_64-apple-darwin" "x86_64-pc-windows-msvc" "x86_64-sun-solaris" "x86_64-unknown-freebsd" "x86_64-unknown-linux-gnu" "x86_64-unknown-netbsd"
+TARGETS ?= "aarch64-apple-ios" "aarch64-linux-android" "x86_64-apple-darwin" "x86_64-pc-windows-msvc" "x86_64-pc-solaris" "x86_64-unknown-freebsd" "x86_64-unknown-linux-gnu" "x86_64-unknown-netbsd"
 
 test:
 	cargo test --all-features

--- a/ci/azure-cross-compile.yml
+++ b/ci/azure-cross-compile.yml
@@ -32,7 +32,7 @@ jobs:
 
         Solaris:
           vmImage: ubuntu-16.04
-          target: x86_64-sun-solaris
+          target: x86_64-pc-solaris
 
     pool:
       vmImage: $(vmImage)


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/82216 removed the
x86_64-sun-solaris target from rustup, changing it to use
x86_64-pc-solaris instead.

Related issues:
 * https://github.com/rust-lang/rust/issues/85098