### PR TITLE
Fix a number of potential fd leaks

### DIFF
--- a/src/sys/unix/pipe.rs
+++ b/src/sys/unix/pipe.rs
@@ -176,7 +176,7 @@ pub fn new() -> io::Result<(Sender, Receiver)> {
                 || libc::fcntl(*fd, libc::F_SETFD, libc::FD_CLOEXEC) != 0
             {
                 let err = io::Error::last_os_error();
-                // Don't leak file descriptors. Can't handle error though.
+                // Don't leak file descriptors. Can't handle closing error though.
                 let _ = libc::close(fds[0]);
                 let _ = libc::close(fds[1]);
                 return Err(err);
@@ -198,9 +198,10 @@ pub fn new() -> io::Result<(Sender, Receiver)> {
     )))]
     compile_error!("unsupported target for `mio::unix::pipe`");
 
-    // Safety: we just initialised the `fds` above.
+    // SAFETY: we just initialised the `fds` above.
     let r = unsafe { Receiver::from_raw_fd(fds[0]) };
     let w = unsafe { Sender::from_raw_fd(fds[1]) };
+
     Ok((w, r))
 }
 

--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -89,15 +89,11 @@ impl Selector {
         let timeout = timeout
             .map(|to| {
                 let to_ms = to.as_millis();
-                // as_millis() truncates, so round up to 1 ms as the documentation says can happen.
-                // This avoids turning submillisecond timeouts into immediate returns unless the
-                // caller explicitly requests that by specifying a zero timeout.
-                let to_ms = to_ms
-                    + if to_ms == 0 && to.subsec_nanos() != 0 {
-                        1
-                    } else {
-                        0
-                    };
+                // `Duration::as_millis` truncates, so round up to 1 ms. This
+                // avoids turning sub-millisecond timeouts into a zero timeout,
+                // unless the caller explicitly requests that by specifying a
+                // zero timeout.
+                let to_ms = to_ms + u128::from(to_ms == 0 && to.subsec_nanos() != 0);
                 cmp::min(MAX_SAFE_TIMEOUT, to_ms) as libc::c_int
             })
             .unwrap_or(-1);

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -40,7 +40,7 @@ pub(crate) fn listen(socket: &net::TcpListener, backlog: u32) -> io::Result<()> 
 }
 
 pub(crate) fn set_reuseaddr(socket: &net::TcpListener, reuseaddr: bool) -> io::Result<()> {
-    let val: libc::c_int = if reuseaddr { 1 } else { 0 };
+    let val: libc::c_int = i32::from(reuseaddr);
     syscall!(setsockopt(
         socket.as_raw_fd(),
         libc::SOL_SOCKET,

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -6,21 +6,13 @@ use std::net::{self, SocketAddr};
 use std::os::unix::io::{AsRawFd, FromRawFd};
 
 pub fn bind(addr: SocketAddr) -> io::Result<net::UdpSocket> {
-    // Gives a warning for non Apple platforms.
-    #[allow(clippy::let_and_return)]
-    let socket = new_ip_socket(addr, libc::SOCK_DGRAM);
+    let fd = new_ip_socket(addr, libc::SOCK_DGRAM)?;
+    let socket = unsafe { net::UdpSocket::from_raw_fd(fd) };
 
-    socket.and_then(|socket| {
-        let (raw_addr, raw_addr_length) = socket_addr(&addr);
-        syscall!(bind(socket, raw_addr.as_ptr(), raw_addr_length))
-            .map_err(|err| {
-                // Close the socket if we hit an error, ignoring the error
-                // from closing since we can't pass back two errors.
-                let _ = unsafe { libc::close(socket) };
-                err
-            })
-            .map(|_| unsafe { net::UdpSocket::from_raw_fd(socket) })
-    })
+    let (raw_addr, raw_addr_length) = socket_addr(&addr);
+    syscall!(bind(fd, raw_addr.as_ptr(), raw_addr_length))?;
+
+    Ok(socket)
 }
 
 pub(crate) fn only_v6(socket: &net::UdpSocket) -> io::Result<bool> {

--- a/src/sys/unix/uds/datagram.rs
+++ b/src/sys/unix/uds/datagram.rs
@@ -7,12 +7,13 @@ use std::os::unix::net;
 use std::path::Path;
 
 pub(crate) fn bind(path: &Path) -> io::Result<net::UnixDatagram> {
-    let fd = new_socket(libc::AF_UNIX, libc::SOCK_DGRAM)?;
-    // Ensure the fd is closed.
-    let socket = unsafe { net::UnixDatagram::from_raw_fd(fd) };
     let (sockaddr, socklen) = socket_addr(path)?;
     let sockaddr = &sockaddr as *const libc::sockaddr_un as *const _;
+
+    let fd = new_socket(libc::AF_UNIX, libc::SOCK_DGRAM)?;
+    let socket = unsafe { net::UnixDatagram::from_raw_fd(fd) };
     syscall!(bind(fd, sockaddr, socklen))?;
+
     Ok(socket)
 }
 

--- a/src/sys/unix/uds/datagram.rs
+++ b/src/sys/unix/uds/datagram.rs
@@ -10,16 +10,15 @@ pub(crate) fn bind(path: &Path) -> io::Result<net::UnixDatagram> {
     let (sockaddr, socklen) = socket_addr(path)?;
     let sockaddr = &sockaddr as *const libc::sockaddr_un as *const _;
 
-    let fd = new_socket(libc::AF_UNIX, libc::SOCK_DGRAM)?;
-    let socket = unsafe { net::UnixDatagram::from_raw_fd(fd) };
-    syscall!(bind(fd, sockaddr, socklen))?;
+    let socket = unbound()?;
+    syscall!(bind(socket.as_raw_fd(), sockaddr, socklen))?;
 
     Ok(socket)
 }
 
 pub(crate) fn unbound() -> io::Result<net::UnixDatagram> {
-    new_socket(libc::AF_UNIX, libc::SOCK_DGRAM)
-        .map(|socket| unsafe { net::UnixDatagram::from_raw_fd(socket) })
+    let fd = new_socket(libc::AF_UNIX, libc::SOCK_DGRAM)?;
+    Ok(unsafe { net::UnixDatagram::from_raw_fd(fd) })
 }
 
 pub(crate) fn pair() -> io::Result<(net::UnixDatagram, net::UnixDatagram)> {

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -7,19 +7,15 @@ use std::path::Path;
 use std::{io, mem};
 
 pub(crate) fn bind(path: &Path) -> io::Result<net::UnixListener> {
-    let socket = new_socket(libc::AF_UNIX, libc::SOCK_STREAM)?;
     let (sockaddr, socklen) = socket_addr(path)?;
     let sockaddr = &sockaddr as *const libc::sockaddr_un as *const libc::sockaddr;
 
-    syscall!(bind(socket, sockaddr, socklen))
-        .and_then(|_| syscall!(listen(socket, 1024)))
-        .map_err(|err| {
-            // Close the socket if we hit an error, ignoring the error from
-            // closing since we can't pass back two errors.
-            let _ = unsafe { libc::close(socket) };
-            err
-        })
-        .map(|_| unsafe { net::UnixListener::from_raw_fd(socket) })
+    let fd = new_socket(libc::AF_UNIX, libc::SOCK_STREAM)?;
+    let socket = unsafe { net::UnixListener::from_raw_fd(fd) };
+    syscall!(bind(fd, sockaddr, socklen))?;
+    syscall!(listen(fd, 1024))?;
+
+    Ok(socket)
 }
 
 pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, SocketAddr)> {

--- a/src/sys/windows/net.rs
+++ b/src/sys/windows/net.rs
@@ -9,7 +9,7 @@ use windows_sys::Win32::Networking::WinSock::{
 };
 
 /// Initialise the network stack for Windows.
-pub(crate) fn init() {
+fn init() {
     static INIT: Once = Once::new();
     INIT.call_once(|| {
         // Let standard library call `WSAStartup` for us, we can't do it
@@ -30,6 +30,8 @@ pub(crate) fn new_ip_socket(addr: SocketAddr, socket_type: u16) -> io::Result<SO
 }
 
 pub(crate) fn new_socket(domain: u32, socket_type: u16) -> io::Result<SOCKET> {
+    init();
+
     syscall!(
         socket(domain as i32, socket_type as i32, 0),
         PartialEq::eq,

--- a/src/sys/windows/net.rs
+++ b/src/sys/windows/net.rs
@@ -4,8 +4,9 @@ use std::net::SocketAddr;
 use std::sync::Once;
 
 use windows_sys::Win32::Networking::WinSock::{
-    ioctlsocket, socket, AF_INET, AF_INET6, FIONBIO, IN6_ADDR, IN6_ADDR_0, INVALID_SOCKET, IN_ADDR,
-    IN_ADDR_0, SOCKADDR, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_IN6_0, SOCKET,
+    closesocket, ioctlsocket, socket, AF_INET, AF_INET6, FIONBIO, IN6_ADDR, IN6_ADDR_0,
+    INVALID_SOCKET, IN_ADDR, IN_ADDR_0, SOCKADDR, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_IN6_0,
+    SOCKET,
 };
 
 /// Initialise the network stack for Windows.
@@ -32,14 +33,18 @@ pub(crate) fn new_ip_socket(addr: SocketAddr, socket_type: u16) -> io::Result<SO
 pub(crate) fn new_socket(domain: u32, socket_type: u16) -> io::Result<SOCKET> {
     init();
 
-    syscall!(
+    let socket = syscall!(
         socket(domain as i32, socket_type as i32, 0),
         PartialEq::eq,
         INVALID_SOCKET
-    )
-    .and_then(|socket| {
-        syscall!(ioctlsocket(socket, FIONBIO, &mut 1), PartialEq::ne, 0).map(|_| socket as SOCKET)
-    })
+    )?;
+
+    if let Err(err) = syscall!(ioctlsocket(socket, FIONBIO, &mut 1), PartialEq::ne, 0) {
+        let _ = unsafe { closesocket(socket) };
+        return Err(err);
+    }
+
+    Ok(socket as SOCKET)
 }
 
 /// A type with the same memory layout as `SOCKADDR`. Used in converting Rust level

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -2,19 +2,12 @@ use std::io;
 use std::net::{self, SocketAddr};
 use std::os::windows::io::AsRawSocket;
 
-use windows_sys::Win32::Networking::WinSock::{
-    self, AF_INET, AF_INET6, SOCKET, SOCKET_ERROR, SOCK_STREAM,
-};
+use windows_sys::Win32::Networking::WinSock::{self, SOCKET, SOCKET_ERROR, SOCK_STREAM};
 
-use crate::sys::windows::net::{init, new_socket, socket_addr};
+use crate::sys::windows::net::{new_ip_socket, socket_addr};
 
 pub(crate) fn new_for_addr(address: SocketAddr) -> io::Result<SOCKET> {
-    init();
-    let domain = match address {
-        SocketAddr::V4(_) => AF_INET,
-        SocketAddr::V6(_) => AF_INET6,
-    };
-    new_socket(domain, SOCK_STREAM)
+    new_ip_socket(address, SOCK_STREAM)
 }
 
 pub(crate) fn bind(socket: &net::TcpListener, addr: SocketAddr) -> io::Result<()> {

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -4,13 +4,12 @@ use std::net::{self, SocketAddr};
 use std::os::windows::io::{AsRawSocket, FromRawSocket};
 use std::os::windows::raw::SOCKET as StdSocket; // windows-sys uses usize, stdlib uses u32/u64.
 
-use crate::sys::windows::net::{init, new_ip_socket, socket_addr};
+use crate::sys::windows::net::{new_ip_socket, socket_addr};
 use windows_sys::Win32::Networking::WinSock::{
     bind as win_bind, closesocket, getsockopt, IPPROTO_IPV6, IPV6_V6ONLY, SOCKET_ERROR, SOCK_DGRAM,
 };
 
 pub fn bind(addr: SocketAddr) -> io::Result<net::UdpSocket> {
-    init();
     new_ip_socket(addr, SOCK_DGRAM).and_then(|socket| {
         let (raw_addr, raw_addr_length) = socket_addr(&addr);
         syscall!(

--- a/tests/unix_datagram.rs
+++ b/tests/unix_datagram.rs
@@ -32,8 +32,8 @@ fn unix_datagram_smoke_unconnected() {
     let path1 = temp_file("unix_datagram_smoke_unconnected1");
     let path2 = temp_file("unix_datagram_smoke_unconnected2");
 
-    let datagram1 = UnixDatagram::bind(&path1).unwrap();
-    let datagram2 = UnixDatagram::bind(&path2).unwrap();
+    let datagram1 = UnixDatagram::bind(path1).unwrap();
+    let datagram2 = UnixDatagram::bind(path2).unwrap();
     smoke_test_unconnected(datagram1, datagram2);
 }
 
@@ -57,8 +57,8 @@ fn unix_datagram_smoke_unconnected_from_std() {
     let path1 = temp_file("unix_datagram_smoke_unconnected_from_std1");
     let path2 = temp_file("unix_datagram_smoke_unconnected_from_std2");
 
-    let datagram1 = net::UnixDatagram::bind(&path1).unwrap();
-    let datagram2 = net::UnixDatagram::bind(&path2).unwrap();
+    let datagram1 = net::UnixDatagram::bind(path1).unwrap();
+    let datagram2 = net::UnixDatagram::bind(path2).unwrap();
 
     datagram1.set_nonblocking(true).unwrap();
     datagram2.set_nonblocking(true).unwrap();
@@ -94,9 +94,9 @@ fn unix_datagram_connect() {
     let path1 = temp_file("unix_datagram_connect1");
     let path2 = temp_file("unix_datagram_connect2");
 
-    let datagram1 = UnixDatagram::bind(&path1).unwrap();
+    let datagram1 = UnixDatagram::bind(path1).unwrap();
     let datagram1_local = datagram1.local_addr().unwrap();
-    let datagram2 = UnixDatagram::bind(&path2).unwrap();
+    let datagram2 = UnixDatagram::bind(path2).unwrap();
     let datagram2_local = datagram2.local_addr().unwrap();
 
     datagram1
@@ -171,7 +171,7 @@ fn unix_datagram_shutdown() {
     let path1 = temp_file("unix_datagram_shutdown1");
     let path2 = temp_file("unix_datagram_shutdown2");
 
-    let mut datagram1 = UnixDatagram::bind(&path1).unwrap();
+    let mut datagram1 = UnixDatagram::bind(path1).unwrap();
     let mut datagram2 = UnixDatagram::bind(&path2).unwrap();
 
     poll.registry()
@@ -246,7 +246,7 @@ fn unix_datagram_reregister() {
         .register(&mut datagram1, TOKEN_1, Interest::READABLE)
         .unwrap();
 
-    let datagram2 = UnixDatagram::bind(&path2).unwrap();
+    let datagram2 = UnixDatagram::bind(path2).unwrap();
     datagram2.connect(&path1).unwrap();
     poll.registry()
         .reregister(&mut datagram1, TOKEN_1, Interest::WRITABLE)
@@ -269,7 +269,7 @@ fn unix_datagram_deregister() {
         .register(&mut datagram1, TOKEN_1, Interest::WRITABLE)
         .unwrap();
 
-    let datagram2 = UnixDatagram::bind(&path2).unwrap();
+    let datagram2 = UnixDatagram::bind(path2).unwrap();
     datagram2.connect(&path1).unwrap();
     poll.registry().deregister(&mut datagram1).unwrap();
     expect_no_events(&mut poll, &mut events);


### PR DESCRIPTION
We do this by simply creating a fd-managing types, e.g. `UnixDatagram`, from the fd once it's created.

Also first tries to parse the path as that can fail without doing a system call.

Fixes #1635 

/cc @silence-coding