### PR TITLE
Support bind TcpStream to source IP address and connect to remote IP with bind_connect()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.cargo
+.vscode
 Cargo.lock
-target*
-libs
+target

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -98,7 +98,7 @@ impl TcpStream {
         let stream = unsafe { TcpStream::from_raw_fd(socket) };
         #[cfg(windows)]
         let stream = unsafe { TcpStream::from_raw_socket(socket as _) };
-        bind_for_addr(stream.as_raw_fd(), source_addr)?;
+        bind_for_addr(&stream, source_addr)?;
         connect(&stream.inner, addr)?;
         Ok(stream)        
     }

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::io;
 use std::mem::{size_of, MaybeUninit};
 use std::net::{self, SocketAddr};
-use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
 use crate::sys::unix::net::{new_socket, socket_addr, to_socket_addr};
 
@@ -14,9 +14,9 @@ pub(crate) fn new_for_addr(address: SocketAddr) -> io::Result<libc::c_int> {
     new_socket(domain, libc::SOCK_STREAM)
 }
 
-pub(crate) fn bind_for_addr(socket: &net::TcpStream, addr: SocketAddr) -> io::Result<()> {
+pub(crate) fn bind_for_addr(socket: RawFd, addr: SocketAddr) -> io::Result<()> {
     let (raw_addr, raw_addr_length) = socket_addr(&addr);
-    syscall!(bind(socket.as_raw_fd(), raw_addr.as_ptr(), raw_addr_length))?;
+    syscall!(bind(socket, raw_addr.as_ptr(), raw_addr_length))?;
     Ok(())
 }
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -14,9 +14,9 @@ pub(crate) fn new_for_addr(address: SocketAddr) -> io::Result<libc::c_int> {
     new_socket(domain, libc::SOCK_STREAM)
 }
 
-pub(crate) fn bind_for_addr(socket: RawFd, addr: SocketAddr) -> io::Result<()> {
+pub(crate) fn bind_for_addr(socket: &net::TcpStream, addr: SocketAddr) -> io::Result<()> {
     let (raw_addr, raw_addr_length) = socket_addr(&addr);
-    syscall!(bind(socket, raw_addr.as_ptr(), raw_addr_length))?;
+    syscall!(bind(socket.as_raw_fd(), raw_addr.as_ptr(), raw_addr_length))?;
     Ok(())
 }
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -14,6 +14,12 @@ pub(crate) fn new_for_addr(address: SocketAddr) -> io::Result<libc::c_int> {
     new_socket(domain, libc::SOCK_STREAM)
 }
 
+pub(crate) fn bind_for_addr(socket: RawFd, addr: SocketAddr) -> io::Result<()> {
+    let (raw_addr, raw_addr_length) = socket_addr(&addr);
+    syscall!(bind(socket, raw_addr.as_ptr(), raw_addr_length))?;
+    Ok(())
+}
+
 pub(crate) fn bind(socket: &net::TcpListener, addr: SocketAddr) -> io::Result<()> {
     let (raw_addr, raw_addr_length) = socket_addr(&addr);
     syscall!(bind(socket.as_raw_fd(), raw_addr.as_ptr(), raw_addr_length))?;


### PR DESCRIPTION
Hi, Dear mio experts

can you kindly help to check do you see is it possible to add interface can support bind source IP address when trying to create TcpStream ?

For many cases it is useful if want to clear define source IP/Port to Dest IP/Port  in fully controlled manner, so please try to see is it possible to add this support? currently it only have Unix system support, if it is required by community I can add windows support later

Br
Alex