### PR TITLE
Add TCP networking for target_os = "wasi"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,5 +81,9 @@ name = "tcp_server"
 required-features = ["os-poll", "net"]
 
 [[example]]
+name = "tcp_listenfd_server"
+required-features = ["os-poll", "net"]
+
+[[example]]
 name = "udp_server"
 required-features = ["os-poll", "net"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ miow   = "0.3.6"
 winapi = { version = "0.3", features = ["winsock2", "mswsock"] }
 ntapi  = "0.3"
 
+[target.'cfg(target_os = "wasi")'.dependencies]
+wasi = "0.11.0"
+libc = "0.2.86"
+
 [dev-dependencies]
 env_logger = { version = "0.8.4", default-features = false }
 rand = "0.8"

--- a/examples/tcp_listenfd_server.rs
+++ b/examples/tcp_listenfd_server.rs
@@ -1,0 +1,210 @@
+// You can run this example from the root of the mio repo:
+// cargo run --example tcp_listenfd_server --features="os-poll net"
+// or with wasi:
+// cargo +nightly build --target wasm32-wasi  --example tcp_listenfd_server --features="os-poll net"
+// wasmtime run --tcplisten 127.0.0.1:9000 --env 'LISTEN_FDS=1' target/wasm32-wasi/debug/examples/tcp_server.wasm
+
+use mio::event::Event;
+use mio::net::{TcpListener, TcpStream};
+use mio::{Events, Interest, Poll, Registry, Token};
+use std::collections::HashMap;
+use std::io::{self, Read, Write};
+use std::str::from_utf8;
+
+// Setup some tokens to allow us to identify which event is for which socket.
+const SERVER: Token = Token(0);
+
+// Some data we'll send over the connection.
+const DATA: &[u8] = b"Hello world!\n";
+
+#[cfg(not(windows))]
+fn get_first_listen_fd_listener() -> Option<std::net::TcpListener> {
+    #[cfg(unix)]
+    use std::os::unix::io::FromRawFd;
+    #[cfg(target_os = "wasi")]
+    use std::os::wasi::io::FromRawFd;
+
+    let stdlistener = unsafe { std::net::TcpListener::from_raw_fd(3) };
+    stdlistener.set_nonblocking(true).unwrap();
+    Some(stdlistener)
+}
+
+#[cfg(windows)]
+fn get_first_listen_fd_listener() -> Option<std::net::TcpListener> {
+    // Windows does not support `LISTEN_FDS`
+    None
+}
+
+fn main() -> io::Result<()> {
+    env_logger::init();
+
+    std::env::var("LISTEN_FDS").expect("LISTEN_FDS environment variable unset");
+
+    // Create a poll instance.
+    let mut poll = Poll::new()?;
+    // Create storage for events.
+    let mut events = Events::with_capacity(128);
+
+    // Setup the TCP server socket.
+    let mut server = {
+        let stdlistener = get_first_listen_fd_listener().unwrap();
+        stdlistener.set_nonblocking(true)?;
+        println!("Using preopened socket FD 3");
+        println!("You can connect to the server using `nc`:");
+        match stdlistener.local_addr() {
+            Ok(a) => println!(" $ nc {} {}", a.ip(), a.port()),
+            Err(_) => println!(" $ nc <IP> <PORT>"),
+        }
+        println!("You'll see our welcome message and anything you type will be printed here.");
+        TcpListener::from_std(stdlistener)
+    };
+
+    // Register the server with poll we can receive events for it.
+    poll.registry()
+        .register(&mut server, SERVER, Interest::READABLE)?;
+
+    // Map of `Token` -> `TcpStream`.
+    let mut connections = HashMap::new();
+    // Unique token for each incoming connection.
+    let mut unique_token = Token(SERVER.0 + 1);
+
+    loop {
+        poll.poll(&mut events, None)?;
+
+        for event in events.iter() {
+            match event.token() {
+                SERVER => loop {
+                    // Received an event for the TCP server socket, which
+                    // indicates we can accept an connection.
+                    let (mut connection, address) = match server.accept() {
+                        Ok((connection, address)) => (connection, address),
+                        Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                            // If we get a `WouldBlock` error we know our
+                            // listener has no more incoming connections queued,
+                            // so we can return to polling and wait for some
+                            // more.
+                            break;
+                        }
+                        Err(e) => {
+                            // If it was any other kind of error, something went
+                            // wrong and we terminate with an error.
+                            return Err(e);
+                        }
+                    };
+
+                    println!("Accepted connection from: {}", address);
+
+                    let token = next(&mut unique_token);
+                    poll.registry()
+                        .register(&mut connection, token, Interest::WRITABLE)?;
+
+                    connections.insert(token, connection);
+                },
+                token => {
+                    // Maybe received an event for a TCP connection.
+                    let done = if let Some(connection) = connections.get_mut(&token) {
+                        handle_connection_event(poll.registry(), connection, event)?
+                    } else {
+                        // Sporadic events happen, we can safely ignore them.
+                        false
+                    };
+                    if done {
+                        if let Some(mut connection) = connections.remove(&token) {
+                            poll.registry().deregister(&mut connection)?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn next(current: &mut Token) -> Token {
+    let next = current.0;
+    current.0 += 1;
+    Token(next)
+}
+
+/// Returns `true` if the connection is done.
+fn handle_connection_event(
+    registry: &Registry,
+    connection: &mut TcpStream,
+    event: &Event,
+) -> io::Result<bool> {
+    if event.is_writable() {
+        // We can (maybe) write to the connection.
+        match connection.write(DATA) {
+            // We want to write the entire `DATA` buffer in a single go. If we
+            // write less we'll return a short write error (same as
+            // `io::Write::write_all` does).
+            Ok(n) if n < DATA.len() => return Err(io::ErrorKind::WriteZero.into()),
+            Ok(_) => {
+                // After we've written something we'll reregister the connection
+                // to only respond to readable events.
+                registry.reregister(connection, event.token(), Interest::READABLE)?
+            }
+            // Would block "errors" are the OS's way of saying that the
+            // connection is not actually ready to perform this I/O operation.
+            Err(ref err) if would_block(err) => {}
+            // Got interrupted (how rude!), we'll try again.
+            Err(ref err) if interrupted(err) => {
+                return handle_connection_event(registry, connection, event)
+            }
+            // Other errors we'll consider fatal.
+            Err(err) => return Err(err),
+        }
+    }
+
+    if event.is_readable() {
+        let mut connection_closed = false;
+        let mut received_data = vec![0; 4096];
+        let mut bytes_read = 0;
+        // We can (maybe) read from the connection.
+        loop {
+            match connection.read(&mut received_data[bytes_read..]) {
+                Ok(0) => {
+                    // Reading 0 bytes means the other side has closed the
+                    // connection or is done writing, then so are we.
+                    connection_closed = true;
+                    break;
+                }
+                Ok(n) => {
+                    bytes_read += n;
+                    if bytes_read == received_data.len() {
+                        received_data.resize(received_data.len() + 1024, 0);
+                    }
+                }
+                // Would block "errors" are the OS's way of saying that the
+                // connection is not actually ready to perform this I/O operation.
+                Err(ref err) if would_block(err) => break,
+                Err(ref err) if interrupted(err) => continue,
+                // Other errors we'll consider fatal.
+                Err(err) => return Err(err),
+            }
+        }
+
+        if bytes_read != 0 {
+            let received_data = &received_data[..bytes_read];
+            if let Ok(str_buf) = from_utf8(received_data) {
+                println!("Received data: {}", str_buf.trim_end());
+            } else {
+                println!("Received (none UTF-8) data: {:?}", received_data);
+            }
+        }
+
+        if connection_closed {
+            println!("Connection closed");
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn would_block(err: &io::Error) -> bool {
+    err.kind() == io::ErrorKind::WouldBlock
+}
+
+fn interrupted(err: &io::Error) -> bool {
+    err.kind() == io::ErrorKind::Interrupted
+}

--- a/examples/tcp_server.rs
+++ b/examples/tcp_server.rs
@@ -13,6 +13,7 @@ const SERVER: Token = Token(0);
 // Some data we'll send over the connection.
 const DATA: &[u8] = b"Hello world!\n";
 
+#[cfg(not(target_os = "wasi"))]
 fn main() -> io::Result<()> {
     env_logger::init();
 
@@ -180,4 +181,9 @@ fn would_block(err: &io::Error) -> bool {
 
 fn interrupted(err: &io::Error) -> bool {
     err.kind() == io::ErrorKind::Interrupted
+}
+
+#[cfg(target_os = "wasi")]
+fn main() {
+    panic!("can't bind to an address with wasi")
 }

--- a/examples/udp_server.rs
+++ b/examples/udp_server.rs
@@ -1,14 +1,16 @@
 // You can run this example from the root of the mio repo:
 // cargo run --example udp_server --features="os-poll net"
 use log::warn;
-use mio::net::UdpSocket;
 use mio::{Events, Interest, Poll, Token};
 use std::io;
 
 // A token to allow us to identify which event is for the `UdpSocket`.
 const UDP_SOCKET: Token = Token(0);
 
+#[cfg(not(target_os = "wasi"))]
 fn main() -> io::Result<()> {
+    use mio::net::UdpSocket;
+
     env_logger::init();
 
     // Create a poll instance.
@@ -19,6 +21,7 @@ fn main() -> io::Result<()> {
 
     // Setup the UDP socket.
     let addr = "127.0.0.1:9000".parse().unwrap();
+
     let mut socket = UdpSocket::bind(addr)?;
 
     // Register our socket with the token defined above and an interest in being
@@ -74,4 +77,9 @@ fn main() -> io::Result<()> {
             }
         }
     }
+}
+
+#[cfg(target_os = "wasi")]
+fn main() {
+    panic!("can't bind to an address with wasi")
 }

--- a/src/io_source.rs
+++ b/src/io_source.rs
@@ -1,6 +1,8 @@
 use std::ops::{Deref, DerefMut};
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
+#[cfg(target_os = "wasi")]
+use std::os::wasi::io::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawSocket;
 #[cfg(debug_assertions)]
@@ -197,6 +199,44 @@ where
         #[cfg(debug_assertions)]
         self.selector_id.remove_association(_registry)?;
         self.state.deregister()
+    }
+}
+
+#[cfg(target_os = "wasi")]
+impl<T> event::Source for IoSource<T>
+where
+    T: AsRawFd,
+{
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        #[cfg(debug_assertions)]
+        self.selector_id.associate(registry)?;
+        registry
+            .selector()
+            .register(self.inner.as_raw_fd() as _, token, interests)
+    }
+
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        #[cfg(debug_assertions)]
+        self.selector_id.check_association(registry)?;
+        registry
+            .selector()
+            .reregister(self.inner.as_raw_fd() as _, token, interests)
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        #[cfg(debug_assertions)]
+        self.selector_id.remove_association(registry)?;
+        registry.selector().deregister(self.inner.as_raw_fd() as _)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ mod interest;
 mod poll;
 mod sys;
 mod token;
+#[cfg(not(target_os = "wasi"))]
 mod waker;
 
 pub mod event;
@@ -65,6 +66,7 @@ pub use event::Events;
 pub use interest::Interest;
 pub use poll::{Poll, Registry};
 pub use token::Token;
+#[cfg(not(target_os = "wasi"))]
 pub use waker::Waker;
 
 #[cfg(all(unix, feature = "os-ext"))]

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -28,7 +28,9 @@
 mod tcp;
 pub use self::tcp::{TcpListener, TcpStream};
 
+#[cfg(not(target_os = "wasi"))]
 mod udp;
+#[cfg(not(target_os = "wasi"))]
 pub use self::udp::UdpSocket;
 
 #[cfg(unix)]

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -1,6 +1,8 @@
 use std::net::{self, SocketAddr};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+#[cfg(target_os = "wasi")]
+use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
 use std::{fmt, io};
@@ -9,6 +11,7 @@ use crate::io_source::IoSource;
 use crate::net::TcpStream;
 #[cfg(unix)]
 use crate::sys::tcp::set_reuseaddr;
+#[cfg(not(target_os = "wasi"))]
 use crate::sys::tcp::{bind, listen, new_for_addr};
 use crate::{event, sys, Interest, Registry, Token};
 
@@ -52,6 +55,7 @@ impl TcpListener {
     /// 2. Set the `SO_REUSEADDR` option on the socket on Unix.
     /// 3. Bind the socket to the specified address.
     /// 4. Calls `listen` on the socket to prepare it to receive new connections.
+    #[cfg(not(target_os = "wasi"))]
     pub fn bind(addr: SocketAddr) -> io::Result<TcpListener> {
         let socket = new_for_addr(addr)?;
         #[cfg(unix)]
@@ -213,5 +217,32 @@ impl FromRawSocket for TcpListener {
     /// non-blocking mode.
     unsafe fn from_raw_socket(socket: RawSocket) -> TcpListener {
         TcpListener::from_std(FromRawSocket::from_raw_socket(socket))
+    }
+}
+
+#[cfg(target_os = "wasi")]
+impl IntoRawFd for TcpListener {
+    fn into_raw_fd(self) -> RawFd {
+        self.inner.into_inner().into_raw_fd()
+    }
+}
+
+#[cfg(target_os = "wasi")]
+impl AsRawFd for TcpListener {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.as_raw_fd()
+    }
+}
+
+#[cfg(target_os = "wasi")]
+impl FromRawFd for TcpListener {
+    /// Converts a `RawFd` to a `TcpListener`.
+    ///
+    /// # Notes
+    ///
+    /// The caller is responsible for ensuring that the socket is in
+    /// non-blocking mode.
+    unsafe fn from_raw_fd(fd: RawFd) -> TcpListener {
+        TcpListener::from_std(FromRawFd::from_raw_fd(fd))
     }
 }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -635,6 +635,7 @@ impl Registry {
     ///
     /// Event sources registered with this `Registry` will be registered with
     /// the original `Registry` and `Poll` instance.
+    #[cfg(not(target_os = "wasi"))]
     pub fn try_clone(&self) -> io::Result<Registry> {
         self.selector
             .try_clone()
@@ -643,7 +644,7 @@ impl Registry {
 
     /// Internal check to ensure only a single `Waker` is active per [`Poll`]
     /// instance.
-    #[cfg(debug_assertions)]
+    #[cfg(all(debug_assertions, not(target_os = "wasi")))]
     pub(crate) fn register_waker(&self) {
         assert!(
             !self.selector.register_waker(),
@@ -652,6 +653,7 @@ impl Registry {
     }
 
     /// Get access to the `sys::Selector`.
+    #[cfg(any(not(target_os = "wasi"), feature = "net"))]
     pub(crate) fn selector(&self) -> &sys::Selector {
         &self.selector
     }

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -63,6 +63,12 @@ cfg_os_poll! {
     pub use self::windows::*;
 }
 
+#[cfg(target_os = "wasi")]
+cfg_os_poll! {
+    mod wasi;
+    pub(crate) use self::wasi::*;
+}
+
 cfg_not_os_poll! {
     mod shell;
     pub(crate) use self::shell::*;

--- a/src/sys/shell/mod.rs
+++ b/src/sys/shell/mod.rs
@@ -7,7 +7,9 @@ macro_rules! os_required {
 mod selector;
 pub(crate) use self::selector::{event, Event, Events, Selector};
 
+#[cfg(not(target_os = "wasi"))]
 mod waker;
+#[cfg(not(target_os = "wasi"))]
 pub(crate) use self::waker::Waker;
 
 cfg_net! {

--- a/src/sys/shell/selector.rs
+++ b/src/sys/shell/selector.rs
@@ -11,6 +11,7 @@ pub type Events = Vec<Event>;
 pub struct Selector {}
 
 impl Selector {
+    #[cfg(not(target_os = "wasi"))]
     pub fn try_clone(&self) -> io::Result<Selector> {
         os_required!();
     }
@@ -19,7 +20,7 @@ impl Selector {
         os_required!();
     }
 
-    #[cfg(debug_assertions)]
+    #[cfg(all(debug_assertions, not(target_os = "wasi")))]
     pub fn register_waker(&self) -> bool {
         os_required!();
     }
@@ -39,6 +40,25 @@ cfg_any_os_ext! {
         }
 
         pub fn deregister(&self, _: RawFd) -> io::Result<()> {
+            os_required!();
+        }
+    }
+}
+
+#[cfg(target_os = "wasi")]
+cfg_any_os_ext! {
+    use crate::{Interest, Token};
+
+    impl Selector {
+        pub fn register(&self, _: wasi::Fd, _: Token, _: Interest) -> io::Result<()> {
+            os_required!();
+        }
+
+        pub fn reregister(&self, _: wasi::Fd, _: Token, _: Interest) -> io::Result<()> {
+            os_required!();
+        }
+
+        pub fn deregister(&self, _: wasi::Fd) -> io::Result<()> {
             os_required!();
         }
     }

--- a/src/sys/shell/tcp.rs
+++ b/src/sys/shell/tcp.rs
@@ -1,18 +1,22 @@
 use std::io;
 use std::net::{self, SocketAddr};
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn new_for_addr(_: SocketAddr) -> io::Result<i32> {
     os_required!();
 }
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn bind(_: &net::TcpListener, _: SocketAddr) -> io::Result<()> {
     os_required!();
 }
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn connect(_: &net::TcpStream, _: SocketAddr) -> io::Result<()> {
     os_required!();
 }
 
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn listen(_: &net::TcpListener, _: u32) -> io::Result<()> {
     os_required!();
 }

--- a/src/sys/shell/udp.rs
+++ b/src/sys/shell/udp.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "wasi"))]
 use std::io;
 use std::net::{self, SocketAddr};
 

--- a/src/sys/wasi/mod.rs
+++ b/src/sys/wasi/mod.rs
@@ -1,0 +1,356 @@
+//! # Notes
+//!
+//! The current implementation is somewhat limited. The `Waker` is not
+//! implemented, as at the time of writing there is no way to support to wake-up
+//! a thread from calling `poll_oneoff`.
+//!
+//! Furthermore the (re/de)register functions also don't work while concurrently
+//! polling as both registering and polling requires a lock on the
+//! `subscriptions`.
+//!
+//! Finally `Selector::try_clone`, required by `Registry::try_clone`, doesn't
+//! work. However this could be implemented by use of an `Arc`.
+//!
+//! In summary, this only (barely) works using a single thread.
+
+use std::cmp::min;
+use std::io;
+#[cfg(all(feature = "net", debug_assertions))]
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[cfg(feature = "net")]
+use crate::{Interest, Token};
+
+cfg_net! {
+    pub(crate) mod tcp {
+        use std::io;
+        use std::net::{self, SocketAddr};
+
+        pub(crate) fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream, SocketAddr)> {
+            let (stream, addr) = listener.accept()?;
+            stream.set_nonblocking(true)?;
+            Ok((stream, addr))
+        }
+    }
+}
+
+/// Unique id for use as `SelectorId`.
+#[cfg(all(debug_assertions, feature = "net"))]
+static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
+
+pub(crate) struct Selector {
+    #[cfg(all(debug_assertions, feature = "net"))]
+    id: usize,
+    /// Subscriptions (reads events) we're interested in.
+    subscriptions: Arc<Mutex<Vec<wasi::Subscription>>>,
+}
+
+impl Selector {
+    pub(crate) fn new() -> io::Result<Selector> {
+        Ok(Selector {
+            #[cfg(all(debug_assertions, feature = "net"))]
+            id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+            subscriptions: Arc::new(Mutex::new(Vec::new())),
+        })
+    }
+
+    #[cfg(all(debug_assertions, feature = "net"))]
+    pub(crate) fn id(&self) -> usize {
+        self.id
+    }
+
+    pub(crate) fn select(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<()> {
+        events.clear();
+
+        let mut subscriptions = self.subscriptions.lock().unwrap();
+
+        // If we want to a use a timeout in the `wasi_poll_oneoff()` function
+        // we need another subscription to the list.
+        if let Some(timeout) = timeout {
+            subscriptions.push(timeout_subscription(timeout));
+        }
+
+        // `poll_oneoff` needs the same number of events as subscriptions.
+        let length = subscriptions.len();
+        events.reserve(length);
+
+        debug_assert!(events.capacity() >= length);
+
+        let res = unsafe { wasi::poll_oneoff(subscriptions.as_ptr(), events.as_mut_ptr(), length) };
+
+        // Remove the timeout subscription we possibly added above.
+        if timeout.is_some() {
+            let timeout_sub = subscriptions.pop();
+            debug_assert_eq!(
+                timeout_sub.unwrap().u.tag,
+                wasi::EVENTTYPE_CLOCK.raw(),
+                "failed to remove timeout subscription"
+            );
+        }
+
+        drop(subscriptions); // Unlock.
+
+        match res {
+            Ok(n_events) => {
+                // Safety: `poll_oneoff` initialises the `events` for us.
+                unsafe { events.set_len(n_events) };
+
+                // Remove the timeout event.
+                if timeout.is_some() {
+                    if let Some(index) = events.iter().position(is_timeout_event) {
+                        events.swap_remove(index);
+                    }
+                }
+
+                check_errors(&events)
+            }
+            Err(err) => Err(io_err(err)),
+        }
+    }
+
+    #[cfg(feature = "net")]
+    pub(crate) fn register(
+        &self,
+        fd: wasi::Fd,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        let mut subscriptions = self.subscriptions.lock().unwrap();
+
+        if interests.is_writable() {
+            let subscription = wasi::Subscription {
+                userdata: token.0 as wasi::Userdata,
+                u: wasi::SubscriptionU {
+                    tag: wasi::EVENTTYPE_FD_WRITE.raw(),
+                    u: wasi::SubscriptionUU {
+                        fd_write: wasi::SubscriptionFdReadwrite {
+                            file_descriptor: fd,
+                        },
+                    },
+                },
+            };
+            subscriptions.push(subscription);
+        }
+
+        if interests.is_readable() {
+            let subscription = wasi::Subscription {
+                userdata: token.0 as wasi::Userdata,
+                u: wasi::SubscriptionU {
+                    tag: wasi::EVENTTYPE_FD_READ.raw(),
+                    u: wasi::SubscriptionUU {
+                        fd_read: wasi::SubscriptionFdReadwrite {
+                            file_descriptor: fd,
+                        },
+                    },
+                },
+            };
+            subscriptions.push(subscription);
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "net")]
+    pub(crate) fn reregister(
+        &self,
+        fd: wasi::Fd,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        self.deregister(fd)
+            .and_then(|()| self.register(fd, token, interests))
+    }
+
+    #[cfg(feature = "net")]
+    pub(crate) fn deregister(&self, fd: wasi::Fd) -> io::Result<()> {
+        let mut subscriptions = self.subscriptions.lock().unwrap();
+
+        let predicate = |subscription: &wasi::Subscription| {
+            // Safety: `subscription.u.tag` defines the type of the union in
+            // `subscription.u.u`.
+            match subscription.u.tag {
+                t if t == wasi::EVENTTYPE_FD_WRITE.raw() => unsafe {
+                    subscription.u.u.fd_write.file_descriptor == fd
+                },
+                t if t == wasi::EVENTTYPE_FD_READ.raw() => unsafe {
+                    subscription.u.u.fd_read.file_descriptor == fd
+                },
+                _ => false,
+            }
+        };
+
+        let mut ret = Err(io::ErrorKind::NotFound.into());
+
+        while let Some(index) = subscriptions.iter().position(predicate) {
+            subscriptions.swap_remove(index);
+            ret = Ok(())
+        }
+
+        ret
+    }
+}
+
+/// Token used to a add a timeout subscription, also used in removing it again.
+const TIMEOUT_TOKEN: wasi::Userdata = wasi::Userdata::max_value();
+
+/// Returns a `wasi::Subscription` for `timeout`.
+fn timeout_subscription(timeout: Duration) -> wasi::Subscription {
+    wasi::Subscription {
+        userdata: TIMEOUT_TOKEN,
+        u: wasi::SubscriptionU {
+            tag: wasi::EVENTTYPE_CLOCK.raw(),
+            u: wasi::SubscriptionUU {
+                clock: wasi::SubscriptionClock {
+                    id: wasi::CLOCKID_MONOTONIC,
+                    // Timestamp is in nanoseconds.
+                    timeout: min(wasi::Timestamp::MAX as u128, timeout.as_nanos())
+                        as wasi::Timestamp,
+                    // Give the implementation another millisecond to coalesce
+                    // events.
+                    precision: Duration::from_millis(1).as_nanos() as wasi::Timestamp,
+                    // Zero means the `timeout` is considered relative to the
+                    // current time.
+                    flags: 0,
+                },
+            },
+        },
+    }
+}
+
+fn is_timeout_event(event: &wasi::Event) -> bool {
+    event.type_ == wasi::EVENTTYPE_CLOCK && event.userdata == TIMEOUT_TOKEN
+}
+
+/// Check all events for possible errors, it returns the first error found.
+fn check_errors(events: &[Event]) -> io::Result<()> {
+    for event in events {
+        if event.error != wasi::ERRNO_SUCCESS {
+            return Err(io_err(event.error));
+        }
+    }
+    Ok(())
+}
+
+/// Convert `wasi::Errno` into an `io::Error`.
+fn io_err(errno: wasi::Errno) -> io::Error {
+    // TODO: check if this is valid.
+    io::Error::from_raw_os_error(errno.raw() as i32)
+}
+
+pub(crate) type Events = Vec<Event>;
+
+pub(crate) type Event = wasi::Event;
+
+pub(crate) mod event {
+    use std::fmt;
+
+    use crate::sys::Event;
+    use crate::Token;
+
+    pub(crate) fn token(event: &Event) -> Token {
+        Token(event.userdata as usize)
+    }
+
+    pub(crate) fn is_readable(event: &Event) -> bool {
+        event.type_ == wasi::EVENTTYPE_FD_READ
+    }
+
+    pub(crate) fn is_writable(event: &Event) -> bool {
+        event.type_ == wasi::EVENTTYPE_FD_WRITE
+    }
+
+    pub(crate) fn is_error(_: &Event) -> bool {
+        // Not supported? It could be that `wasi::Event.error` could be used for
+        // this, but the docs say `error that occurred while processing the
+        // subscription request`, so it's checked in `Select::select` already.
+        false
+    }
+
+    pub(crate) fn is_read_closed(event: &Event) -> bool {
+        event.type_ == wasi::EVENTTYPE_FD_READ
+            // Safety: checked the type of the union above.
+            && (event.fd_readwrite.flags & wasi::EVENTRWFLAGS_FD_READWRITE_HANGUP) != 0
+    }
+
+    pub(crate) fn is_write_closed(event: &Event) -> bool {
+        event.type_ == wasi::EVENTTYPE_FD_WRITE
+            // Safety: checked the type of the union above.
+            && (event.fd_readwrite.flags & wasi::EVENTRWFLAGS_FD_READWRITE_HANGUP) != 0
+    }
+
+    pub(crate) fn is_priority(_: &Event) -> bool {
+        // Not supported.
+        false
+    }
+
+    pub(crate) fn is_aio(_: &Event) -> bool {
+        // Not supported.
+        false
+    }
+
+    pub(crate) fn is_lio(_: &Event) -> bool {
+        // Not supported.
+        false
+    }
+
+    pub(crate) fn debug_details(f: &mut fmt::Formatter<'_>, event: &Event) -> fmt::Result {
+        debug_detail!(
+            TypeDetails(wasi::Eventtype),
+            PartialEq::eq,
+            wasi::EVENTTYPE_CLOCK,
+            wasi::EVENTTYPE_FD_READ,
+            wasi::EVENTTYPE_FD_WRITE,
+        );
+
+        #[allow(clippy::trivially_copy_pass_by_ref)]
+        fn check_flag(got: &wasi::Eventrwflags, want: &wasi::Eventrwflags) -> bool {
+            (got & want) != 0
+        }
+        debug_detail!(
+            EventrwflagsDetails(wasi::Eventrwflags),
+            check_flag,
+            wasi::EVENTRWFLAGS_FD_READWRITE_HANGUP,
+        );
+
+        struct EventFdReadwriteDetails(wasi::EventFdReadwrite);
+
+        impl fmt::Debug for EventFdReadwriteDetails {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct("EventFdReadwrite")
+                    .field("nbytes", &self.0.nbytes)
+                    .field("flags", &self.0.flags)
+                    .finish()
+            }
+        }
+
+        f.debug_struct("Event")
+            .field("userdata", &event.userdata)
+            .field("error", &event.error)
+            .field("type", &TypeDetails(event.type_))
+            .field("fd_readwrite", &EventFdReadwriteDetails(event.fd_readwrite))
+            .finish()
+    }
+}
+
+cfg_os_poll! {
+    cfg_io_source! {
+        pub(crate) struct IoSourceState;
+
+        impl IoSourceState {
+            pub(crate) fn new() -> IoSourceState {
+                IoSourceState
+            }
+
+            pub(crate) fn do_io<T, F, R>(&self, f: F, io: &T) -> io::Result<R>
+            where
+                F: FnOnce(&T) -> io::Result<R>,
+            {
+                // We don't hold state, so we can just call the function and
+                // return.
+                f(io)
+            }
+        }
+    }
+}

--- a/tests/close_on_drop.rs
+++ b/tests/close_on_drop.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
 use std::io::Read;

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
 use std::time::Duration;

--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
 use std::net;

--- a/tests/registering.rs
+++ b/tests/registering.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
 use std::io::{self, Write};

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
 use std::io::{self, Read};

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
 use mio::net::{TcpListener, TcpStream};

--- a/tests/tcp_listener.rs
+++ b/tests/tcp_listener.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
 use mio::net::TcpListener;

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
 use log::{debug, info};

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,5 +1,6 @@
 // Not all functions are used by all tests.
 #![allow(dead_code, unused_macros)]
+#![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
 use std::mem::size_of;

--- a/tests/waker.rs
+++ b/tests/waker.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
 use mio::{Events, Poll, Token, Waker};


### PR DESCRIPTION
With

* https://github.com/bytecodealliance/wasmtime/pull/3711
* https://github.com/rust-lang/rust/pull/93158

merged, mio can have limited support for TCP networking for the `wasm32-wasi` target.

I also modified the `tcp_server` example.

```
$ cargo +nightly build --target wasm32-wasi --release --example tcp_server --features="os-poll net"
   Compiling cfg-if v1.0.0
   Compiling wasi v0.10.2+wasi-snapshot-preview1
   Compiling log v0.4.14
   Compiling libc v0.2.112
   Compiling ppv-lite86 v0.2.15
   Compiling wasi v0.11.0+wasi-snapshot-preview1
   Compiling getrandom v0.2.3
   Compiling rand_core v0.6.3
   Compiling env_logger v0.8.4
   Compiling rand_chacha v0.3.1
   Compiling mio v0.8.0 (/home/harald/git/mio)
   Compiling rand v0.8.4
    Finished release [optimized] target(s) in 2.92s

$ wasmtime run --tcplisten 127.0.0.1:9000 --env 'LISTEN_FDS=1' target/wasm32-wasi/release/examples/tcp_server.wasm
Using preopened socket FD 3
You can connect to the server using `nc`:
 $ nc <IP> <PORT>
You'll see our welcome message and anything you type will be printed here.
```