### PR TITLE
Wasm32-wasi target support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = [
   "aarch64-apple-ios",
   "aarch64-linux-android",
+  "wasm32-wasi",
   "x86_64-apple-darwin",
   "x86_64-pc-windows-msvc",
   "x86_64-unknown-dragonfly",

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -635,7 +635,6 @@ impl Registry {
     ///
     /// Event sources registered with this `Registry` will be registered with
     /// the original `Registry` and `Poll` instance.
-    #[cfg(not(target_os = "wasi"))]
     pub fn try_clone(&self) -> io::Result<Registry> {
         self.selector
             .try_clone()

--- a/src/sys/shell/selector.rs
+++ b/src/sys/shell/selector.rs
@@ -11,7 +11,6 @@ pub type Events = Vec<Event>;
 pub struct Selector {}
 
 impl Selector {
-    #[cfg(not(target_os = "wasi"))]
     pub fn try_clone(&self) -> io::Result<Selector> {
         os_required!();
     }

--- a/src/sys/wasi/mod.rs
+++ b/src/sys/wasi/mod.rs
@@ -110,6 +110,13 @@ impl Selector {
         }
     }
 
+    pub(crate) fn try_clone(&self) -> io::Result<Selector> {
+        Ok(Selector {
+            id: self.id,
+            subscriptions: self.subscriptions.clone(),
+        })
+    }
+
     #[cfg(feature = "net")]
     pub(crate) fn register(
         &self,


### PR DESCRIPTION
I'm working on getting Tokio working on Rust, and some changes were needed for Mio.

Companion to https://github.com/tokio-rs/tokio/pull/4716

Signed-off-by: Richard Zak <richard@profian.com>