### PR TITLE
Update to windows-sys 0.36

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,12 +49,11 @@ log = "0.4.8"
 libc = "0.2.121"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = ">=0.32, <=0.34"
+version = "=0.36"
 features = [
   "Win32_Storage_FileSystem",         # Enables NtCreateFile
   "Win32_Foundation",                 # Basic types eg HANDLE
   "Win32_Networking_WinSock",         # winsock2 types/functions
-  "Win32_NetworkManagement_IpHelper", # AF_INET and AF_INET6 constants
   "Win32_System_IO",                  # IO types like OVERLAPPED etc
   "Win32_System_WindowsProgramming",  # General future used for various types/funcs
 ]

--- a/src/sys/windows/net.rs
+++ b/src/sys/windows/net.rs
@@ -4,14 +4,9 @@ use std::net::SocketAddr;
 use std::sync::Once;
 
 use windows_sys::Win32::Networking::WinSock::{
-    ioctlsocket, socket, FIONBIO, IN6_ADDR, IN6_ADDR_0, INVALID_SOCKET, IN_ADDR, IN_ADDR_0,
-    SOCKADDR, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_IN6_0, SOCKET,
+    ioctlsocket, socket, AF_INET, AF_INET6, FIONBIO, IN6_ADDR, IN6_ADDR_0, INVALID_SOCKET, IN_ADDR,
+    IN_ADDR_0, SOCKADDR, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_IN6_0, SOCKET,
 };
-// We need to import a giant feature set for these 2 constants, they will hopefully
-// be moved to `Win32::Networking::WinSock` in the future, since this needlessly
-// increases compile times for all downstream users
-// <https://github.com/microsoft/win32metadata/issues/845>
-pub(crate) use windows_sys::Win32::NetworkManagement::IpHelper::{AF_INET, AF_INET6};
 
 /// Initialise the network stack for Windows.
 pub(crate) fn init() {

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -536,15 +536,11 @@ cfg_io_source! {
     use std::mem::size_of;
     use std::ptr::null_mut;
 
-    use windows_sys::Win32::Networking::WinSock::{WSAGetLastError, SOCKET_ERROR, WSAIoctl, IOC_OUT, IOC_WS2};
+    use windows_sys::Win32::Networking::WinSock::{
+        WSAGetLastError, WSAIoctl, SIO_BASE_HANDLE, SIO_BSP_HANDLE,
+        SIO_BSP_HANDLE_POLL, SIO_BSP_HANDLE_SELECT, SOCKET_ERROR,
+    };
 
-    // These constants were part of winapi but are not yet in windows-sys
-    //
-    // https://github.com/microsoft/win32metadata/issues/844
-    const SIO_BSP_HANDLE: u32 = IOC_OUT | IOC_WS2 | 27; // 1_207_959_579u32
-    const SIO_BSP_HANDLE_SELECT: u32 = IOC_OUT | IOC_WS2 | 28; // 1_207_959_580u32
-    const SIO_BSP_HANDLE_POLL: u32 = IOC_OUT | IOC_WS2 | 29; // 1_207_959_581u32
-    const SIO_BASE_HANDLE: u32 = IOC_OUT | IOC_WS2 | 34; // 1_207_959_586u32
 
     impl SelectorInner {
         fn register(

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -2,9 +2,11 @@ use std::io;
 use std::net::{self, SocketAddr};
 use std::os::windows::io::AsRawSocket;
 
-use windows_sys::Win32::Networking::WinSock::{self, SOCKET, SOCKET_ERROR, SOCK_STREAM};
+use windows_sys::Win32::Networking::WinSock::{
+    self, AF_INET, AF_INET6, SOCKET, SOCKET_ERROR, SOCK_STREAM,
+};
 
-use crate::sys::windows::net::{init, new_socket, socket_addr, AF_INET, AF_INET6};
+use crate::sys::windows::net::{init, new_socket, socket_addr};
 
 pub(crate) fn new_for_addr(address: SocketAddr) -> io::Result<SOCKET> {
     init();


### PR DESCRIPTION
Removes the need for the Win32_NetworkManagement_IpHelper feature as
AF_INET and AF_INET6 are now included in the Win32_Networking_WinSock
feature.

Updates #1558