### PR TITLE
feat: Move `poll::selector` to `Registry::selector`

### DIFF
--- a/src/io_source.rs
+++ b/src/io_source.rs
@@ -7,8 +7,6 @@ use std::os::windows::io::AsRawSocket;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{fmt, io};
 
-#[cfg(any(unix, debug_assertions))]
-use crate::poll;
 use crate::sys::IoSourceState;
 use crate::{event, Interest, Registry, Token};
 
@@ -142,7 +140,9 @@ where
     ) -> io::Result<()> {
         #[cfg(debug_assertions)]
         self.selector_id.associate(registry)?;
-        poll::selector(registry).register(self.inner.as_raw_fd(), token, interests)
+        registry
+            .selector()
+            .register(self.inner.as_raw_fd(), token, interests)
     }
 
     fn reregister(
@@ -153,13 +153,15 @@ where
     ) -> io::Result<()> {
         #[cfg(debug_assertions)]
         self.selector_id.check_association(registry)?;
-        poll::selector(registry).reregister(self.inner.as_raw_fd(), token, interests)
+        registry
+            .selector()
+            .reregister(self.inner.as_raw_fd(), token, interests)
     }
 
     fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
         #[cfg(debug_assertions)]
         self.selector_id.remove_association(registry)?;
-        poll::selector(registry).deregister(self.inner.as_raw_fd())
+        registry.selector().deregister(self.inner.as_raw_fd())
     }
 }
 
@@ -230,7 +232,7 @@ impl SelectorId {
     /// Associate an I/O source with `registry`, returning an error if its
     /// already registered.
     fn associate(&self, registry: &Registry) -> io::Result<()> {
-        let registry_id = poll::selector(&registry).id();
+        let registry_id = registry.selector().id();
         let previous_id = self.id.swap(registry_id, Ordering::AcqRel);
 
         if previous_id == Self::UNASSOCIATED {
@@ -247,7 +249,7 @@ impl SelectorId {
     /// error if its registered with a different `Registry` or not registered at
     /// all.
     fn check_association(&self, registry: &Registry) -> io::Result<()> {
-        let registry_id = poll::selector(&registry).id();
+        let registry_id = registry.selector().id();
         let id = self.id.load(Ordering::Acquire);
 
         if id == registry_id {
@@ -268,7 +270,7 @@ impl SelectorId {
     /// Remove a previously made association from `registry`, returns an error
     /// if it was not previously associated with `registry`.
     fn remove_association(&self, registry: &Registry) -> io::Result<()> {
-        let registry_id = poll::selector(&registry).id();
+        let registry_id = registry.selector().id();
         let previous_id = self.id.swap(Self::UNASSOCIATED, Ordering::AcqRel);
 
         if previous_id == registry_id {

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -628,6 +628,11 @@ impl Registry {
             panic!("Only a single `Waker` can be active per `Poll` instance");
         }
     }
+
+    /// Get access to the `sys::Selector`.
+    pub(crate) fn selector(&self) -> &sys::Selector {
+        &self.selector
+    }
 }
 
 impl fmt::Debug for Registry {
@@ -641,11 +646,6 @@ impl AsRawFd for Registry {
     fn as_raw_fd(&self) -> RawFd {
         self.selector.as_raw_fd()
     }
-}
-
-/// Get access to the `sys::Selector` from `Registry`.
-pub(crate) fn selector(registry: &Registry) -> &sys::Selector {
-    &registry.selector
 }
 
 cfg_os_poll! {

--- a/src/sys/unix/sourcefd.rs
+++ b/src/sys/unix/sourcefd.rs
@@ -1,4 +1,4 @@
-use crate::{event, poll, Interest, Registry, Token};
+use crate::{event, Interest, Registry, Token};
 
 use std::io;
 use std::os::unix::io::RawFd;
@@ -98,7 +98,7 @@ impl<'a> event::Source for SourceFd<'a> {
         token: Token,
         interests: Interest,
     ) -> io::Result<()> {
-        poll::selector(registry).register(*self.0, token, interests)
+        registry.selector().register(*self.0, token, interests)
     }
 
     fn reregister(
@@ -107,10 +107,10 @@ impl<'a> event::Source for SourceFd<'a> {
         token: Token,
         interests: Interest,
     ) -> io::Result<()> {
-        poll::selector(registry).reregister(*self.0, token, interests)
+        registry.selector().reregister(*self.0, token, interests)
     }
 
     fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
-        poll::selector(registry).deregister(*self.0)
+        registry.selector().deregister(*self.0)
     }
 }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -45,7 +45,7 @@ cfg_io_source! {
     use std::pin::Pin;
     use std::sync::{Arc, Mutex};
 
-    use crate::{poll, Interest, Registry, Token};
+    use crate::{Interest, Registry, Token};
 
     struct InternalState {
         selector: Arc<SelectorInner>,
@@ -101,7 +101,8 @@ cfg_io_source! {
             if self.inner.is_some() {
                 Err(io::ErrorKind::AlreadyExists.into())
             } else {
-                poll::selector(registry)
+                registry
+                    .selector()
                     .register(socket, token, interests)
                     .map(|state| {
                         self.inner = Some(Box::new(state));
@@ -117,7 +118,8 @@ cfg_io_source! {
         ) -> io::Result<()> {
             match self.inner.as_mut() {
                 Some(state) => {
-                    poll::selector(registry)
+                    registry
+                        .selector()
                         .reregister(state.sock_state.clone(), token, interests)
                         .map(|()| {
                             state.token = token;

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -1,4 +1,4 @@
-use crate::{poll, sys, Registry, Token};
+use crate::{sys, Registry, Token};
 
 use std::io;
 
@@ -84,7 +84,7 @@ impl Waker {
     pub fn new(registry: &Registry, token: Token) -> io::Result<Waker> {
         #[cfg(debug_assertions)]
         registry.register_waker();
-        sys::Waker::new(poll::selector(&registry), token).map(|inner| Waker { inner })
+        sys::Waker::new(registry.selector(), token).map(|inner| Waker { inner })
     }
 
     /// Wake up the [`Poll`] associated with this `Waker`.

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -46,10 +46,10 @@ fn set_keepalive() {
 
     let socket = TcpSocket::new_v4().unwrap();
     socket.set_keepalive(false).unwrap();
-    assert_eq!(false, socket.get_keepalive().unwrap());
+    assert!(!socket.get_keepalive().unwrap());
 
     socket.set_keepalive(true).unwrap();
-    assert_eq!(true, socket.get_keepalive().unwrap());
+    assert!(socket.get_keepalive().unwrap());
 
     socket.bind(addr).unwrap();
 

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -193,10 +193,10 @@ fn set_get_broadcast() {
     let socket1 = UdpSocket::bind(any_local_address()).unwrap();
 
     socket1.set_broadcast(true).unwrap();
-    assert_eq!(socket1.broadcast().unwrap(), true);
+    assert!(socket1.broadcast().unwrap());
 
     socket1.set_broadcast(false).unwrap();
-    assert_eq!(socket1.broadcast().unwrap(), false);
+    assert!(!socket1.broadcast().unwrap());
 
     assert!(socket1.take_error().unwrap().is_none());
 }
@@ -215,10 +215,10 @@ fn set_get_multicast_loop_v4() {
     let socket1 = UdpSocket::bind(any_local_address()).unwrap();
 
     socket1.set_multicast_loop_v4(true).unwrap();
-    assert_eq!(socket1.multicast_loop_v4().unwrap(), true);
+    assert!(socket1.multicast_loop_v4().unwrap());
 
     socket1.set_multicast_loop_v4(false).unwrap();
-    assert_eq!(socket1.multicast_loop_v4().unwrap(), false);
+    assert!(!socket1.multicast_loop_v4().unwrap());
 
     assert!(socket1.take_error().unwrap().is_none());
 }
@@ -257,10 +257,10 @@ fn set_get_multicast_loop_v6() {
     let socket1 = UdpSocket::bind(any_local_ipv6_address()).unwrap();
 
     socket1.set_multicast_loop_v6(true).unwrap();
-    assert_eq!(socket1.multicast_loop_v6().unwrap(), true);
+    assert!(socket1.multicast_loop_v6().unwrap());
 
     socket1.set_multicast_loop_v6(false).unwrap();
-    assert_eq!(socket1.multicast_loop_v6().unwrap(), false);
+    assert!(!socket1.multicast_loop_v6().unwrap());
 
     assert!(socket1.take_error().unwrap().is_none());
 }


### PR DESCRIPTION
Hello,

This patch moves the `poll::selector` function to `Registry::selector`. It then updates the rest of the code accordingly. I believe it makes the code simpler to read and to understand.