### PR TITLE
macos: add mach port support

### DIFF
--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -173,6 +173,28 @@ impl Event {
         sys::event::is_aio(&self.inner)
     }
 
+    /// Returns true if the event contains mach port readiness.
+    ///
+    /// # Notes
+    ///
+    /// Method is available on all platforms, but not all platforms support mach ports.
+    ///
+    /// The table below shows what flags are checked on what OS.
+    ///
+    /// | [OS selector] | Flag(s) checked |
+    /// |---------------|-----------------|
+    /// | [epoll]       | *Not supported* |
+    /// | [kqueue]<sup>1</sup> | `EVFILT_MACHPORT` |
+    ///
+    /// 1: Only supported on MacOS.
+    ///
+    /// [OS selector]: ../struct.Poll.html#implementation-notes
+    /// [epoll]: http://man7.org/linux/man-pages/man7/epoll.7.html
+    /// [kqueue]: https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
+    pub fn is_mach_port(&self) -> bool {
+        sys::event::is_mach_port(&self.inner)
+    }
+
     /// Returns true if the event contains LIO readiness.
     ///
     /// # Notes
@@ -211,7 +233,8 @@ impl fmt::Debug for Event {
             .field("write_closed", &self.is_write_closed())
             .field("priority", &self.is_priority())
             .field("aio", &self.is_aio())
-            .field("lio", &self.is_lio());
+            .field("lio", &self.is_lio())
+            .field("mach", &self.is_mach_port());
 
         if alternate {
             struct EventDetails<'a>(&'a sys::Event);

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -184,9 +184,9 @@ impl Event {
     /// | [OS selector] | Flag(s) checked |
     /// |---------------|-----------------|
     /// | [epoll]       | *Not supported* |
-    /// | [kqueue]<sup>1</sup> | `EVFILT_MACHPORT` |
+    /// | [kqueue][^1] | `EVFILT_MACHPORT` |
     ///
-    /// 1: Only supported on MacOS.
+    /// [^1]: Only supported on MacOS.
     ///
     /// [OS selector]: ../struct.Poll.html#implementation-notes
     /// [epoll]: http://man7.org/linux/man-pages/man7/epoll.7.html

--- a/src/sys/shell/selector.rs
+++ b/src/sys/shell/selector.rs
@@ -122,6 +122,10 @@ pub mod event {
         os_required!();
     }
 
+    pub fn is_mach_port(_: &Event) -> bool {
+        os_required!();
+    }
+
     pub fn debug_details(_: &mut fmt::Formatter<'_>, _: &Event) -> fmt::Result {
         os_required!();
     }

--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -200,6 +200,11 @@ pub mod event {
         false
     }
 
+    pub fn is_mach_port(_: &Event) -> bool {
+        // not supported
+        false
+    }
+
     pub fn is_lio(_: &Event) -> bool {
         // Not supported.
         false

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -443,6 +443,19 @@ pub mod event {
         }
     }
 
+    #[allow(unused_variables)] // `event` is only used on MacOS.
+    pub fn is_mach_port(event: &Event) -> bool {
+        #[cfg(target_os = "macos")]
+        {
+            event.filter == libc::EVFILT_MACHPORT
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            false
+        }
+    }
+
+
     pub fn debug_details(f: &mut fmt::Formatter<'_>, event: &Event) -> fmt::Result {
         debug_detail!(
             FilterDetails(Filter),

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -455,7 +455,6 @@ pub mod event {
         }
     }
 
-
     pub fn debug_details(f: &mut fmt::Formatter<'_>, event: &Event) -> fmt::Result {
         debug_detail!(
             FilterDetails(Filter),

--- a/src/sys/wasi/mod.rs
+++ b/src/sys/wasi/mod.rs
@@ -295,6 +295,11 @@ pub(crate) mod event {
         false
     }
 
+    pub(crate) fn is_mach_port(_: &Event) -> bool {
+        // Not supported.
+        false
+    }
+
     pub(crate) fn debug_details(f: &mut fmt::Formatter<'_>, event: &Event) -> fmt::Result {
         debug_detail!(
             TypeDetails(wasi::Eventtype),

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -83,6 +83,11 @@ pub fn is_aio(_: &Event) -> bool {
     false
 }
 
+pub fn is_mach_port(_: &Event) -> bool {
+    // not supported
+    false
+}
+
 pub fn is_lio(_: &Event) -> bool {
     // Not supported.
     false


### PR DESCRIPTION
Adds support for mach ports, which are unfortunately used to drive many APIs on MacOS.