### PR TITLE
Future-proof the kevent ABI

### DIFF
--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -46,8 +46,6 @@ macro_rules! kevent {
             ident: $id as libc::uintptr_t,
             filter: $filter as Filter,
             flags: $flags,
-            fflags: 0,
-            data: 0,
             udata: $data as UData,
             ..unsafe { mem::zeroed() }
         }


### PR DESCRIPTION
FreeBSD 12 adds some new private fields to struct kevent, and it changes
the type of "data" from intptr_t to i64.  For now libc only binds the
11-compat ABI, but that will change some day.  Adjust mio's structure
definitions for compatibility with either ABI.

This should work on all 32 and 64 bit platforms.