### PR TITLE
feat: Implement `ExactSizeIterator` for `events::Iter`

### DIFF
--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -223,6 +223,8 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
+impl<'a> ExactSizeIterator for Iter<'a> {}
+
 impl fmt::Debug for Events {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self).finish()


### PR DESCRIPTION
The size of `events::Iter` is known. The method `Iter::size_hint`
returns the asme lower and upper size. It fulfills the invariant of
`ExatSizeIterator` and thus it allows us to implement
`ExactSizeIterator` with the default implementation for `len` and
`is_empty` safely.

In most usecases, using `ExactSizeIterator.len` is more appropriate
than `Iterator.count` because it doesn't consume the iterator.