### PR TITLE
Round up when converting timeout to ms for epoll_wait()

### DIFF
--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -88,19 +88,17 @@ impl Selector {
 
         let timeout = timeout
             .map(|to| {
-                cmp::min(
-                    MAX_SAFE_TIMEOUT,
-                    to.as_millis()
-                        // as_millis() truncates, so round up to the nearest millisecond as the
-                        // documentation says can happen.  This avoids turning submillisecond
-                        // timeouts into immediate returns unless the caller explicitly requests
-                        // that by specifying a zero timeout.
-			+ if to.subsec_nanos() % 1_000_000 == 0 {
-			    0
-			} else {
-			    1
-			},
-                ) as libc::c_int
+                let to_ms = to.as_millis();
+                // as_millis() truncates, so round up to 1 ms as the documentation says can happen.
+                // This avoids turning submillisecond timeouts into immediate returns unless the
+                // caller explicitly requests that by specifying a zero timeout.
+                let to_ms = to_ms
+                    + if to_ms == 0 && to.subsec_nanos() != 0 {
+                        1
+                    } else {
+                        0
+                    };
+                cmp::min(MAX_SAFE_TIMEOUT, to_ms) as libc::c_int
             })
             .unwrap_or(-1);
 


### PR DESCRIPTION
Fixes #1614

I'm a total beginner to rust, so there may be a better way to do this.  I'm also unfamiliar with async I/O, so it's entirely possible that crossterm is misusing the API.  But the `epoll_wait` manpage does say that the timeout will be rounded up.