### PR TITLE
Fixed clippy warning: needlless_borrow.

### DIFF
--- a/src/event/source.rs
+++ b/src/event/source.rs
@@ -121,7 +121,7 @@ where
         token: Token,
         interests: Interest,
     ) -> io::Result<()> {
-        (&mut **self).register(registry, token, interests)
+        (**self).register(registry, token, interests)
     }
 
     fn reregister(
@@ -130,10 +130,10 @@ where
         token: Token,
         interests: Interest,
     ) -> io::Result<()> {
-        (&mut **self).reregister(registry, token, interests)
+        (**self).reregister(registry, token, interests)
     }
 
     fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
-        (&mut **self).deregister(registry)
+        (**self).deregister(registry)
     }
 }


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow.