### PR TITLE
Move Wine (6.11+) to supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Currently supported platforms:
 * Windows
 * iOS
 * macOS
+* Wine (version 6.11+, see [issue #1444])
 
 There are potentially others. If you find that Mio works on another
 platform, submit a PR to update the list!
@@ -156,7 +157,6 @@ This uses the Windows AFD system to access socket readiness events.
 ### Unsupported
 
 * Haiku, see [issue #1472]
-* Wine, see [issue #1444]
 
 [issue #1472]: https://github.com/tokio-rs/mio/issues/1472
 


### PR DESCRIPTION
As noted in https://github.com/tokio-rs/mio/issues/1444#issuecomment-867685922, Wine's latest version, 6.11, has implemented the functionality necessary for mio to work correctly under wine.

While it will indeed take a while for 6.11 or higher versions to be available most distros' default package manager, Wine can still be installed in many cases directly from packages made by Wine themselves, or built from source, so I feel that listing it in the supported section with the minimum necessary version (just as with Android) is a more optimistic portrayal of support rather than a user needing to look at #1444 and read the comments to find that it is indeed supported once they acquire the necessary minimum version.