### PR TITLE
Removes comma from features comment in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub mod features {
     #![cfg_attr(feature = "os-poll", doc = "## `os-poll` (enabled)")]
     #![cfg_attr(not(feature = "os-poll"), doc = "## `os-poll` (disabled)")]
     //!
-    //! Mio by default provides only a shell implementation, that `panic!`s the
+    //! Mio by default provides only a shell implementation that `panic!`s the
     //! moment it is actually run. To run it requires OS support, this is
     //! enabled by activating the `os-poll` feature.
     //!


### PR DESCRIPTION
There's a comma when explaining the features mod that breaks the sentence awkwardly.

This PR serves to provide slightly clearer documentation to the already informative work provided by the library.