### PR TITLE
Release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 0.8.1
+
+## Added
+
+* Add `try_io` method to all I/O types (#1551). This execute a user defined I/O
+  closure while updating Mio's internal state ensuring that the I/O type
+  receives more events if it hits a WouldBlock error. This is added to the
+  following types:
+   * `TcpStream`
+   * `UdpSocket`
+   * `UnixDatagram`
+   * `UnixStream`
+   * `unix::pipe::Sender`
+   * `unix::pipe::Receiver`
+* Basic, experimental support for `wasm32-wasi` target (#1549). Note that a lot
+  of time type are still missing, e.g. the `Waker`, and may never be possible to
+  implement.
+
 # 0.8.0
 
 ## Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "mio"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create git tag
-version       = "0.8.0"
+version       = "0.8.1"
 license       = "MIT"
 authors       = [
   "Carl Lerche <me@carllerche.com>",


### PR DESCRIPTION
Adds two new features:
* `try_io` method to all I/O types (#1551).
* Basic, experimental support for `wasm32-wasi` target (#1549).

/cc @haraldh @npmccallum @masa-koz 