### PR TITLE
Update MSRV to 1.61 and edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 name = "mio"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
     parameters:
       name: minrust
       displayName: Min Rust
-      rust_version: 1.46.0
+      rust_version: 1.61.0
       cmd: check
       cross: true
 


### PR DESCRIPTION
For edition, I ran `cargo fix --edition` and updated `edition` in `Cargo.toml`.

Resolves #1562.