### PR TITLE
Use ubuntu-18.04 instead of ubuntu-16.04

### DIFF
--- a/ci/azure-clippy.yml
+++ b/ci/azure-clippy.yml
@@ -3,7 +3,7 @@ jobs:
   displayName: Clippy
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
 
   steps:
     - template: azure-install-rust.yml

--- a/ci/azure-cross-compile.yml
+++ b/ci/azure-cross-compile.yml
@@ -1,5 +1,5 @@
 parameters:
-  vmImage: ubuntu-16.04
+  vmImage: ubuntu-18.04
 
 jobs:
   - job: ${{ parameters.name }}
@@ -15,23 +15,23 @@ jobs:
           target: aarch64-apple-ios
 
         Android_ARM:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-18.04
           target: arm-linux-androideabi
 
         Android_ARM64:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-18.04
           target: aarch64-linux-android
 
         Android_32:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-18.04
           target: i686-unknown-linux-gnu
 
         NetBSD:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-18.04
           target: x86_64-unknown-netbsd
 
         Solaris:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-18.04
           target: x86_64-pc-solaris
 
     pool:

--- a/ci/azure-minimal-versions.yml
+++ b/ci/azure-minimal-versions.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         Linux:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-18.04
         Windows:
           vmImage: vs2017-win2016
     pool:

--- a/ci/azure-rustfmt.yml
+++ b/ci/azure-rustfmt.yml
@@ -3,7 +3,7 @@ jobs:
   - job: ${{ parameters.name }}
     displayName: Check rustfmt
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
     steps:
       - template: azure-install-rust.yml
         parameters:

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         Linux:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-18.04
 
         ${{ if parameters.cross }}:
           MacOS:


### PR DESCRIPTION
Traditional 5-years support of Ubuntu 16.04 by Canonical ended in April, 2021, and GitHub Actions and Azure Pipelines' `ubuntu-16.04` environment will be removed in September, 2021: https://github.com/actions/virtual-environments/issues/3287