### PR TITLE
protocol: add feature to create MPTCP sockets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ os-ext = [
 # Enables `mio::net` module containing networking primitives.
 net = []
 
+mptcp = []
+
 [dependencies]
 log = "0.4.8"
 

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -113,6 +113,7 @@ impl TcpListener {
     ///
     /// This value sets the time-to-live field that is used in every packet sent
     /// from this socket.
+    #[cfg(not(feature = "mptcp"))]
     pub fn set_ttl(&self, ttl: u32) -> io::Result<()> {
         self.inner.set_ttl(ttl)
     }
@@ -122,6 +123,7 @@ impl TcpListener {
     /// For more information about this option, see [`set_ttl`][link].
     ///
     /// [link]: #method.set_ttl
+    #[cfg(not(feature = "mptcp"))]
     pub fn ttl(&self) -> io::Result<u32> {
         self.inner.ttl()
     }

--- a/tests/tcp_listener.rs
+++ b/tests/tcp_listener.rs
@@ -92,6 +92,7 @@ where
 }
 
 #[test]
+#[cfg(not(feature = "mptcp"))]
 fn set_get_ttl() {
     init();
 
@@ -105,6 +106,7 @@ fn set_get_ttl() {
 }
 
 #[test]
+#[cfg(not(feature = "mptcp"))]
 fn get_ttl_without_previous_set() {
     init();
 


### PR DESCRIPTION
Hey !

I was working on this "feature" for a side project, I thought it might be nice to submit it upstream :)

-----

This commit add support for creating MPTCP sockets.

Small details:
- We can only create a MPTCP socket in a TCP context. This is why we check that we're in an SOCK_STREAM socket type and that the domain is either AF_INET(6).
- Disabled the TTL test and helper in case of MPTCP as it's not supported by the protocol.

	-> "Operation not supported"

As a more general note, MPTCP is now more widely
available since Linux Kernel >= 5.6. But it still
need to be enabled manually using:
$ sysctl net.mptcp.enabled=1