### PR TITLE
Mention remove of os-util feature in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * udp (replaced with "net" feature).
   * uds (replaced with "net" feature).
   * pipe (replaced with "os-ext" feature).
+  * os-util (replaced with "os-ext" feature).
 * `TcpSocket` type
   (https://github.com/tokio-rs/mio/commit/02e9be41f27daf822575444fdd2b3067433a5996).
   The socket2 crate provides all the functionality and more.


### PR DESCRIPTION
https://github.com/tokio-rs/mio/commit/105f8f2afb57b01ddea716a0aa9720f226c520e3 removed os-util feature, but changelog doesn't mention it.