### PR TITLE
Fix path validation for abstract unix socket.

### DIFF
--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -48,6 +48,7 @@ cfg_os_poll! {
                     "path must be no longer than libc::sockaddr_un.sun_path",
                 ));
             }
+            (Some(&0), _) => {}
             (_, Ordering::Greater) | (_, Ordering::Equal) => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,


### PR DESCRIPTION
The validation of abstract unix socket is wrong, and I fixed it.
Look at the original validation [code](https://github.com/tokio-rs/mio/blob/d4cbf76f60d6472524dddd74746a861c79bf42c5/src/sys/unix/uds/mod.rs#L43):
```rust 
match (bytes.get(0), bytes.len().cmp(&sockaddr.sun_path.len())) {
    // Abstract paths don't need a null terminator
    (Some(&0), Ordering::Greater) => {
        return Err(io::Error::new(
            io::ErrorKind::InvalidInput,
            "path must be no longer than libc::sockaddr_un.sun_path",
        ));
    }
    (_, Ordering::Greater) | (_, Ordering::Equal) => {
        return Err(io::Error::new(
            io::ErrorKind::InvalidInput,
            "path must be shorter than libc::sockaddr_un.sun_path",
        ));
    }
    _ => {}
}
```
Abstract paths don't need a null terminator, so it's valid when it's no longer than the `libc::sockaddr_un.sun_path`. However, when the length of an abstract path equals to `sun_path`, `(Some(&0), Ordering::Equal)` will match on the second arm and will return an error.

I added the branch `(Some(&0), _) => {}` to accept such case.