### PR TITLE
Set the close-on-exec flag for the duplicate epoll_fd

### DIFF
--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -41,7 +41,7 @@ impl Selector {
     }
 
     pub fn try_clone(&self) -> io::Result<Selector> {
-        syscall!(dup(self.ep)).map(|ep| Selector {
+        syscall!(fcntl(self.ep, libc::F_DUPFD_CLOEXEC, 0)).map(|ep| Selector {
             // It's the same selector, so we use the same id.
             #[cfg(debug_assertions)]
             id: self.id,


### PR DESCRIPTION
Set the close-on-exec flag for the duplicate epoll_fd

The close-on-exec flag (FD_CLOEXEC; see fcntl(2)) for the
duplicate descriptor created by dup(2) is off.

We can use fcntl + F_DUPFD_CLOEXEC to dup the epoll_fd to fix this
issue.

Fixes: tokio-rs/tokio#3809

Signed-off-by: Tim Zhang <tim@hyper.sh>