### PR TITLE
Set RUSTUP_IO_THREADS=1 to avoid FreeBSD CI failure

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,8 @@ freebsd_instance:
 
 env:
   RUST_BACKTRACE: full
+  # Workaround for https://github.com/rust-lang/rustup/issues/2774.
+  RUSTUP_IO_THREADS: "1"
 
 task:
   name: FreeBSD


### PR DESCRIPTION
Workaround for https://github.com/rust-lang/rustup/issues/2774 mentioned in https://github.com/rust-lang/rustup/issues/2774#issuecomment-843835682.