### PR TITLE
fix(wasi): don't fail select() on empty subscriptions

### DIFF
--- a/src/sys/wasi/mod.rs
+++ b/src/sys/wasi/mod.rs
@@ -72,6 +72,10 @@ impl Selector {
             subscriptions.push(timeout_subscription(timeout));
         }
 
+        if subscriptions.is_empty() {
+            return Ok(());
+        }
+
         // `poll_oneoff` needs the same number of events as subscriptions.
         let length = subscriptions.len();
         events.reserve(length);


### PR DESCRIPTION
return `Ok(())` rather than `Err(EINVAL)`

Signed-off-by: Harald Hoyer <harald@profian.com>