### PR TITLE
Fix incorrect rustdoc for TcpStream::connect

### DIFF
--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -66,8 +66,8 @@ impl TcpStream {
     /// [here](https://github.com/Thomasdezeeuw/heph/blob/0c4f1ab3eaf08bea1d65776528bfd6114c9f8374/src/net/tcp/stream.rs#L560-L622).
     ///
     ///  1. Call `TcpStream::connect`
-    ///  2. Register the returned stream with at least [read interest].
-    ///  3. Wait for a (readable) event.
+    ///  2. Register the returned stream with at least [write interest].
+    ///  3. Wait for a (writable) event.
     ///  4. Check `TcpStream::peer_addr`. If it returns `libc::EINPROGRESS` or
     ///     `ErrorKind::NotConnected` it means the stream is not yet connected,
     ///     go back to step 3. If it returns an address it means the stream is
@@ -75,7 +75,7 @@ impl TcpStream {
     ///     whent wrong.
     ///  5. Now the stream can be used.
     ///
-    /// [read interest]: Interest::READABLE
+    /// [write interest]: Interest::WRITABLE
     #[cfg(not(target_os = "wasi"))]
     pub fn connect(addr: SocketAddr) -> io::Result<TcpStream> {
         let socket = new_for_addr(addr)?;


### PR DESCRIPTION
It is `Interest::WRITABLE` we should care about after non-blocking `TcpStream::connect`.

I find two manuals:
* https://man7.org/linux/man-pages/man2/connect.2.html EINPROGRESS

  > The socket is nonblocking and the connection cannot be
  > completed immediately.  (UNIX domain sockets failed with
  > EAGAIN instead.)  It is possible to [select(2)](https://man7.org/linux/man-pages/man2/select.2.html) or [poll(2)](https://man7.org/linux/man-pages/man2/poll.2.html)
  > for completion by selecting the socket for writing.  After
  > [select(2)](https://man7.org/linux/man-pages/man2/select.2.html) indicates writability, use [getsockopt(2)](https://man7.org/linux/man-pages/man2/getsockopt.2.html) to read
  > the SO_ERROR option at level SOL_SOCKET to determine
  > whether connect() completed successfully (SO_ERROR is
  > zero) or unsuccessfully (SO_ERROR is one of the usual
  > error codes listed here, explaining the reason for the
  > failure).

* https://www.freebsd.org/cgi/man.cgi?connect EINPROGRESS
   > The socket is non-blocking and the connection cannot be completed immediately.  It is possible to [select(2)](https://www.freebsd.org/cgi/man.cgi?query=select&sektion=2&apropos=0&manpath=FreeBSD+13.0-RELEASE+and+Ports) for completion by selecting the socket for writing.

I find two code usages:
* [TcpStream::connect_mio](https://github.com/tokio-rs/tokio/blob/2bb97db5e149260a09180e53195dc4c79db9c206/tokio/src/net/tcp/stream.rs#L137) from tokio.
  ```rust
    pub(crate) async fn connect_mio(sys: mio::net::TcpStream) -> io::Result<TcpStream> {
        let stream = TcpStream::new(sys)?;

        // Once we've connected, wait for the stream to be writable as
        // that's when the actual connection has been initiated. Once we're
        // writable we check for `take_socket_error` to see if the connect
        // actually hit an error or not.
        //
        // If all that succeeded then we ship everything on up.
        poll_fn(|cx| stream.io.registration().poll_write_ready(cx)).await?;

        if let Some(e) = stream.io.take_error()? {
            return Err(e);
        }

        Ok(stream)
    }
  ```
* [`uv__tcp_connect`](https://github.com/libuv/libuv/blob/69ebb2d720ac476248460e1fb3f0f3d10af483dc/src/unix/tcp.c#L253) from libuv.
  ```c
  uv__req_init(handle->loop, req, UV_CONNECT);
  req->cb = cb;
  req->handle = (uv_stream_t*) handle;
  QUEUE_INIT(&req->queue);
  handle->connect_req = req;

  uv__io_start(handle->loop, &handle->io_watcher, POLLOUT);

  if (handle->delayed_error)
    uv__io_feed(handle->loop, &handle->io_watcher);
 ```