### PR TITLE
feature: added `IP_TOS` methods to `TcpSocket`

### DIFF
--- a/src/net/tcp/socket.rs
+++ b/src/net/tcp/socket.rs
@@ -200,6 +200,31 @@ impl TcpSocket {
         sys::tcp::get_keepalive(self.sys)
     }
 
+    /// Sets the value of `IP_TOS` of this socket.
+    ///
+    /// **Note**: This will not work on all versions of Windows,
+    /// see more: <https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options>
+    #[cfg(not(any(
+        target_os = "fuschia",
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "illumos",
+    )))]
+    pub fn set_tos(&self, tos: u32) -> io::Result<()> {
+        sys::tcp::set_tos(self.sys, tos)
+    }
+
+    /// Gets the value of `IP_TOS` on this socket
+    #[cfg(not(any(
+        target_os = "fuschia",
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "illumos",
+    )))]
+    pub fn get_tos(&self) -> io::Result<u32> {
+        sys::tcp::get_tos(self.sys)
+    }
+
     /// Sets parameters configuring TCP keepalive probes for this socket.
     ///
     /// The supported parameters depend on the operating system, and are

--- a/src/sys/shell/tcp.rs
+++ b/src/sys/shell/tcp.rs
@@ -79,6 +79,26 @@ pub(crate) fn get_keepalive(_: TcpSocket) -> io::Result<bool> {
     os_required!();
 }
 
+#[cfg(not(any(
+    target_os = "fuschia",
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "illumos",
+)))]
+pub(crate) fn set_tos(_: TcpSocket, _: u32) -> io::Result<()> {
+    os_required!();
+}
+
+#[cfg(not(any(
+    target_os = "fuschia",
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "illumos",
+)))]
+pub(crate) fn get_tos(_: TcpSocket) -> io::Result<u32> {
+    os_required!();
+}
+
 pub(crate) fn set_keepalive_params(_: TcpSocket, _: TcpKeepalive) -> io::Result<()> {
     os_required!()
 }

--- a/tests/tcp_socket.rs
+++ b/tests/tcp_socket.rs
@@ -56,6 +56,26 @@ fn set_keepalive() {
     let _ = socket.listen(128).unwrap();
 }
 
+#[cfg(not(any(
+    target_os = "fuschia",
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "illumos",
+)))]
+#[test]
+fn set_tos() {
+    let addr = "127.0.0.1:0".parse().unwrap();
+
+    let tos = 0x10;
+    let socket = TcpSocket::new_v4().unwrap();
+    socket.set_tos(tos).unwrap();
+    assert!(socket.get_tos().unwrap() == tos);
+
+    socket.bind(addr).unwrap();
+
+    let _ = socket.listen(128).unwrap();
+}
+
 #[test]
 fn set_keepalive_time() {
     let dur = Duration::from_secs(4); // Chosen by fair dice roll, guaranteed to be random


### PR DESCRIPTION
This pull request adds two methods to `TcpSocket`: `set_tos` and `get_tos`. `IP_TOS` is useful in some applications where selecting the type-of-service is necessary.
It is important to note that the Microsoft docs state that `IP_TOS` should not be used without the Quality of Service API, although it does not have any impact on functionality.