### PR TITLE
feat: Make `IoSource` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@ pub mod event;
 
 cfg_io_source! {
     mod io_source;
+
+    pub use io_source::IoSource;
 }
 
 cfg_net! {


### PR DESCRIPTION
Hello,

This patch exposes `IoSource` to the user. It's the simplest path to “expose the `Selector`” to the user. I understand the `sys::Selector` has not the same API depending on the platform (e.g. Windows), so we need an abstraction layer. I believe `IoSource` is the best abstraction layer to register a raw FD (without going through the `net` module) onto the `sys::Selector`.

Thoughts?