### PR TITLE
Implement new I/O-safe traits on types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,8 @@ jobs:
         override: true
     - name: Check
       # We only run check allowing us to use newer features in tests.
-      run: cargo check --all-features
+      # notgull: exclude the io_safety feature since that requires 1.63
+      run: cargo check --features "os-ext,net"
   Nightly:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ os-ext = [
 ]
 # Enables `mio::net` module containing networking primitives.
 net = []
+# Implement I/O-safe traits on `mio` objects, like `AsFd`
+# Requires Rust 1.63.0
+io_safety = []
 
 [dependencies]
 log = "0.4.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,14 @@ pub mod features {
     #![cfg_attr(not(feature = "net"), doc = "## Network types (disabled)")]
     //!
     //! The `net` feature enables networking primitives in the `net` module.
+    //! 
+    #![cfg_attr(feature = "io_safety", doc = "## I/O Safety (enabled)")]
+    #![cfg_attr(not(feature = "io_safety"), doc = "## I/O Safety (disabled)")]
+    //! 
+    //! The `io_safety` feature adds the [`AsFd`] and [`AsSocket`] traits to
+    //! Mio types. These traits allow you to use Mio types using these I/O safe
+    //! traits. In addition, `From<OwnedFd> for ...` and `From<...> for OwnedFd`
+    //! is implemented for Mio types.
 }
 
 pub mod guide {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,14 +117,17 @@ pub mod features {
     #![cfg_attr(not(feature = "net"), doc = "## Network types (disabled)")]
     //!
     //! The `net` feature enables networking primitives in the `net` module.
-    //! 
+    //!
     #![cfg_attr(feature = "io_safety", doc = "## I/O Safety (enabled)")]
     #![cfg_attr(not(feature = "io_safety"), doc = "## I/O Safety (disabled)")]
-    //! 
+    //!
     //! The `io_safety` feature adds the [`AsFd`] and [`AsSocket`] traits to
     //! Mio types. These traits allow you to use Mio types using these I/O safe
     //! traits. In addition, `From<OwnedFd> for ...` and `From<...> for OwnedFd`
     //! is implemented for Mio types.
+    //!
+    //! [`AsFd`]: std::os::unix::io::AsFd
+    //! [`AsSocket`]: std::os::windows::io::AsSocket
 }
 
 pub mod guide {

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -1,16 +1,16 @@
 use std::net::{self, SocketAddr};
+#[cfg(all(feature = "io_safety", unix))]
+use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+#[cfg(all(feature = "io_safety", target_os = "wasi"))]
+use std::os::wasi::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(target_os = "wasi")]
 use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
-#[cfg(all(feature = "io_safety", unix))]
-use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(all(feature = "io_safety", windows))]
 use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
-#[cfg(all(feature = "io_safety", target_os = "wasi"))]
-use std::os::wasi::io::{AsFd, BorrowedFd, OwnedFd};
 use std::{fmt, io};
 
 use crate::io_source::IoSource;

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -8,7 +8,7 @@ use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket}
 #[cfg(all(feature = "io_safety", unix))]
 use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(all(feature = "io_safety", windows))]
-use std::os::windows::io::{AsRawSocket, BorrowedSocket, OwnedSocket};
+use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
 #[cfg(all(feature = "io_safety", target_os = "wasi"))]
 use std::os::wasi::io::{AsFd, BorrowedFd, OwnedFd};
 use std::{fmt, io};

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -429,7 +429,7 @@ impl FromRawSocket for TcpStream {
 #[cfg(all(feature = "io_safety", windows))]
 impl AsSocket for TcpStream {
     fn as_socket(&self) -> BorrowedSocket<'_> {
-        self.as_socket()
+        self.inner.as_socket()
     }
 }
 

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -1,18 +1,18 @@
 use std::fmt;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::{self, Shutdown, SocketAddr};
+#[cfg(all(feature = "io_safety", unix))]
+use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+#[cfg(all(feature = "io_safety", target_os = "wasi"))]
+use std::os::wasi::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(target_os = "wasi")]
 use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
-#[cfg(all(feature = "io_safety", unix))]
-use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(all(feature = "io_safety", windows))]
 use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
-#[cfg(all(feature = "io_safety", target_os = "wasi"))]
-use std::os::wasi::io::{AsFd, BorrowedFd, OwnedFd};
 
 use crate::io_source::IoSource;
 #[cfg(not(target_os = "wasi"))]

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -14,12 +14,12 @@ use std::fmt;
 use std::io;
 use std::net;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+#[cfg(all(feature = "io_safety", unix))]
+use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
-#[cfg(all(feature = "io_safety", unix))]
-use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(all(feature = "io_safety", windows))]
 use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -21,7 +21,7 @@ use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket}
 #[cfg(all(feature = "io_safety", unix))]
 use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(all(feature = "io_safety", windows))]
-use std::os::windows::io::{AsRawSocket, BorrowedSocket, OwnedSocket};
+use std::os::windows::io::{AsSocket, BorrowedSocket, OwnedSocket};
 
 /// A User Datagram Protocol socket.
 ///

--- a/src/net/uds/datagram.rs
+++ b/src/net/uds/datagram.rs
@@ -2,9 +2,9 @@ use crate::io_source::IoSource;
 use crate::{event, sys, Interest, Registry, Token};
 
 use std::net::Shutdown;
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(feature = "io_safety")]
 use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net;
 use std::path::Path;
 use std::{fmt, io};

--- a/src/net/uds/datagram.rs
+++ b/src/net/uds/datagram.rs
@@ -3,6 +3,8 @@ use crate::{event, sys, Interest, Registry, Token};
 
 use std::net::Shutdown;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+#[cfg(feature = "io_safety")]
+use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::net;
 use std::path::Path;
 use std::{fmt, io};
@@ -232,5 +234,26 @@ impl FromRawFd for UnixDatagram {
     /// non-blocking mode.
     unsafe fn from_raw_fd(fd: RawFd) -> UnixDatagram {
         UnixDatagram::from_std(FromRawFd::from_raw_fd(fd))
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl AsFd for UnixDatagram {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inner.as_fd()
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl From<OwnedFd> for UnixDatagram {
+    fn from(fd: OwnedFd) -> UnixDatagram {
+        UnixDatagram::from_std(fd.into())
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl From<UnixDatagram> for OwnedFd {
+    fn from(ts: UnixDatagram) -> Self {
+        ts.inner.into_inner().into()
     }
 }

--- a/src/net/uds/listener.rs
+++ b/src/net/uds/listener.rs
@@ -2,9 +2,9 @@ use crate::io_source::IoSource;
 use crate::net::{SocketAddr, UnixStream};
 use crate::{event, sys, Interest, Registry, Token};
 
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(feature = "io_safety")]
 use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net;
 use std::path::Path;
 use std::{fmt, io};
@@ -121,7 +121,7 @@ impl From<OwnedFd> for UnixListener {
 
 #[cfg(feature = "io_safety")]
 impl From<UnixListener> for OwnedFd {
-    fn from(ts: UnixListener) -> Self { 
+    fn from(ts: UnixListener) -> Self {
         ts.inner.into_inner().into()
     }
 }

--- a/src/net/uds/stream.rs
+++ b/src/net/uds/stream.rs
@@ -4,9 +4,9 @@ use crate::{event, sys, Interest, Registry, Token};
 use std::fmt;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::Shutdown;
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(feature = "io_safety")]
 use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net;
 use std::path::Path;
 

--- a/src/net/uds/stream.rs
+++ b/src/net/uds/stream.rs
@@ -5,6 +5,8 @@ use std::fmt;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::Shutdown;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+#[cfg(feature = "io_safety")]
+use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::net;
 use std::path::Path;
 
@@ -241,5 +243,26 @@ impl FromRawFd for UnixStream {
     /// non-blocking mode.
     unsafe fn from_raw_fd(fd: RawFd) -> UnixStream {
         UnixStream::from_std(FromRawFd::from_raw_fd(fd))
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl AsFd for UnixStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inner.as_fd()
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl From<OwnedFd> for UnixStream {
+    fn from(fd: OwnedFd) -> UnixStream {
+        UnixStream::from_std(fd.into())
+    }
+}
+
+#[cfg(feature = "io_safety")]
+impl From<UnixStream> for OwnedFd {
+    fn from(ts: UnixStream) -> Self {
+        ts.inner.into_inner().into()
     }
 }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,9 +1,9 @@
 use crate::{event, sys, Events, Interest, Token};
 use log::trace;
-#[cfg(unix)]
-use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(all(feature = "io_safety", unix))]
 use std::os::unix::io::{AsFd, BorrowedFd};
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::time::Duration;
 use std::{fmt, io};
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -2,6 +2,8 @@ use crate::{event, sys, Events, Interest, Token};
 use log::trace;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(all(feature = "io_safety", unix))]
+use std::os::unix::io::{AsFd, BorrowedFd};
 use std::time::Duration;
 use std::{fmt, io};
 
@@ -419,6 +421,13 @@ impl AsRawFd for Poll {
     }
 }
 
+#[cfg(all(feature = "io_safety", unix))]
+impl AsFd for Poll {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.registry.as_fd()
+    }
+}
+
 impl fmt::Debug for Poll {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Poll").finish()
@@ -701,6 +710,13 @@ impl fmt::Debug for Registry {
 impl AsRawFd for Registry {
     fn as_raw_fd(&self) -> RawFd {
         self.selector.as_raw_fd()
+    }
+}
+
+#[cfg(all(feature = "io_safety", unix))]
+impl AsFd for Registry {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.selector.as_fd()
     }
 }
 

--- a/src/sys/shell/selector.rs
+++ b/src/sys/shell/selector.rs
@@ -83,7 +83,7 @@ impl AsRawFd for Selector {
 
 #[cfg(all(feature = "io_safety", unix))]
 impl AsFd for Selector {
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         os_required!()
     }
 }

--- a/src/sys/shell/selector.rs
+++ b/src/sys/shell/selector.rs
@@ -1,6 +1,8 @@
 use std::io;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(all(feature = "io_safety", unix))]
+use std::os::unix::io::{AsFd, BorrowedFd};
 use std::time::Duration;
 
 pub type Event = usize;
@@ -75,6 +77,13 @@ cfg_io_source! {
 #[cfg(unix)]
 impl AsRawFd for Selector {
     fn as_raw_fd(&self) -> RawFd {
+        os_required!()
+    }
+}
+
+#[cfg(all(feature = "io_safety", unix))]
+impl AsFd for Selector {
+    fn as_fd(&self) -> BorrowedFd {
         os_required!()
     }
 }

--- a/src/sys/shell/selector.rs
+++ b/src/sys/shell/selector.rs
@@ -1,8 +1,8 @@
 use std::io;
-#[cfg(unix)]
-use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(all(feature = "io_safety", unix))]
 use std::os::unix::io::{AsFd, BorrowedFd};
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::time::Duration;
 
 pub type Event = usize;

--- a/src/sys/unix/pipe.rs
+++ b/src/sys/unix/pipe.rs
@@ -4,9 +4,9 @@
 
 use std::fs::File;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(feature = "io_safety")]
 use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::process::{ChildStderr, ChildStdin, ChildStdout};
 
 use crate::io_source::IoSource;
@@ -572,7 +572,7 @@ impl AsFd for Receiver {
 impl From<OwnedFd> for Receiver {
     fn from(fd: OwnedFd) -> Receiver {
         Receiver {
-            inner: IoSource::new(fd.into())
+            inner: IoSource::new(fd.into()),
         }
     }
 }

--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -2,9 +2,9 @@ use crate::{Interest, Token};
 
 use libc::{EPOLLET, EPOLLIN, EPOLLOUT, EPOLLRDHUP};
 use log::error;
-use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(feature = "io_safety")]
 use std::os::unix::io::{AsFd, BorrowedFd};
+use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -2,9 +2,9 @@ use crate::{Interest, Token};
 use log::error;
 use std::mem::{self, MaybeUninit};
 use std::ops::{Deref, DerefMut};
-use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(feature = "io_safety")]
 use std::os::unix::io::{AsFd, BorrowedFd};
+use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
@@ -313,7 +313,7 @@ impl AsFd for Selector {
     fn as_fd(&self) -> BorrowedFd<'_> {
         // SAFETY: the lifetime is bound by "self"
         unsafe { BorrowedFd::borrow_raw(self.kq) }
-    }   
+    }
 }
 
 impl Drop for Selector {


### PR DESCRIPTION
This PR adds a new feature, `io_safety`, which implements `AsFd`/`AsSocket`/`From<OwnedFd>`/`From<OwnedSocket>`/`Into<OwnedFd>`/`Into<OwnedSocket>` on the types within `mio`. Enabling this feature requires Rust 1.63 or higher.

See also: #1588