### PR TITLE
backport switch to winapi 0.3 onto mio 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,8 @@ fuchsia-zircon-sys = "0.3.2"
 libc   = "0.2.54"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2.6"
-miow   = "0.2.2"
-kernel32-sys = "0.2"
+winapi = { version = "0.3.7", features = ["minwindef", "minwinbase", "ioapiset", "winsock2"] }
+miow   = "0.3.3"
 
 [dev-dependencies]
 env_logger = { version = "0.4.0", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,9 +126,6 @@ extern crate miow;
 #[cfg(windows)]
 extern crate winapi;
 
-#[cfg(windows)]
-extern crate kernel32;
-
 #[macro_use]
 extern crate log;
 

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -139,7 +139,6 @@
 use std::io;
 use std::os::windows::prelude::*;
 
-use kernel32;
 use winapi;
 
 mod awakener;
@@ -162,8 +161,8 @@ enum Family {
 
 unsafe fn cancel(socket: &AsRawSocket,
                  overlapped: &Overlapped) -> io::Result<()> {
-    let handle = socket.as_raw_socket() as winapi::HANDLE;
-    let ret = kernel32::CancelIoEx(handle, overlapped.as_mut_ptr());
+    let handle = socket.as_raw_socket() as winapi::um::winnt::HANDLE;
+    let ret = winapi::um::ioapiset::CancelIoEx(handle, overlapped.as_mut_ptr());
     if ret == 0 {
         Err(io::Error::last_os_error())
     } else {
@@ -171,15 +170,15 @@ unsafe fn cancel(socket: &AsRawSocket,
     }
 }
 
-unsafe fn no_notify_on_instant_completion(handle: winapi::HANDLE) -> io::Result<()> {
+unsafe fn no_notify_on_instant_completion(handle: winapi::um::winnt::HANDLE) -> io::Result<()> {
     // TODO: move those to winapi
-    const FILE_SKIP_COMPLETION_PORT_ON_SUCCESS: winapi::UCHAR = 1;
-    const FILE_SKIP_SET_EVENT_ON_HANDLE: winapi::UCHAR = 2;
+    const FILE_SKIP_COMPLETION_PORT_ON_SUCCESS: winapi::shared::minwindef::UCHAR = 1;
+    const FILE_SKIP_SET_EVENT_ON_HANDLE: winapi::shared::minwindef::UCHAR = 2;
 
     let flags = FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE;
 
-    let r = kernel32::SetFileCompletionNotificationModes(handle, flags);
-    if r == winapi::TRUE {
+    let r = winapi::um::winbase::SetFileCompletionNotificationModes(handle, flags);
+    if r == winapi::shared::minwindef::TRUE {
         Ok(())
     } else {
         Err(io::Error::last_os_error())

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -9,7 +9,9 @@ use std::time::Duration;
 
 use lazycell::AtomicLazyCell;
 
-use winapi::*;
+use winapi::shared::winerror::WAIT_TIMEOUT;
+use winapi::um::minwinbase::OVERLAPPED;
+use winapi::um::minwinbase::OVERLAPPED_ENTRY;
 use miow;
 use miow::iocp::{CompletionPort, CompletionStatus};
 

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -9,7 +9,8 @@ use std::time::Duration;
 use miow::iocp::CompletionStatus;
 use miow::net::*;
 use net2::{TcpBuilder, TcpStreamExt as Net2TcpExt};
-use winapi::*;
+use winapi::um::minwinbase::OVERLAPPED_ENTRY;
+use winapi::um::winnt::HANDLE;
 use iovec::IoVec;
 
 use {poll, Ready, Poll, PollOpt, Token};
@@ -746,8 +747,13 @@ impl ListenerImp {
             Family::V6 => TcpBuilder::new_v6(),
         }.and_then(|builder| unsafe {
             trace!("scheduling an accept");
-            self.inner.socket.accept_overlapped(&builder, &mut me.accept_buf,
-                                                self.inner.accept.as_mut_ptr())
+            let socket = builder.to_tcp_stream()?;
+            let ready = self.inner.socket.accept_overlapped(
+                &socket,
+                &mut me.accept_buf,
+                self.inner.accept.as_mut_ptr(),
+            )?;
+            Ok((socket, ready))
         });
         match res {
             Ok((socket, _)) => {

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -12,7 +12,8 @@ use std::sync::{Mutex, MutexGuard};
 
 #[allow(unused_imports)]
 use net2::{UdpBuilder, UdpSocketExt};
-use winapi::*;
+use winapi::um::minwinbase::OVERLAPPED_ENTRY;
+use winapi::um::winsock2::WSAEMSGSIZE;
 use miow::iocp::CompletionStatus;
 use miow::net::SocketAddrBuf;
 use miow::net::UdpSocketExt as MiowUdpSocketExt;


### PR DESCRIPTION
Needed for this to still build after https://github.com/rust-lang/rust/pull/102513.
Cc @Thomasdezeeuw  @Noah-Kennedy

This is a direct port of https://github.com/tokio-rs/mio/commit/756bf282fd7f8423ad703a1d498fdb32f138dfb3.
I have zero familiarity with mio, winapi, and the Windows APIs... so I hope this makes sense.^^ I don't even have a Windows machine to build-test this; I used `cargo miri` since that is able to do check-builds for foreign targets.