### PR TITLE
Document that Mio report OOB data in Event::is_readable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
       name: nightly
       displayName: Nightly
       # Pin nightly to avoid being impacted by breakage
-      rust_version: nightly-2020-03-24
+      rust_version: nightly-2021-11-05
       benches: true
 
   # This represents the minimum Rust version supported by

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -25,6 +25,15 @@ impl Event {
     }
 
     /// Returns true if the event contains readable readiness.
+    ///
+    /// # Notes
+    ///
+    /// Out-of-band (OOB) data also triggers readable events. But must
+    /// application don't actually read OOB data, this could leave an
+    /// application open to a Denial-of-Service (Dos) attack, see
+    /// <https://github.com/sandstorm-io/sandstorm-website/blob/58f93346028c0576e8147627667328eaaf4be9fa/_posts/2015-04-08-osx-security-bug.md>.
+    /// However because Mio uses edge-triggers it will not result in an infinite
+    /// loop as described in the article above.
     pub fn is_readable(&self) -> bool {
         sys::event::is_readable(&self.inner)
     }

--- a/src/sys/unix/uds/socketaddr.rs
+++ b/src/sys/unix/uds/socketaddr.rs
@@ -78,14 +78,8 @@ cfg_os_poll! {
         /// Documentation reflected in [`SocketAddr`]
         ///
         /// [`SocketAddr`]: std::os::unix::net::SocketAddr
-        // FIXME: The matches macro requires rust 1.42.0 and we still support 1.39.0
-        #[allow(clippy::match_like_matches_macro)]
         pub fn is_unnamed(&self) -> bool {
-            if let AddressKind::Unnamed = self.address() {
-                true
-            } else {
-                false
-            }
+            matches!(self.address(), AddressKind::Unnamed)
         }
 
         /// Returns the contents of this address if it is a `pathname` address.


### PR DESCRIPTION
Reporting Out-of-band (OOB) as readable it could leave applications open
to DoS attacks. However because Mio uses edge-triggers most applications
won't actually be effected.

Closes #1317.