### PR TITLE
Fix compilation error on FreeBSD 12

### DIFF
--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -1,6 +1,6 @@
 use crate::{Interest, Token};
 use log::error;
-use std::mem::MaybeUninit;
+use std::mem::{self, MaybeUninit};
 use std::ops::{Deref, DerefMut};
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(debug_assertions)]
@@ -60,6 +60,7 @@ macro_rules! kevent {
             fflags: 0,
             data: 0,
             udata: $data as UData,
+            ..unsafe { mem::zeroed() }
         }
     };
 }


### PR DESCRIPTION
Fixes #1539 

Needs to backport to v0.7.x