### PR TITLE
style(examples): use would_block and remove set_nonblocking

### DIFF
--- a/examples/tcp_listenfd_server.rs
+++ b/examples/tcp_listenfd_server.rs
@@ -48,7 +48,6 @@ fn main() -> io::Result<()> {
     // Setup the TCP server socket.
     let mut server = {
         let stdlistener = get_first_listen_fd_listener().unwrap();
-        stdlistener.set_nonblocking(true)?;
         println!("Using preopened socket FD 3");
         println!("You can connect to the server using `nc`:");
         match stdlistener.local_addr() {
@@ -78,7 +77,7 @@ fn main() -> io::Result<()> {
                     // indicates we can accept an connection.
                     let (mut connection, address) = match server.accept() {
                         Ok((connection, address)) => (connection, address),
-                        Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                        Err(ref e) if would_block(e) => {
                             // If we get a `WouldBlock` error we know our
                             // listener has no more incoming connections queued,
                             // so we can return to polling and wait for some


### PR DESCRIPTION
`set_nonblocking` has been invoked in `get_first_listen_fd_listener` function.