### PR TITLE
Replace miow, winapi, and ntapi with windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,12 @@ libc = "0.2.86"
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = ">=0.32, <=0.34"
 features = [
-  "Win32_Storage_FileSystem",        # Enables NtCreateFile
-  "Win32_Foundation",                # Basic types eg HANDLE
-  "Win32_Networking_WinSock",        # winsock2 types/functions
-  "Win32_System_IO",                 # IO types like OVERLAPPED etc
-  "Win32_System_WindowsProgramming", # General future used for various types/funcs
+  "Win32_Storage_FileSystem",         # Enables NtCreateFile
+  "Win32_Foundation",                 # Basic types eg HANDLE
+  "Win32_Networking_WinSock",         # winsock2 types/functions
+  "Win32_NetworkManagement_IpHelper", # AF_INET and AF_INET6 constants
+  "Win32_System_IO",                  # IO types like OVERLAPPED etc
+  "Win32_System_WindowsProgramming",  # General future used for various types/funcs
 ]
 
 [target.'cfg(target_os = "wasi")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ log = "0.4.8"
 libc = "0.2.86"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.34"
+version = ">=0.32, <=0.34"
 features = [
   "Win32_Storage_FileSystem",        # Enables NtCreateFile
   "Win32_Foundation",                # Basic types eg HANDLE

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,11 @@ default = []
 # Enables the `Poll` and `Registry` types.
 os-poll = []
 # Enables additional OS specific extensions, e.g. Unix `pipe(2)`.
-os-ext = ["os-poll", "windows-sys/Win32_System_Pipes"]
+os-ext = [
+  "os-poll",
+  "windows-sys/Win32_System_Pipes",
+  "windows-sys/Win32_Security",
+]
 # Enables `mio::net` module containing networking primitives.
 net = []
 
@@ -44,11 +48,8 @@ log = "0.4.8"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.86"
 
-[target.'cfg(windows)'.dependencies]
-miow = "0.4"
-
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.28" # This matches the version in miow, but it's fairly outdated
+version = "0.34"
 features = [
   "Win32_Storage_FileSystem",        # Enables NtCreateFile
   "Win32_Foundation",                # Basic types eg HANDLE

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default = []
 # Enables the `Poll` and `Registry` types.
 os-poll = []
 # Enables additional OS specific extensions, e.g. Unix `pipe(2)`.
-os-ext = ["os-poll"]
+os-ext = ["os-poll", "windows-sys/Win32_System_Pipes"]
 # Enables `mio::net` module containing networking primitives.
 net = []
 
@@ -45,9 +45,17 @@ log = "0.4.8"
 libc = "0.2.86"
 
 [target.'cfg(windows)'.dependencies]
-miow   = "0.3.6"
-winapi = { version = "0.3", features = ["winsock2", "mswsock"] }
-ntapi  = "0.3"
+miow = "0.4"
+
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.28" # This matches the version in miow, but it's fairly outdated
+features = [
+  "Win32_Storage_FileSystem",        # Enables NtCreateFile
+  "Win32_Foundation",                # Basic types eg HANDLE
+  "Win32_Networking_WinSock",        # winsock2 types/functions
+  "Win32_System_IO",                 # IO types like OVERLAPPED etc
+  "Win32_System_WindowsProgramming", # General future used for various types/funcs
+]
 
 [target.'cfg(target_os = "wasi")'.dependencies]
 wasi = "0.11.0"

--- a/src/sys/windows/afd.rs
+++ b/src/sys/windows/afd.rs
@@ -14,9 +14,13 @@ use windows_sys::Win32::{
 
 const IOCTL_AFD_POLL: u32 = 0x00012024;
 
-// <https://processhacker.sourceforge.io/doc/ntioapi_8h.html#a0d4d550cad4d62d75b76961e25f6550c>
 #[link(name = "ntdll")]
 extern "system" {
+    /// See <https://processhacker.sourceforge.io/doc/ntioapi_8h.html#a0d4d550cad4d62d75b76961e25f6550c>
+    ///
+    /// This is an undocumented API and as such not part of <https://github.com/microsoft/win32metadata>
+    /// from which `windows-sys` is generated, and also unlikely to be added, so
+    /// we manually declare it here
     fn NtCancelIoFileEx(
         FileHandle: HANDLE,
         IoRequestToCancel: *mut IO_STATUS_BLOCK,

--- a/src/sys/windows/afd.rs
+++ b/src/sys/windows/afd.rs
@@ -14,7 +14,7 @@ use windows_sys::Win32::{
 
 const IOCTL_AFD_POLL: u32 = 0x00012024;
 
-/// <https://processhacker.sourceforge.io/doc/ntioapi_8h.html#a0d4d550cad4d62d75b76961e25f6550c>
+// <https://processhacker.sourceforge.io/doc/ntioapi_8h.html#a0d4d550cad4d62d75b76961e25f6550c>
 #[link(name = "ntdll")]
 extern "system" {
     fn NtCancelIoFileEx(

--- a/src/sys/windows/afd.rs
+++ b/src/sys/windows/afd.rs
@@ -4,7 +4,7 @@ use std::fs::File;
 use std::io;
 use std::mem::size_of;
 use std::os::windows::io::AsRawHandle;
-use std::ptr::null_mut;
+
 use windows_sys::Win32::{
     Foundation::{
         RtlNtStatusToDosError, HANDLE, NTSTATUS, STATUS_NOT_FOUND, STATUS_PENDING, STATUS_SUCCESS,
@@ -125,6 +125,7 @@ impl Afd {
 cfg_io_source! {
     use std::mem::zeroed;
     use std::os::windows::io::{FromRawHandle, RawHandle};
+    use std::ptr::null_mut;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::iocp::CompletionPort;

--- a/src/sys/windows/afd.rs
+++ b/src/sys/windows/afd.rs
@@ -5,11 +5,11 @@ use std::io;
 use std::mem::size_of;
 use std::os::windows::io::AsRawHandle;
 
-use windows_sys::Win32::{
-    Foundation::{
-        RtlNtStatusToDosError, HANDLE, NTSTATUS, STATUS_NOT_FOUND, STATUS_PENDING, STATUS_SUCCESS,
-    },
-    System::WindowsProgramming::{NtDeviceIoControlFile, IO_STATUS_BLOCK, IO_STATUS_BLOCK_0},
+use windows_sys::Win32::Foundation::{
+    RtlNtStatusToDosError, HANDLE, NTSTATUS, STATUS_NOT_FOUND, STATUS_PENDING, STATUS_SUCCESS,
+};
+use windows_sys::Win32::System::WindowsProgramming::{
+    NtDeviceIoControlFile, IO_STATUS_BLOCK, IO_STATUS_BLOCK_0,
 };
 
 const IOCTL_AFD_POLL: u32 = 0x00012024;

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -1,8 +1,7 @@
 use std::fmt;
 
-use super::iocp::CompletionStatus;
-
 use super::afd;
+use super::iocp::CompletionStatus;
 use crate::Token;
 
 #[derive(Clone)]

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use miow::iocp::CompletionStatus;
+use super::iocp::CompletionStatus;
 
 use super::afd;
 use crate::Token;

--- a/src/sys/windows/handle.rs
+++ b/src/sys/windows/handle.rs
@@ -1,0 +1,30 @@
+use std::os::windows::io::RawHandle;
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+
+/// Wrapper around a Windows HANDLE so that we close it upon drop in all scenarios
+#[derive(Debug)]
+pub struct Handle(HANDLE);
+
+impl Handle {
+    #[inline]
+    pub fn new(handle: HANDLE) -> Self {
+        Self(handle)
+    }
+
+    pub fn raw(&self) -> HANDLE {
+        self.0
+    }
+
+    pub fn into_raw(self) -> RawHandle {
+        let ret = self.0;
+        // This is super important so that drop is not called!
+        std::mem::forget(self);
+        ret as RawHandle
+    }
+}
+
+impl Drop for Handle {
+    fn drop(&mut self) {
+        unsafe { CloseHandle(self.0) };
+    }
+}

--- a/src/sys/windows/io_status_block.rs
+++ b/src/sys/windows/io_status_block.rs
@@ -1,17 +1,17 @@
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 
-use ntapi::ntioapi::IO_STATUS_BLOCK;
+use windows_sys::Win32::System::WindowsProgramming::IO_STATUS_BLOCK;
 
 pub struct IoStatusBlock(IO_STATUS_BLOCK);
 
 cfg_io_source! {
-    use ntapi::ntioapi::IO_STATUS_BLOCK_u;
+    use windows_sys::Win32::System::WindowsProgramming::{IO_STATUS_BLOCK_0};
 
     impl IoStatusBlock {
         pub fn zeroed() -> Self {
             Self(IO_STATUS_BLOCK {
-                u: IO_STATUS_BLOCK_u { Status: 0 },
+                Anonymous: IO_STATUS_BLOCK_0 { Status: 0 },
                 Information: 0,
             })
         }

--- a/src/sys/windows/iocp.rs
+++ b/src/sys/windows/iocp.rs
@@ -180,6 +180,7 @@ impl CompletionStatus {
     ///
     /// This method will wrap the `OVERLAPPED_ENTRY` in a `CompletionStatus`,
     /// returning the wrapped structure.
+    #[cfg(feature = "os-ext")]
     pub fn from_entry(entry: &OVERLAPPED_ENTRY) -> &Self {
         // Safety: CompletionStatus is repr(transparent) w/ OVERLAPPED_ENTRY, so
         // a reference to one is guaranteed to be layout compatible with the

--- a/src/sys/windows/iocp.rs
+++ b/src/sys/windows/iocp.rs
@@ -9,7 +9,7 @@ use std::os::windows::io::*;
 use std::time::Duration;
 
 use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
-use windows_sys::Win32System::IO::{
+use windows_sys::Win32::System::IO::{
     CreateIoCompletionPort, GetQueuedCompletionStatusEx, PostQueuedCompletionStatus, OVERLAPPED,
     OVERLAPPED_ENTRY,
 };

--- a/src/sys/windows/iocp.rs
+++ b/src/sys/windows/iocp.rs
@@ -1,0 +1,280 @@
+//! Bindings to IOCP, I/O Completion Ports
+
+use crate::sys::windows::Overlapped;
+use std::cmp;
+use std::fmt;
+use std::io;
+use std::mem;
+use std::os::windows::io::*;
+use std::time::Duration;
+
+use windows_sys::Win32::{
+    Foundation::{HANDLE, INVALID_HANDLE_VALUE},
+    System::IO::{
+        CreateIoCompletionPort, GetQueuedCompletionStatusEx, PostQueuedCompletionStatus,
+        OVERLAPPED, OVERLAPPED_ENTRY,
+    },
+};
+
+/// A handle to an Windows I/O Completion Port.
+#[derive(Debug)]
+pub(crate) struct CompletionPort {
+    handle: HANDLE,
+}
+
+/// A status message received from an I/O completion port.
+///
+/// These statuses can be created via the `new` or `empty` constructors and then
+/// provided to a completion port, or they are read out of a completion port.
+/// The fields of each status are read through its accessor methods.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct CompletionStatus(OVERLAPPED_ENTRY);
+
+impl fmt::Debug for CompletionStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CompletionStatus(OVERLAPPED_ENTRY)")
+    }
+}
+
+unsafe impl Send for CompletionStatus {}
+unsafe impl Sync for CompletionStatus {}
+
+impl CompletionPort {
+    /// Creates a new I/O completion port with the specified concurrency value.
+    ///
+    /// The number of threads given corresponds to the level of concurrency
+    /// allowed for threads associated with this port. Consult the Windows
+    /// documentation for more information about this value.
+    pub fn new(threads: u32) -> io::Result<CompletionPort> {
+        let ret = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, 0, 0, threads) };
+        if ret == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(CompletionPort { handle: ret })
+        }
+    }
+
+    /// Associates a new `HANDLE` to this I/O completion port.
+    ///
+    /// This function will associate the given handle to this port with the
+    /// given `token` to be returned in status messages whenever it receives a
+    /// notification.
+    ///
+    /// Any object which is convertible to a `HANDLE` via the `AsRawHandle`
+    /// trait can be provided to this function, such as `std::fs::File` and
+    /// friends.
+    pub fn add_handle<T: AsRawHandle + ?Sized>(&self, token: usize, t: &T) -> io::Result<()> {
+        self._add(token, t.as_raw_handle() as HANDLE)
+    }
+
+    // /// Associates a new `SOCKET` to this I/O completion port.
+    // ///
+    // /// This function will associate the given socket to this port with the
+    // /// given `token` to be returned in status messages whenever it receives a
+    // /// notification.
+    // ///
+    // /// Any object which is convertible to a `SOCKET` via the `AsRawSocket`
+    // /// trait can be provided to this function, such as `std::net::TcpStream`
+    // /// and friends.
+    // pub fn add_socket<T: AsRawSocket + ?Sized>(&self, token: usize, t: &T) -> io::Result<()> {
+    //     self._add(token, t.as_raw_socket() as HANDLE)
+    // }
+
+    fn _add(&self, token: usize, handle: HANDLE) -> io::Result<()> {
+        assert_eq!(mem::size_of_val(&token), mem::size_of::<usize>());
+        let ret = unsafe { CreateIoCompletionPort(handle, self.handle, token as usize, 0) };
+        if ret == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            debug_assert_eq!(ret, self.handle);
+            Ok(())
+        }
+    }
+
+    /// Dequeues a number of completion statuses from this I/O completion port.
+    ///
+    /// This function is the same as `get` except that it may return more than
+    /// one status. A buffer of "zero" statuses is provided (the contents are
+    /// not read) and then on success this function will return a sub-slice of
+    /// statuses which represent those which were dequeued from this port. This
+    /// function does not wait to fill up the entire list of statuses provided.
+    ///
+    /// Like with `get`, a timeout may be specified for this operation.
+    pub fn get_many<'a>(
+        &self,
+        list: &'a mut [CompletionStatus],
+        timeout: Option<Duration>,
+    ) -> io::Result<&'a mut [CompletionStatus]> {
+        debug_assert_eq!(
+            mem::size_of::<CompletionStatus>(),
+            mem::size_of::<OVERLAPPED_ENTRY>()
+        );
+        let mut removed = 0;
+        let timeout = duration_millis(timeout);
+        let len = cmp::min(list.len(), <u32>::max_value() as usize) as u32;
+        let ret = unsafe {
+            GetQueuedCompletionStatusEx(
+                self.handle,
+                list.as_ptr() as *mut _,
+                len,
+                &mut removed,
+                timeout,
+                0,
+            )
+        };
+
+        if ret == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(&mut list[..removed as usize])
+        }
+    }
+
+    /// Posts a new completion status onto this I/O completion port.
+    ///
+    /// This function will post the given status, with custom parameters, to the
+    /// port. Threads blocked in `get` or `get_many` will eventually receive
+    /// this status.
+    pub fn post(&self, status: CompletionStatus) -> io::Result<()> {
+        let ret = unsafe {
+            PostQueuedCompletionStatus(
+                self.handle,
+                status.0.dwNumberOfBytesTransferred,
+                status.0.lpCompletionKey,
+                status.0.lpOverlapped,
+            )
+        };
+
+        if ret == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl AsRawHandle for CompletionPort {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.handle as RawHandle
+    }
+}
+
+impl FromRawHandle for CompletionPort {
+    unsafe fn from_raw_handle(handle: RawHandle) -> CompletionPort {
+        CompletionPort {
+            handle: handle as HANDLE,
+        }
+    }
+}
+
+impl IntoRawHandle for CompletionPort {
+    fn into_raw_handle(self) -> RawHandle {
+        self.handle as RawHandle
+    }
+}
+
+impl CompletionStatus {
+    /// Creates a new completion status with the provided parameters.
+    ///
+    /// This function is useful when creating a status to send to a port with
+    /// the `post` method. The parameters are opaquely passed through and not
+    /// interpreted by the system at all.
+    pub(crate) fn new(bytes: u32, token: usize, overlapped: *mut Overlapped) -> Self {
+        CompletionStatus(OVERLAPPED_ENTRY {
+            dwNumberOfBytesTransferred: bytes,
+            lpCompletionKey: token,
+            lpOverlapped: overlapped as *mut _,
+            Internal: 0,
+        })
+    }
+
+    /// Creates a new borrowed completion status from the borrowed
+    /// `OVERLAPPED_ENTRY` argument provided.
+    ///
+    /// This method will wrap the `OVERLAPPED_ENTRY` in a `CompletionStatus`,
+    /// returning the wrapped structure.
+    pub fn from_entry(entry: &OVERLAPPED_ENTRY) -> &Self {
+        // Safety: CompletionStatus is repr(transparent) w/ OVERLAPPED_ENTRY, so
+        // a reference to one is guaranteed to be layout compatible with the
+        // reference to another.
+        unsafe { &*(entry as *const _ as *const _) }
+    }
+
+    /// Creates a new "zero" completion status.
+    ///
+    /// This function is useful when creating a stack buffer or vector of
+    /// completion statuses to be passed to the `get_many` function.
+    pub fn zero() -> Self {
+        Self::new(0, 0, std::ptr::null_mut())
+    }
+
+    /// Returns the number of bytes that were transferred for the I/O operation
+    /// associated with this completion status.
+    pub fn bytes_transferred(&self) -> u32 {
+        self.0.dwNumberOfBytesTransferred
+    }
+
+    /// Returns the completion key value associated with the file handle whose
+    /// I/O operation has completed.
+    ///
+    /// A completion key is a per-handle key that is specified when it is added
+    /// to an I/O completion port via `add_handle` or `add_socket`.
+    pub fn token(&self) -> usize {
+        self.0.lpCompletionKey as usize
+    }
+
+    /// Returns a pointer to the `Overlapped` structure that was specified when
+    /// the I/O operation was started.
+    pub fn overlapped(&self) -> *mut OVERLAPPED {
+        self.0.lpOverlapped
+    }
+
+    /// Returns a pointer to the internal `OVERLAPPED_ENTRY` object.
+    pub fn entry(&self) -> &OVERLAPPED_ENTRY {
+        &self.0
+    }
+}
+
+#[inline]
+fn duration_millis(dur: Option<Duration>) -> u32 {
+    if let Some(dur) = dur {
+        std::cmp::min(dur.as_millis(), u32::MAX as u128) as u32
+    } else {
+        u32::MAX
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CompletionPort, CompletionStatus};
+
+    #[test]
+    fn is_send_sync() {
+        fn is_send_sync<T: Send + Sync>() {}
+        is_send_sync::<CompletionPort>();
+    }
+
+    #[test]
+    fn get_many() {
+        let c = CompletionPort::new(1).unwrap();
+
+        c.post(CompletionStatus::new(1, 2, 3 as *mut _)).unwrap();
+        c.post(CompletionStatus::new(4, 5, 6 as *mut _)).unwrap();
+
+        let mut s = vec![CompletionStatus::zero(); 4];
+        {
+            let s = c.get_many(&mut s, None).unwrap();
+            assert_eq!(s.len(), 2);
+            assert_eq!(s[0].bytes_transferred(), 1);
+            assert_eq!(s[0].token(), 2);
+            assert_eq!(s[0].overlapped(), 3 as *mut _);
+            assert_eq!(s[1].bytes_transferred(), 4);
+            assert_eq!(s[1].token(), 5);
+            assert_eq!(s[1].overlapped(), 6 as *mut _);
+        }
+        assert_eq!(s[2].bytes_transferred(), 0);
+        assert_eq!(s[2].token(), 0);
+        assert_eq!(s[2].overlapped(), 0 as *mut _);
+    }
+}

--- a/src/sys/windows/iocp.rs
+++ b/src/sys/windows/iocp.rs
@@ -8,12 +8,10 @@ use std::mem;
 use std::os::windows::io::*;
 use std::time::Duration;
 
-use windows_sys::Win32::{
-    Foundation::{HANDLE, INVALID_HANDLE_VALUE},
-    System::IO::{
-        CreateIoCompletionPort, GetQueuedCompletionStatusEx, PostQueuedCompletionStatus,
-        OVERLAPPED, OVERLAPPED_ENTRY,
-    },
+use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
+use windows_sys::Win32System::IO::{
+    CreateIoCompletionPort, GetQueuedCompletionStatusEx, PostQueuedCompletionStatus, OVERLAPPED,
+    OVERLAPPED_ENTRY,
 };
 
 /// A handle to an Windows I/O Completion Port.

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -10,6 +10,8 @@ pub use selector::{Selector, SelectorInner, SockState};
 mod overlapped;
 use overlapped::Overlapped;
 
+mod iocp;
+
 // Macros must be defined before the modules that use them
 cfg_net! {
     /// Helper macro to execute a system call that returns an `io::Result`.

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1,16 +1,19 @@
 mod afd;
-mod io_status_block;
 
 pub mod event;
 pub use event::{Event, Events};
 
-mod selector;
-pub use selector::{Selector, SelectorInner, SockState};
+mod handle;
+use handle::Handle;
+
+mod io_status_block;
+mod iocp;
 
 mod overlapped;
 use overlapped::Overlapped;
 
-mod iocp;
+mod selector;
+pub use selector::{Selector, SelectorInner, SockState};
 
 // Macros must be defined before the modules that use them
 cfg_net! {

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -6,29 +6,24 @@ use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
 use std::{fmt, mem, slice};
 
-use windows_sys::Win32::{
-    Foundation::{
-        ERROR_BROKEN_PIPE, ERROR_IO_INCOMPLETE, ERROR_IO_PENDING, ERROR_NO_DATA,
-        ERROR_PIPE_CONNECTED, ERROR_PIPE_LISTENING, HANDLE, INVALID_HANDLE_VALUE,
-    },
-    Storage::FileSystem::{
-        ReadFile, WriteFile, FILE_FLAG_FIRST_PIPE_INSTANCE, FILE_FLAG_OVERLAPPED,
-        PIPE_ACCESS_DUPLEX,
-    },
-    System::{
-        Pipes::{
-            ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, PIPE_TYPE_BYTE,
-            PIPE_UNLIMITED_INSTANCES,
-        },
-        IO::{CancelIoEx, GetOverlappedResult, OVERLAPPED, OVERLAPPED_ENTRY},
-    },
+use windows_sys::Win32::Foundation::{
+    ERROR_BROKEN_PIPE, ERROR_IO_INCOMPLETE, ERROR_IO_PENDING, ERROR_NO_DATA, ERROR_PIPE_CONNECTED,
+    ERROR_PIPE_LISTENING, HANDLE, INVALID_HANDLE_VALUE,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    ReadFile, WriteFile, FILE_FLAG_FIRST_PIPE_INSTANCE, FILE_FLAG_OVERLAPPED, PIPE_ACCESS_DUPLEX,
+};
+use windows_sys::Win32::System::Pipes::{
+    ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, PIPE_TYPE_BYTE,
+    PIPE_UNLIMITED_INSTANCES,
+};
+use windows_sys::Win32::System::IO::{
+    CancelIoEx, GetOverlappedResult, OVERLAPPED, OVERLAPPED_ENTRY,
 };
 
 use crate::event::Source;
-use crate::sys::windows::{
-    iocp::{CompletionPort, CompletionStatus},
-    Event, Handle, Overlapped,
-};
+use crate::sys::windows::iocp::{CompletionPort, CompletionStatus};
+use crate::sys::windows::{Event, Handle, Overlapped};
 use crate::Registry;
 use crate::{Interest, Token};
 

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -8,9 +8,10 @@ use std::{fmt, mem, slice};
 
 use miow::iocp::{CompletionPort, CompletionStatus};
 use miow::pipe;
-use winapi::shared::winerror::{ERROR_BROKEN_PIPE, ERROR_PIPE_LISTENING};
-use winapi::um::ioapiset::CancelIoEx;
-use winapi::um::minwinbase::{OVERLAPPED, OVERLAPPED_ENTRY};
+use windows_sys::Win32::{
+    Foundation::{ERROR_BROKEN_PIPE, ERROR_PIPE_LISTENING},
+    System::IO::{CancelIoEx, OVERLAPPED, OVERLAPPED_ENTRY},
+};
 
 use crate::event::Source;
 use crate::sys::windows::{Event, Overlapped};

--- a/src/sys/windows/overlapped.rs
+++ b/src/sys/windows/overlapped.rs
@@ -4,8 +4,8 @@ use std::cell::UnsafeCell;
 use std::fmt;
 
 #[cfg(feature = "os-ext")]
-use winapi::um::minwinbase::OVERLAPPED;
-use winapi::um::minwinbase::OVERLAPPED_ENTRY;
+use windows_sys::Win32::System::IO::OVERLAPPED;
+use windows_sys::Win32::System::IO::OVERLAPPED_ENTRY;
 
 #[repr(C)]
 pub(crate) struct Overlapped {

--- a/src/sys/windows/overlapped.rs
+++ b/src/sys/windows/overlapped.rs
@@ -3,13 +3,11 @@ use crate::sys::windows::Event;
 use std::cell::UnsafeCell;
 use std::fmt;
 
-#[cfg(feature = "os-ext")]
-use windows_sys::Win32::System::IO::OVERLAPPED;
-use windows_sys::Win32::System::IO::OVERLAPPED_ENTRY;
+use windows_sys::Win32::System::IO::{OVERLAPPED, OVERLAPPED_ENTRY};
 
 #[repr(C)]
 pub(crate) struct Overlapped {
-    inner: UnsafeCell<miow::Overlapped>,
+    inner: UnsafeCell<OVERLAPPED>,
     pub(crate) callback: fn(&OVERLAPPED_ENTRY, Option<&mut Vec<Event>>),
 }
 
@@ -17,13 +15,13 @@ pub(crate) struct Overlapped {
 impl Overlapped {
     pub(crate) fn new(cb: fn(&OVERLAPPED_ENTRY, Option<&mut Vec<Event>>)) -> Overlapped {
         Overlapped {
-            inner: UnsafeCell::new(miow::Overlapped::zero()),
+            inner: UnsafeCell::new(unsafe { std::mem::zeroed() }),
             callback: cb,
         }
     }
 
     pub(crate) fn as_ptr(&self) -> *const OVERLAPPED {
-        unsafe { (*self.inner.get()).raw() }
+        self.inner.get()
     }
 }
 

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -10,7 +10,7 @@ cfg_net! {
     use crate::Interest;
 }
 
-use miow::iocp::{CompletionPort, CompletionStatus};
+use super::iocp::{CompletionPort, CompletionStatus};
 use std::collections::VecDeque;
 use std::ffi::c_void;
 use std::io;

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -538,6 +538,9 @@ cfg_io_source! {
 
     use windows_sys::Win32::Networking::WinSock::{WSAGetLastError, SOCKET_ERROR, WSAIoctl, IOC_OUT, IOC_WS2};
 
+    // These constants were part of winapi but are not yet in windows-sys
+    //
+    // https://github.com/microsoft/win32metadata/issues/844
     const SIO_BSP_HANDLE: u32 = IOC_OUT | IOC_WS2 | 27; // 1_207_959_579u32
     const SIO_BSP_HANDLE_SELECT: u32 = IOC_OUT | IOC_WS2 | 28; // 1_207_959_580u32
     const SIO_BSP_HANDLE_POLL: u32 = IOC_OUT | IOC_WS2 | 29; // 1_207_959_581u32

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -23,10 +23,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use windows_sys::Win32::{
-    Foundation::{ERROR_INVALID_HANDLE, ERROR_IO_PENDING, HANDLE, STATUS_CANCELLED, WAIT_TIMEOUT},
-    System::IO::OVERLAPPED,
+use windows_sys::Win32::Foundation::{
+    ERROR_INVALID_HANDLE, ERROR_IO_PENDING, HANDLE, STATUS_CANCELLED, WAIT_TIMEOUT,
 };
+use windows_sys::Win32::System::IO::OVERLAPPED;
 
 #[derive(Debug)]
 struct AfdGroup {

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -2,21 +2,21 @@ use std::io;
 use std::net::{self, SocketAddr};
 use std::os::windows::io::AsRawSocket;
 
-use winapi::um::winsock2::{self, PF_INET, PF_INET6, SOCKET, SOCKET_ERROR, SOCK_STREAM};
+use windows_sys::Win32::Networking::WinSock::{self, SOCKET, SOCKET_ERROR, SOCK_STREAM};
 
-use crate::sys::windows::net::{init, new_socket, socket_addr};
+use crate::sys::windows::net::{init, new_socket, socket_addr, AF_INET, AF_INET6};
 
 pub(crate) fn new_for_addr(address: SocketAddr) -> io::Result<SOCKET> {
     init();
     let domain = match address {
-        SocketAddr::V4(_) => PF_INET,
-        SocketAddr::V6(_) => PF_INET6,
+        SocketAddr::V4(_) => AF_INET,
+        SocketAddr::V6(_) => AF_INET6,
     };
     new_socket(domain, SOCK_STREAM)
 }
 
 pub(crate) fn bind(socket: &net::TcpListener, addr: SocketAddr) -> io::Result<()> {
-    use winsock2::bind;
+    use WinSock::bind;
 
     let (raw_addr, raw_addr_length) = socket_addr(&addr);
     syscall!(
@@ -32,7 +32,7 @@ pub(crate) fn bind(socket: &net::TcpListener, addr: SocketAddr) -> io::Result<()
 }
 
 pub(crate) fn connect(socket: &net::TcpStream, addr: SocketAddr) -> io::Result<()> {
-    use winsock2::connect;
+    use WinSock::connect;
 
     let (raw_addr, raw_addr_length) = socket_addr(&addr);
     let res = syscall!(
@@ -53,7 +53,7 @@ pub(crate) fn connect(socket: &net::TcpStream, addr: SocketAddr) -> io::Result<(
 
 pub(crate) fn listen(socket: &net::TcpListener, backlog: u32) -> io::Result<()> {
     use std::convert::TryInto;
-    use winsock2::listen;
+    use WinSock::listen;
 
     let backlog = backlog.try_into().unwrap_or(i32::max_value());
     syscall!(

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -2,14 +2,12 @@ use std::io;
 use std::mem::{self, MaybeUninit};
 use std::net::{self, SocketAddr};
 use std::os::windows::io::{AsRawSocket, FromRawSocket};
-use std::os::windows::raw::SOCKET as StdSocket; // winapi uses usize, stdlib uses u32/u64.
-
-use winapi::ctypes::c_int;
-use winapi::shared::ws2def::IPPROTO_IPV6;
-use winapi::shared::ws2ipdef::IPV6_V6ONLY;
-use winapi::um::winsock2::{bind as win_bind, closesocket, getsockopt, SOCKET_ERROR, SOCK_DGRAM};
+use std::os::windows::raw::SOCKET as StdSocket; // windows-sys uses usize, stdlib uses u32/u64.
 
 use crate::sys::windows::net::{init, new_ip_socket, socket_addr};
+use windows_sys::Win32::Networking::WinSock::{
+    bind as win_bind, closesocket, getsockopt, IPPROTO_IPV6, IPV6_V6ONLY, SOCKET_ERROR, SOCK_DGRAM,
+};
 
 pub fn bind(addr: SocketAddr) -> io::Result<net::UdpSocket> {
     init();
@@ -31,14 +29,14 @@ pub fn bind(addr: SocketAddr) -> io::Result<net::UdpSocket> {
 }
 
 pub(crate) fn only_v6(socket: &net::UdpSocket) -> io::Result<bool> {
-    let mut optval: MaybeUninit<c_int> = MaybeUninit::uninit();
-    let mut optlen = mem::size_of::<c_int>() as c_int;
+    let mut optval: MaybeUninit<i32> = MaybeUninit::uninit();
+    let mut optlen = mem::size_of::<i32>() as i32;
 
     syscall!(
         getsockopt(
             socket.as_raw_socket() as usize,
-            IPPROTO_IPV6 as c_int,
-            IPV6_V6ONLY as c_int,
+            IPPROTO_IPV6 as i32,
+            IPV6_V6ONLY as i32,
             optval.as_mut_ptr().cast(),
             &mut optlen,
         ),
@@ -46,7 +44,7 @@ pub(crate) fn only_v6(socket: &net::UdpSocket) -> io::Result<bool> {
         SOCKET_ERROR
     )?;
 
-    debug_assert_eq!(optlen as usize, mem::size_of::<c_int>());
+    debug_assert_eq!(optlen as usize, mem::size_of::<i32>());
     // Safety: `getsockopt` initialised `optval` for us.
     let optval = unsafe { optval.assume_init() };
     Ok(optval != 0)

--- a/src/sys/windows/waker.rs
+++ b/src/sys/windows/waker.rs
@@ -2,7 +2,7 @@ use crate::sys::windows::Event;
 use crate::sys::windows::Selector;
 use crate::Token;
 
-use miow::iocp::CompletionPort;
+use super::iocp::CompletionPort;
 use std::io;
 use std::sync::Arc;
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -263,9 +263,11 @@ pub fn set_linger_zero(socket: &TcpStream) {
 #[cfg(windows)]
 pub fn set_linger_zero(socket: &TcpStream) {
     use std::os::windows::io::AsRawSocket;
-    use winapi::um::winsock2::{linger, setsockopt, SOCKET_ERROR, SOL_SOCKET, SO_LINGER};
+    use windows_sys::Win32::Networking::WinSock::{
+        linger, setsockopt, SOCKET_ERROR, SOL_SOCKET, SO_LINGER,
+    };
 
-    let val = linger {
+    let mut val = linger {
         l_onoff: 1,
         l_linger: 0,
     };
@@ -273,9 +275,9 @@ pub fn set_linger_zero(socket: &TcpStream) {
     let res = unsafe {
         setsockopt(
             socket.as_raw_socket() as _,
-            SOL_SOCKET,
-            SO_LINGER,
-            &val as *const _ as *const _,
+            SOL_SOCKET as i32,
+            SO_LINGER as i32,
+            &mut val as *mut _ as *mut _,
             size_of::<linger>() as _,
         )
     };

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -9,8 +9,7 @@ use std::time::Duration;
 use mio::windows::NamedPipe;
 use mio::{Events, Interest, Poll, Token};
 use rand::Rng;
-use winapi::shared::winerror::*;
-use winapi::um::winbase::FILE_FLAG_OVERLAPPED;
+use windows_sys::Win32::{Foundation::ERROR_NO_DATA, Storage::FileSystem::FILE_FLAG_OVERLAPPED};
 
 fn _assert_kinds() {
     fn _assert_send<T: Send>() {}


### PR DESCRIPTION
This removes the dependency on `miow`, `winapi`, and `ntapi` in favor of just using `windows-sys` directly. A few types/functions from `miow` were copied, and added, namely the `Handle` wrapper (for `CloseHandle` dropping) and the `CompletionPort` and `CompletionStatus` types.

There was only a single function, `NtCancelIoFileEx` that was present in `ntapi` but not `windows-sys`, so I merely added the extern declaration in the one place it was used as it is not worth bringing in a dependency just for that.

Note this uses the latest `window-sys` version, but I think the version restriction can be loosened to `>=0.32` as (probably) the only actual relevant change for mio was the change of `HANDLE` from `*mut c_void` to `isize`. This is unfortunately a downside of the `windows-sys` crate, its minor version is bumped fairly frequently, but other than changes such as the one previously mentioned, most of those versions won't actually meaningfully affect mio's usage, and having an exact version requirement could mean duplicate versions of the `windows-sys` crates being used in downstream crates if they use a slightly newer version of it that is otherwise fully API compatible. Though of course the safest is to have `>=0.32, <=0.34` to avoid a minor version > 0.34 _actually_ having breaking changes for mio and downstream crates failing to compile unless they manually pin the version.