### PR TITLE
Relax windows-sys dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ log = "0.4.8"
 libc = "0.2.121"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "=0.36"
+version = "0.36"
 features = [
   "Win32_Storage_FileSystem",         # Enables NtCreateFile
   "Win32_Foundation",                 # Basic types eg HANDLE


### PR DESCRIPTION
Was this supposed to be set to 0.36 exactly or was that an oversight from #1569?