### PR TITLE
deps: update to windows-sys 0.42.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,11 +49,11 @@ log = "0.4.8"
 libc = "0.2.121"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.36"
+version = "0.42"
 features = [
-  "Win32_Storage_FileSystem",         # Enables NtCreateFile
   "Win32_Foundation",                 # Basic types eg HANDLE
   "Win32_Networking_WinSock",         # winsock2 types/functions
+  "Win32_Storage_FileSystem",         # Enables NtCreateFile
   "Win32_System_IO",                  # IO types like OVERLAPPED etc
   "Win32_System_WindowsProgramming",  # General future used for various types/funcs
 ]

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -264,10 +264,10 @@ pub fn set_linger_zero(socket: &TcpStream) {
 pub fn set_linger_zero(socket: &TcpStream) {
     use std::os::windows::io::AsRawSocket;
     use windows_sys::Win32::Networking::WinSock::{
-        linger, setsockopt, SOCKET_ERROR, SOL_SOCKET, SO_LINGER,
+        setsockopt, LINGER, SOCKET_ERROR, SOL_SOCKET, SO_LINGER,
     };
 
-    let mut val = linger {
+    let mut val = LINGER {
         l_onoff: 1,
         l_linger: 0,
     };
@@ -278,7 +278,7 @@ pub fn set_linger_zero(socket: &TcpStream) {
             SOL_SOCKET as i32,
             SO_LINGER as i32,
             &mut val as *mut _ as *mut _,
-            size_of::<linger>() as _,
+            size_of::<LINGER>() as _,
         )
     };
     assert!(


### PR DESCRIPTION
`windows-sys 0.42.0` was released some time ago and should break neither MSRV nor public API
(I hope).