### PR TITLE
Backport fix about close-on-exec to v0.7.x

### DIFF
--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -41,7 +41,7 @@ impl Selector {
     }
 
     pub fn try_clone(&self) -> io::Result<Selector> {
-        syscall!(dup(self.ep)).map(|ep| Selector {
+        syscall!(fcntl(self.ep, libc::F_DUPFD_CLOEXEC)).map(|ep| Selector {
             // It's the same selector, so we use the same id.
             #[cfg(debug_assertions)]
             id: self.id,


### PR DESCRIPTION
Backport #1491 

The close-on-exec flag (FD_CLOEXEC; see fcntl(2)) for the duplicate descriptor is off
and we should set it manually.

Fixes: tokio-rs/tokio#3809

Signed-off-by: Tim Zhang <tim@hyper.sh>