### PR TITLE
Add networking for target_os = "wasi"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ miow   = "0.3.6"
 winapi = { version = "0.3", features = ["winsock2", "mswsock"] }
 ntapi  = "0.3"
 
+[target.'cfg(target_os = "wasi")'.dependencies]
+wasi = "0.11.0"
+libc = "0.2.86"
+
 [dev-dependencies]
 env_logger = { version = "0.8.4", default-features = false }
 rand = "0.8"

--- a/src/io_source.rs
+++ b/src/io_source.rs
@@ -1,6 +1,8 @@
 use std::ops::{Deref, DerefMut};
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
+#[cfg(target_os = "wasi")]
+use std::os::wasi::io::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawSocket;
 #[cfg(debug_assertions)]
@@ -197,6 +199,44 @@ where
         #[cfg(debug_assertions)]
         self.selector_id.remove_association(_registry)?;
         self.state.deregister()
+    }
+}
+
+#[cfg(target_os = "wasi")]
+impl<T> event::Source for IoSource<T>
+where
+    T: AsRawFd,
+{
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        #[cfg(debug_assertions)]
+        self.selector_id.associate(registry)?;
+        registry
+            .selector()
+            .register(self.inner.as_raw_fd() as _, token, interests)
+    }
+
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        #[cfg(debug_assertions)]
+        self.selector_id.check_association(registry)?;
+        registry
+            .selector()
+            .reregister(self.inner.as_raw_fd() as _, token, interests)
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        #[cfg(debug_assertions)]
+        self.selector_id.remove_association(registry)?;
+        registry.selector().deregister(self.inner.as_raw_fd() as _)
     }
 }
 

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -1,13 +1,15 @@
 use std::net::{self, SocketAddr};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+#[cfg(target_os = "wasi")]
+use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
 use std::{fmt, io};
 
 use crate::io_source::IoSource;
 use crate::net::TcpStream;
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "wasi"))]
 use crate::sys::tcp::set_reuseaddr;
 use crate::sys::tcp::{bind, listen, new_for_addr};
 use crate::{event, sys, Interest, Registry, Token};
@@ -54,7 +56,7 @@ impl TcpListener {
     /// 4. Calls `listen` on the socket to prepare it to receive new connections.
     pub fn bind(addr: SocketAddr) -> io::Result<TcpListener> {
         let socket = new_for_addr(addr)?;
-        #[cfg(unix)]
+        #[cfg(any(unix, target_os = "wasi"))]
         let listener = unsafe { TcpListener::from_raw_fd(socket) };
         #[cfg(windows)]
         let listener = unsafe { TcpListener::from_raw_socket(socket as _) };
@@ -213,5 +215,32 @@ impl FromRawSocket for TcpListener {
     /// non-blocking mode.
     unsafe fn from_raw_socket(socket: RawSocket) -> TcpListener {
         TcpListener::from_std(FromRawSocket::from_raw_socket(socket))
+    }
+}
+
+#[cfg(target_os = "wasi")]
+impl IntoRawFd for TcpListener {
+    fn into_raw_fd(self) -> RawFd {
+        self.inner.into_inner().into_raw_fd()
+    }
+}
+
+#[cfg(target_os = "wasi")]
+impl AsRawFd for TcpListener {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.as_raw_fd()
+    }
+}
+
+#[cfg(target_os = "wasi")]
+impl FromRawFd for TcpListener {
+    /// Converts a `RawFd` to a `TcpListener`.
+    ///
+    /// # Notes
+    ///
+    /// The caller is responsible for ensuring that the socket is in
+    /// non-blocking mode.
+    unsafe fn from_raw_fd(fd: RawFd) -> TcpListener {
+        TcpListener::from_std(FromRawFd::from_raw_fd(fd))
     }
 }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -3,6 +3,8 @@ use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::{self, Shutdown, SocketAddr};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+#[cfg(target_os = "wasi")]
+use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
 
@@ -75,7 +77,7 @@ impl TcpStream {
     /// [read interest]: Interest::READABLE
     pub fn connect(addr: SocketAddr) -> io::Result<TcpStream> {
         let socket = new_for_addr(addr)?;
-        #[cfg(unix)]
+        #[cfg(any(unix, target_os = "wasi"))]
         let stream = unsafe { TcpStream::from_raw_fd(socket) };
         #[cfg(windows)]
         let stream = unsafe { TcpStream::from_raw_socket(socket as _) };
@@ -330,5 +332,32 @@ impl FromRawSocket for TcpStream {
     /// non-blocking mode.
     unsafe fn from_raw_socket(socket: RawSocket) -> TcpStream {
         TcpStream::from_std(FromRawSocket::from_raw_socket(socket))
+    }
+}
+
+#[cfg(target_os = "wasi")]
+impl IntoRawFd for TcpStream {
+    fn into_raw_fd(self) -> RawFd {
+        self.inner.into_inner().into_raw_fd()
+    }
+}
+
+#[cfg(target_os = "wasi")]
+impl AsRawFd for TcpStream {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.as_raw_fd()
+    }
+}
+
+#[cfg(target_os = "wasi")]
+impl FromRawFd for TcpStream {
+    /// Converts a `RawFd` to a `TcpStream`.
+    ///
+    /// # Notes
+    ///
+    /// The caller is responsible for ensuring that the socket is in
+    /// non-blocking mode.
+    unsafe fn from_raw_fd(fd: RawFd) -> TcpStream {
+        TcpStream::from_std(FromRawFd::from_raw_fd(fd))
     }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -16,6 +16,8 @@ use std::net;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+#[cfg(target_os = "wasi")]
+use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
 
@@ -631,5 +633,32 @@ impl FromRawSocket for UdpSocket {
     /// non-blocking mode.
     unsafe fn from_raw_socket(socket: RawSocket) -> UdpSocket {
         UdpSocket::from_std(FromRawSocket::from_raw_socket(socket))
+    }
+}
+
+#[cfg(target_os = "wasi")]
+impl IntoRawFd for UdpSocket {
+    fn into_raw_fd(self) -> RawFd {
+        self.inner.into_inner().into_raw_fd()
+    }
+}
+
+#[cfg(target_os = "wasi")]
+impl AsRawFd for UdpSocket {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.as_raw_fd()
+    }
+}
+
+#[cfg(target_os = "wasi")]
+impl FromRawFd for UdpSocket {
+    /// Converts a `RawFd` to a `UdpSocket`.
+    ///
+    /// # Notes
+    ///
+    /// The caller is responsible for ensuring that the socket is in
+    /// non-blocking mode.
+    unsafe fn from_raw_fd(fd: RawFd) -> UdpSocket {
+        UdpSocket::from_std(FromRawFd::from_raw_fd(fd))
     }
 }

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -63,6 +63,12 @@ cfg_os_poll! {
     pub use self::windows::*;
 }
 
+#[cfg(target_os = "wasi")]
+cfg_os_poll! {
+    mod wasi;
+    pub(crate) use self::wasi::*;
+}
+
 cfg_not_os_poll! {
     mod shell;
     pub(crate) use self::shell::*;

--- a/src/sys/wasi/mod.rs
+++ b/src/sys/wasi/mod.rs
@@ -22,6 +22,12 @@ use std::time::Duration;
 
 use crate::{Interest, Token};
 
+cfg_net! {
+    mod net;
+
+    pub(crate) use net::{tcp, udp};
+}
+
 /// Unique id for use as `SelectorId`.
 #[cfg(debug_assertions)]
 static NEXT_ID: AtomicUsize = AtomicUsize::new(1);

--- a/src/sys/wasi/mod.rs
+++ b/src/sys/wasi/mod.rs
@@ -1,0 +1,369 @@
+//! # Notes
+//!
+//! The current implementation is somewhat limited. The `Waker` is not
+//! implemented, as at the time of writing there is no way to support to wake-up
+//! a thread from calling `poll_oneoff`.
+//!
+//! Furthermore the (re/de)register functions also don't work while concurrently
+//! polling as both registering and polling requires a lock on the
+//! `subscriptions`.
+//!
+//! Finally `Selector::try_clone`, required by `Registry::try_clone`, doesn't
+//! work. However this could be implemented by use of an `Arc`.
+//!
+//! In summary, this only (barely) works using a single thread.
+
+use std::cmp::min;
+use std::io;
+#[cfg(debug_assertions)]
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::{Interest, Token};
+
+/// Unique id for use as `SelectorId`.
+#[cfg(debug_assertions)]
+static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
+
+pub(crate) struct Selector {
+    #[cfg(debug_assertions)]
+    id: usize,
+    /// Subscriptions (reads events) we're interested in.
+    subscriptions: Arc<Mutex<Vec<wasi::Subscription>>>,
+    #[cfg(debug_assertions)]
+    has_waker: AtomicBool,
+}
+
+impl Selector {
+    pub(crate) fn new() -> io::Result<Selector> {
+        Ok(Selector {
+            #[cfg(debug_assertions)]
+            id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+            subscriptions: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(debug_assertions)]
+            has_waker: AtomicBool::new(false),
+        })
+    }
+
+    #[cfg(debug_assertions)]
+    pub(crate) fn id(&self) -> usize {
+        self.id
+    }
+
+    pub(crate) fn try_clone(&self) -> io::Result<Selector> {
+        Ok(Selector {
+            #[cfg(debug_assertions)]
+            id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+            #[cfg(debug_assertions)]
+            has_waker: AtomicBool::new(false),
+            subscriptions: self.subscriptions.clone(),
+        })
+    }
+
+    pub(crate) fn select(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<()> {
+        events.clear();
+
+        let mut subscriptions = self.subscriptions.lock().unwrap();
+
+        // If we want to a use a timeout in the `wasi_poll_oneoff()` function
+        // we need another subscription to the list.
+        if let Some(timeout) = timeout {
+            subscriptions.push(timeout_subscription(timeout));
+        }
+
+        // `poll_oneoff` needs the same number of events as subscriptions.
+        let length = subscriptions.len();
+        events.reserve(length);
+
+        debug_assert!(events.capacity() >= length);
+
+        let res = unsafe { wasi::poll_oneoff(subscriptions.as_ptr(), events.as_mut_ptr(), length) };
+
+        // Remove the timeout subscription we possibly added above.
+        if timeout.is_some() {
+            let timeout_sub = subscriptions.pop();
+            debug_assert_eq!(
+                timeout_sub.unwrap().u.tag,
+                wasi::EVENTTYPE_CLOCK.raw(),
+                "failed to remove timeout subscription"
+            );
+        }
+
+        drop(subscriptions); // Unlock.
+
+        match res {
+            Ok(n_events) => {
+                // Safety: `poll_oneoff` initialises the `events` for us.
+                unsafe { events.set_len(n_events) };
+
+                // Remove the timeout event.
+                if timeout.is_some() {
+                    if let Some(index) = events.iter().position(is_timeout_event) {
+                        events.swap_remove(index);
+                    }
+                }
+
+                check_errors(&events)
+            }
+            Err(err) => Err(io_err(err)),
+        }
+    }
+
+    pub(crate) fn register(
+        &self,
+        fd: wasi::Fd,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        let mut subscriptions = self.subscriptions.lock().unwrap();
+
+        // Cannot subscribe to read and write at the same time.
+        if interests.is_writable() {
+            let subscription = wasi::Subscription {
+                userdata: token.0 as wasi::Userdata,
+                u: wasi::SubscriptionU {
+                    tag: wasi::EVENTTYPE_FD_WRITE.raw(),
+                    u: wasi::SubscriptionUU {
+                        fd_write: wasi::SubscriptionFdReadwrite {
+                            file_descriptor: fd,
+                        },
+                    },
+                },
+            };
+            subscriptions.push(subscription);
+        } else if interests.is_readable() {
+            let subscription = wasi::Subscription {
+                userdata: token.0 as wasi::Userdata,
+                u: wasi::SubscriptionU {
+                    tag: wasi::EVENTTYPE_FD_READ.raw(),
+                    u: wasi::SubscriptionUU {
+                        fd_read: wasi::SubscriptionFdReadwrite {
+                            file_descriptor: fd,
+                        },
+                    },
+                },
+            };
+            subscriptions.push(subscription);
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn reregister(
+        &self,
+        fd: wasi::Fd,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        self.deregister(fd)
+            .and_then(|()| self.register(fd, token, interests))
+    }
+
+    pub(crate) fn deregister(&self, fd: wasi::Fd) -> io::Result<()> {
+        let mut subscriptions = self.subscriptions.lock().unwrap();
+
+        let predicate = |subscription: &wasi::Subscription| {
+            // Safety: `subscription.u.tag` defines the type of the union in
+            // `subscription.u.u`.
+            match subscription.u.tag {
+                t if t == wasi::EVENTTYPE_FD_WRITE.raw() => unsafe {
+                    subscription.u.u.fd_write.file_descriptor == fd
+                },
+                t if t == wasi::EVENTTYPE_FD_READ.raw() => unsafe {
+                    subscription.u.u.fd_read.file_descriptor == fd
+                },
+                _ => false,
+            }
+        };
+        if let Some(index) = subscriptions.iter().position(predicate) {
+            subscriptions.swap_remove(index);
+            // We might have two subscriptions (read and write).
+            if let Some(index) = subscriptions.iter().skip(index).position(predicate) {
+                subscriptions.swap_remove(index);
+            }
+            Ok(())
+        } else {
+            Err(io::ErrorKind::NotFound.into())
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    pub(crate) fn register_waker(&self) -> bool {
+        self.has_waker.swap(true, Ordering::AcqRel)
+    }
+}
+
+/// Token used to a add a timeout subscription, also used in removing it again.
+const TIMEOUT_TOKEN: wasi::Userdata = wasi::Userdata::max_value();
+
+/// Returns a `wasi::Subscription` for `timeout`.
+fn timeout_subscription(timeout: Duration) -> wasi::Subscription {
+    wasi::Subscription {
+        userdata: TIMEOUT_TOKEN,
+        u: wasi::SubscriptionU {
+            tag: wasi::EVENTTYPE_CLOCK.raw(),
+            u: wasi::SubscriptionUU {
+                clock: wasi::SubscriptionClock {
+                    id: wasi::CLOCKID_MONOTONIC,
+                    // Timestamp is in nanoseconds.
+                    timeout: min(wasi::Timestamp::MAX as u128, timeout.as_nanos())
+                        as wasi::Timestamp,
+                    // Give the implementation another millisecond to coalesce
+                    // events.
+                    precision: Duration::from_millis(1).as_nanos() as wasi::Timestamp,
+                    // Zero means the `timeout` is considered relative to the
+                    // current time.
+                    flags: 0,
+                },
+            },
+        },
+    }
+}
+
+fn is_timeout_event(event: &wasi::Event) -> bool {
+    event.type_ == wasi::EVENTTYPE_CLOCK && event.userdata == TIMEOUT_TOKEN
+}
+
+/// Check all events for possible errors, it returns the first error found.
+fn check_errors(events: &[Event]) -> io::Result<()> {
+    for event in events {
+        if event.error != wasi::ERRNO_SUCCESS {
+            return Err(io_err(event.error));
+        }
+    }
+    Ok(())
+}
+
+/// Convert `wasi::Errno` into an `io::Error`.
+fn io_err(errno: wasi::Errno) -> io::Error {
+    // TODO: check if this is valid.
+    io::Error::from_raw_os_error(errno.raw() as i32)
+}
+
+pub(crate) type Events = Vec<Event>;
+
+pub(crate) type Event = wasi::Event;
+
+pub(crate) mod event {
+    use std::fmt;
+
+    use crate::sys::Event;
+    use crate::Token;
+
+    pub(crate) fn token(event: &Event) -> Token {
+        Token(event.userdata as usize)
+    }
+
+    pub(crate) fn is_readable(event: &Event) -> bool {
+        event.type_ == wasi::EVENTTYPE_FD_READ
+    }
+
+    pub(crate) fn is_writable(event: &Event) -> bool {
+        event.type_ == wasi::EVENTTYPE_FD_WRITE
+    }
+
+    pub(crate) fn is_error(_: &Event) -> bool {
+        // Not supported? It could be that `wasi::Event.error` could be used for
+        // this, but the docs say `error that occurred while processing the
+        // subscription request`, so it's checked in `Select::select` already.
+        false
+    }
+
+    pub(crate) fn is_read_closed(event: &Event) -> bool {
+        event.type_ == wasi::EVENTTYPE_FD_READ
+            // Safety: checked the type of the union above.
+            && (event.fd_readwrite.flags & wasi::EVENTRWFLAGS_FD_READWRITE_HANGUP) != 0
+    }
+
+    pub(crate) fn is_write_closed(event: &Event) -> bool {
+        event.type_ == wasi::EVENTTYPE_FD_WRITE
+            // Safety: checked the type of the union above.
+            && (event.fd_readwrite.flags & wasi::EVENTRWFLAGS_FD_READWRITE_HANGUP) != 0
+    }
+
+    pub(crate) fn is_priority(_: &Event) -> bool {
+        // Not supported.
+        false
+    }
+
+    pub(crate) fn is_aio(_: &Event) -> bool {
+        // Not supported.
+        false
+    }
+
+    pub(crate) fn is_lio(_: &Event) -> bool {
+        // Not supported.
+        false
+    }
+
+    pub(crate) fn debug_details(f: &mut fmt::Formatter<'_>, event: &Event) -> fmt::Result {
+        debug_detail!(
+            TypeDetails(wasi::Eventtype),
+            PartialEq::eq,
+            wasi::EVENTTYPE_CLOCK,
+            wasi::EVENTTYPE_FD_READ,
+            wasi::EVENTTYPE_FD_WRITE,
+        );
+
+        #[allow(clippy::trivially_copy_pass_by_ref)]
+        fn check_flag(got: &wasi::Eventrwflags, want: &wasi::Eventrwflags) -> bool {
+            (got & want) != 0
+        }
+        debug_detail!(
+            EventrwflagsDetails(wasi::Eventrwflags),
+            check_flag,
+            wasi::EVENTRWFLAGS_FD_READWRITE_HANGUP,
+        );
+
+        struct EventFdReadwriteDetails(wasi::EventFdReadwrite);
+
+        impl fmt::Debug for EventFdReadwriteDetails {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct("EventFdReadwrite")
+                    .field("nbytes", &self.0.nbytes)
+                    .field("flags", &self.0.flags)
+                    .finish()
+            }
+        }
+
+        f.debug_struct("Event")
+            .field("userdata", &event.userdata)
+            .field("error", &event.error)
+            .field("type", &TypeDetails(event.type_))
+            .field("fd_readwrite", &EventFdReadwriteDetails(event.fd_readwrite))
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Waker {}
+
+impl Waker {
+    pub(crate) fn new(_: &Selector, _: Token) -> io::Result<Waker> {
+        Ok(Waker {})
+    }
+
+    pub(crate) fn wake(&self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+cfg_io_source! {
+    pub(crate) struct IoSourceState;
+
+    impl IoSourceState {
+        pub(crate) fn new() -> IoSourceState {
+            IoSourceState
+        }
+
+        pub(crate) fn do_io<T, F, R>(&self, f: F, io: &T) -> io::Result<R>
+        where
+            F: FnOnce(&T) -> io::Result<R>,
+        {
+            // We don't hold state, so we can just call the function and
+            // return.
+            f(io)
+        }
+    }
+}

--- a/src/sys/wasi/net.rs
+++ b/src/sys/wasi/net.rs
@@ -1,0 +1,60 @@
+#![allow(dead_code)]
+
+use std::io;
+
+/// A lot of function are not support on Wasi, this function returns a
+/// consistent error when calling those functions.
+fn unsupported() -> io::Error {
+    io::Error::new(io::ErrorKind::Other, "not supported on wasi")
+}
+
+pub(crate) mod tcp {
+    use std::io;
+    use std::net;
+
+    use super::unsupported;
+
+    pub type TcpSocket = wasi::Fd;
+
+    pub(crate) fn new_for_addr(_address: net::SocketAddr) -> io::Result<i32> {
+        Err(unsupported())
+    }
+
+    pub(crate) fn bind(_: &net::TcpListener, _: net::SocketAddr) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub(crate) fn connect(_: &net::TcpStream, _: net::SocketAddr) -> io::Result<net::TcpStream> {
+        Err(unsupported())
+    }
+
+    pub(crate) fn listen(_: &net::TcpListener, _: u32) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub(crate) fn set_reuseaddr(_: &net::TcpListener, _: bool) -> io::Result<()> {
+        Ok(())
+    }
+    pub(crate) fn accept(
+        listener: &net::TcpListener,
+    ) -> io::Result<(net::TcpStream, net::SocketAddr)> {
+        let res = listener.accept();
+        res
+    }
+}
+
+pub(crate) mod udp {
+    use std::io;
+    use std::net::{self, SocketAddr};
+    use std::os::wasi::io::FromRawFd;
+
+    //use super::unsupported;
+
+    pub(crate) fn bind(_: SocketAddr) -> io::Result<net::UdpSocket> {
+        Ok(unsafe { net::UdpSocket::from_raw_fd(0) })
+    }
+
+    pub(crate) fn only_v6(_socket: &net::UdpSocket) -> io::Result<bool> {
+        Ok(false)
+    }
+}


### PR DESCRIPTION
With

* https://github.com/bytecodealliance/wasmtime/pull/3711
* https://github.com/rust-lang/rust/pull/93158

merged, mio can have limited support for tcp networking for the `wasm32-wasi` target.
