### PR TITLE
net/uds: add methods to connect/bind with a socket address

### DIFF
--- a/src/net/uds/listener.rs
+++ b/src/net/uds/listener.rs
@@ -13,9 +13,14 @@ pub struct UnixListener {
 }
 
 impl UnixListener {
-    /// Creates a new `UnixListener` bound to the specified socket.
+    /// Creates a new `UnixListener` bound to the specified socket `path`.
     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
         sys::uds::listener::bind(path.as_ref()).map(UnixListener::from_std)
+    }
+
+    /// Creates a new `UnixListener` bound to the specified socket `address`.
+    pub fn bind_addr(address: &SocketAddr) -> io::Result<UnixListener> {
+        sys::uds::listener::bind_addr(address).map(UnixListener::from_std)
     }
 
     /// Creates a new `UnixListener` from a standard `net::UnixListener`.

--- a/src/net/uds/stream.rs
+++ b/src/net/uds/stream.rs
@@ -1,4 +1,5 @@
 use crate::io_source::IoSource;
+use crate::net::SocketAddr;
 use crate::{event, sys, Interest, Registry, Token};
 
 use std::fmt;
@@ -20,6 +21,14 @@ impl UnixStream {
     /// cannot be completed immediately. Usually it means the backlog is full.
     pub fn connect<P: AsRef<Path>>(path: P) -> io::Result<UnixStream> {
         sys::uds::stream::connect(path.as_ref()).map(UnixStream::from_std)
+    }
+
+    /// Connects to the socket named by `address`.
+    ///
+    /// This may return a `WouldBlock` in which case the socket connection
+    /// cannot be completed immediately. Usually it means the backlog is full.
+    pub fn connect_addr(address: &SocketAddr) -> io::Result<UnixStream> {
+        sys::uds::stream::connect_addr(address).map(UnixStream::from_std)
     }
 
     /// Creates a new `UnixStream` from a standard `net::UnixStream`.

--- a/src/sys/shell/uds.rs
+++ b/src/sys/shell/uds.rs
@@ -42,6 +42,10 @@ pub(crate) mod listener {
         os_required!()
     }
 
+    pub(crate) fn bind_addr(_: &SocketAddr) -> io::Result<net::UnixListener> {
+        os_required!()
+    }
+
     pub(crate) fn accept(_: &net::UnixListener) -> io::Result<(UnixStream, SocketAddr)> {
         os_required!()
     }
@@ -58,6 +62,10 @@ pub(crate) mod stream {
     use std::path::Path;
 
     pub(crate) fn connect(_: &Path) -> io::Result<net::UnixStream> {
+        os_required!()
+    }
+
+    pub(crate) fn connect_addr(_: &SocketAddr) -> io::Result<net::UnixStream> {
         os_required!()
     }
 

--- a/src/sys/unix/uds/datagram.rs
+++ b/src/sys/unix/uds/datagram.rs
@@ -2,12 +2,13 @@ use super::{socket_addr, SocketAddr};
 use crate::sys::unix::net::new_socket;
 
 use std::io;
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::os::unix::net;
 use std::path::Path;
 
 pub(crate) fn bind(path: &Path) -> io::Result<net::UnixDatagram> {
-    let (sockaddr, socklen) = socket_addr(path)?;
+    let (sockaddr, socklen) = socket_addr(path.as_os_str().as_bytes())?;
     let sockaddr = &sockaddr as *const libc::sockaddr_un as *const _;
 
     let socket = unbound()?;

--- a/src/sys/unix/uds/socketaddr.rs
+++ b/src/sys/unix/uds/socketaddr.rs
@@ -73,6 +73,14 @@ cfg_os_poll! {
             SocketAddr { sockaddr, socklen }
         }
 
+        pub(crate) fn raw_sockaddr(&self) -> &libc::sockaddr_un {
+            &self.sockaddr
+        }
+
+        pub(crate) fn raw_socklen(&self) -> &libc::socklen_t {
+            &self.socklen
+        }
+
         /// Returns `true` if the address is unnamed.
         ///
         /// Documentation reflected in [`SocketAddr`]

--- a/src/sys/unix/uds/stream.rs
+++ b/src/sys/unix/uds/stream.rs
@@ -2,17 +2,26 @@ use super::{socket_addr, SocketAddr};
 use crate::sys::unix::net::new_socket;
 
 use std::io;
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::os::unix::net;
 use std::path::Path;
 
 pub(crate) fn connect(path: &Path) -> io::Result<net::UnixStream> {
-    let (sockaddr, socklen) = socket_addr(path)?;
-    let sockaddr = &sockaddr as *const libc::sockaddr_un as *const libc::sockaddr;
+    let socket_address = {
+        let (sockaddr, socklen) = socket_addr(path.as_os_str().as_bytes())?;
+        SocketAddr::from_parts(sockaddr, socklen)
+    };
 
+    connect_addr(&socket_address)
+}
+
+pub(crate) fn connect_addr(address: &SocketAddr) -> io::Result<net::UnixStream> {
     let fd = new_socket(libc::AF_UNIX, libc::SOCK_STREAM)?;
     let socket = unsafe { net::UnixStream::from_raw_fd(fd) };
-    match syscall!(connect(fd, sockaddr, socklen)) {
+    let sockaddr = address.raw_sockaddr() as *const libc::sockaddr_un as *const libc::sockaddr;
+
+    match syscall!(connect(fd, sockaddr, *address.raw_socklen())) {
         Ok(_) => {}
         Err(ref err) if err.raw_os_error() == Some(libc::EINPROGRESS) => {}
         Err(e) => return Err(e),

--- a/tests/unix_stream.rs
+++ b/tests/unix_stream.rs
@@ -78,6 +78,55 @@ fn unix_stream_connect() {
 }
 
 #[test]
+fn unix_stream_connect_addr() {
+    let (mut poll, mut events) = init_with_poll();
+    let barrier = Arc::new(Barrier::new(2));
+    let local_addr = {
+        // Workaround through a temporary listener using the same address,
+        // as there is currently no way of directly building a `SocketAddr`.
+        let path = temp_file("unix_stream_connect_addr");
+        let listener = net::UnixListener::bind(path.clone()).unwrap();
+        let mio_listener = mio::net::UnixListener::from_std(listener);
+        let address = mio_listener.local_addr().unwrap();
+        drop(mio_listener);
+        _ = std::fs::remove_file(&path);
+        address
+    };
+    let path = temp_file("unix_stream_connect_addr");
+    let listener = net::UnixListener::bind(path).unwrap();
+    let mut stream = UnixStream::connect_addr(&local_addr).unwrap();
+
+    let barrier_clone = barrier.clone();
+    let handle = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        barrier_clone.wait();
+        drop(stream);
+    });
+
+    poll.registry()
+        .register(
+            &mut stream,
+            TOKEN_1,
+            Interest::READABLE | Interest::WRITABLE,
+        )
+        .unwrap();
+    expect_events(
+        &mut poll,
+        &mut events,
+        vec![ExpectEvent::new(TOKEN_1, Interest::WRITABLE)],
+    );
+
+    barrier.wait();
+    expect_events(
+        &mut poll,
+        &mut events,
+        vec![ExpectEvent::new(TOKEN_1, Interest::READABLE)],
+    );
+
+    handle.join().unwrap();
+}
+
+#[test]
 fn unix_stream_from_std() {
     smoke_test(
         |path| {


### PR DESCRIPTION
This enhances `connect` and `bind` logic for Unix Domain Sockets (UDS), by adding methods which allow to directly use a socket address. This mirrors similar features which already exist in `mio` for TCP and UDP sockets.