### PR TITLE
Set FD_CLOEXEC flag on duplicated kqueue Poll

### DIFF
--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -87,7 +87,7 @@ impl Selector {
     }
 
     pub fn try_clone(&self) -> io::Result<Selector> {
-        syscall!(dup(self.kq)).map(|kq| Selector {
+        syscall!(fcntl(self.kq, libc::F_DUPFD_CLOEXEC)).map(|kq| Selector {
             // It's the same selector, so we use the same id.
             #[cfg(debug_assertions)]
             id: self.id,


### PR DESCRIPTION
Same as commit c52635c76a59be28d0bf287a0bad6d6871a2e36c, but for kqueue.