### PR TITLE
fix: don't `try_clone()` a debug-only field

### DIFF
--- a/src/sys/wasi/mod.rs
+++ b/src/sys/wasi/mod.rs
@@ -112,6 +112,7 @@ impl Selector {
 
     pub(crate) fn try_clone(&self) -> io::Result<Selector> {
         Ok(Selector {
+            #[cfg(all(debug_assertions, feature = "net"))]
             id: self.id,
             subscriptions: self.subscriptions.clone(),
         })


### PR DESCRIPTION
This allows `wasm32-wasi` targets to be built in release mode, and is a follow-up to https://github.com/tokio-rs/mio/pull/1576.

Signed-off-by: Richard Zak <richard@profian.com>