### PR TITLE
Switch to GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ overhead as possible over the OS abstractions.
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
-[![Build Status][azure-badge]][azure-url]
+[![Build Status][actions-badge]][actions-url]
 [![Build Status][cirrus-badge]][cirrus-url]
 
 [crates-badge]: https://img.shields.io/crates/v/mio.svg
 [crates-url]: https://crates.io/crates/mio
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
-[azure-badge]: https://dev.azure.com/tokio-rs/Tokio/_apis/build/status/tokio-rs.mio?branchName=master
-[azure-url]: https://dev.azure.com/tokio-rs/Tokio/_build/latest?definitionId=2&branchName=master
+[actions-badge]: https://github.com/tokio-rs/mio/workflows/CI/badge.svg
+[actions-url]: https://github.com/tokio-rs/mio/actions?query=workflow%3ACI+branch%3Amaster
 [cirrus-badge]: https://api.cirrus-ci.com/github/tokio-rs/mio.svg
 [cirrus-url]: https://cirrus-ci.com/github/tokio-rs/mio
 


### PR DESCRIPTION
Follow up to #1598. The badge changes were adapted from the Tokio Readme.