### PR TITLE
Don't ignore EAGAIN in UDS connect call

### DIFF
--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -75,6 +75,10 @@ impl TcpStream {
     ///     whent wrong.
     ///  5. Now the stream can be used.
     ///
+    /// This may return a `WouldBlock` in which case the socket connection
+    /// cannot be completed immediately, it usually means there are insufficient
+    /// entries in the routing cache.
+    ///
     /// [write interest]: Interest::WRITABLE
     #[cfg(not(target_os = "wasi"))]
     pub fn connect(addr: SocketAddr) -> io::Result<TcpStream> {

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -320,6 +320,10 @@ impl UdpSocket {
     /// Connects the UDP socket setting the default destination for `send()`
     /// and limiting packets that are read via `recv` from the address specified
     /// in `addr`.
+    ///
+    /// This may return a `WouldBlock` in which case the socket connection
+    /// cannot be completed immediately, it usually means there are insufficient
+    /// entries in the routing cache.
     pub fn connect(&self, addr: SocketAddr) -> io::Result<()> {
         self.inner.connect(addr)
     }

--- a/src/net/uds/datagram.rs
+++ b/src/net/uds/datagram.rs
@@ -22,8 +22,8 @@ impl UnixDatagram {
     ///
     /// This function is intended to be used to wrap a Unix datagram from the
     /// standard library in the Mio equivalent. The conversion assumes nothing
-    /// about the underlying datagram; ; it is left up to the user to set it
-    /// in non-blocking mode.
+    /// about the underlying datagram; it is left up to the user to set it in
+    /// non-blocking mode.
     pub fn from_std(socket: net::UnixDatagram) -> UnixDatagram {
         UnixDatagram {
             inner: IoSource::new(socket),
@@ -33,8 +33,7 @@ impl UnixDatagram {
     /// Connects the socket to the specified address.
     ///
     /// This may return a `WouldBlock` in which case the socket connection
-    /// cannot be completed immediately, it usually means there are insufficient
-    /// entries in the routing cache.
+    /// cannot be completed immediately.
     pub fn connect<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         self.inner.connect(path)
     }

--- a/src/net/uds/datagram.rs
+++ b/src/net/uds/datagram.rs
@@ -31,6 +31,10 @@ impl UnixDatagram {
     }
 
     /// Connects the socket to the specified address.
+    ///
+    /// This may return a `WouldBlock` in which case the socket connection
+    /// cannot be completed immediately, it usually means there are insufficient
+    /// entries in the routing cache.
     pub fn connect<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         self.inner.connect(path)
     }

--- a/src/net/uds/stream.rs
+++ b/src/net/uds/stream.rs
@@ -15,6 +15,9 @@ pub struct UnixStream {
 
 impl UnixStream {
     /// Connects to the socket named by `path`.
+    ///
+    /// This may return a `WouldBlock` in which case the socket connection
+    /// cannot be completed immediately.
     pub fn connect<P: AsRef<Path>>(path: P) -> io::Result<UnixStream> {
         sys::uds::stream::connect(path.as_ref()).map(UnixStream::from_std)
     }

--- a/src/net/uds/stream.rs
+++ b/src/net/uds/stream.rs
@@ -17,7 +17,7 @@ impl UnixStream {
     /// Connects to the socket named by `path`.
     ///
     /// This may return a `WouldBlock` in which case the socket connection
-    /// cannot be completed immediately.
+    /// cannot be completed immediately. Usually it means the backlog is full.
     pub fn connect<P: AsRef<Path>>(path: P) -> io::Result<UnixStream> {
         sys::uds::stream::connect(path.as_ref()).map(UnixStream::from_std)
     }

--- a/src/sys/unix/uds/stream.rs
+++ b/src/sys/unix/uds/stream.rs
@@ -13,7 +13,7 @@ pub(crate) fn connect(path: &Path) -> io::Result<net::UnixStream> {
 
     match syscall!(connect(socket, sockaddr, socklen)) {
         Ok(_) => {}
-        Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {}
+        Err(ref err) if err.raw_os_error() == Some(libc::EINPROGRESS) => {}
         Err(e) => {
             // Close the socket if we hit an error, ignoring the error
             // from closing since we can't pass back two errors.


### PR DESCRIPTION
Per the Linux manual:
> EAGAIN For nonblocking UNIX domain sockets, the socket is
>        nonblocking, and the connection cannot be completed
>        immediately.

Previously the code incorrectly assumed that the connection was now in
progress, which is incorrect. If that were the case EINPROGRESS
would/should be returned by the OS.

Also documents that connect calls can return a WouldBlock error.
This is a reflect of the Linux manual, which unfortunately doesn't
specify how to determine when the connect call should be retried.

Fixes #1560