### PR TITLE
Test x86_64-pc-windows-gnu with Wine on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,20 @@ jobs:
       run: rustup component add rust-src
     - name: Run tests with sanitizer
       run: make test_sanitizer SAN=${{ matrix.sanitizer }}
+  Wine:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+    # Install linker, libraries, and test runner (Wine) for x86_64-pc-windows-gnu.
+    - uses: taiki-e/setup-cross-toolchain-action@v1
+      with:
+        target: x86_64-pc-windows-gnu
+        runner: wine@7.13
+    - name: Tests
+      run: cargo test --all-features --target x86_64-pc-windows-gnu
+    - name: Tests release build
+      run: cargo test --release --all-features --target x86_64-pc-windows-gnu
   # Single job required to merge the pr.
   Passed:
     runs-on: ubuntu-latest
@@ -138,5 +152,6 @@ jobs:
       - Docs
       - Rustfmt
       - CheckTargets
+      - Wine
     steps:
       - run: exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,8 @@ jobs:
     - name: Tests
       run: cargo test --all-features --target x86_64-pc-windows-gnu
       env:
+        # Several tests are still failing, so emit cfg(wine) to allow ignoring
+        # them by cfg_attr(wine, ignore).
         RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg wine
     - name: Tests release build
       run: cargo test --release --all-features --target x86_64-pc-windows-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,12 @@ jobs:
         runner: wine@7.13
     - name: Tests
       run: cargo test --all-features --target x86_64-pc-windows-gnu
+      env:
+        RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg wine
     - name: Tests release build
       run: cargo test --release --all-features --target x86_64-pc-windows-gnu
+      env:
+        RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg wine
   # Single job required to merge the pr.
   Passed:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Currently supported platforms:
 * Windows
 * iOS
 * macOS
+* Wine (version 7.13+, see [issue #1444])
 
 There are potentially others. If you find that Mio works on another
 platform, submit a PR to update the list!
@@ -149,16 +150,15 @@ The Windows implementation for polling sockets is using the [wepoll] strategy.
 This uses the Windows AFD system to access socket readiness events.
 
 [wepoll]: https://github.com/piscisaureus/wepoll
+[issue #1444]: https://github.com/tokio-rs/mio/issues/1444
 
 ### Unsupported
 
 * Haiku, see [issue #1472]
 * Solaris, see [issue #1152]
-* Wine, see [issue #1444]
 
 [issue #1472]: https://github.com/tokio-rs/mio/issues/1472
 [issue #1152]: https://github.com/tokio-rs/mio/issues/1152
-[issue #1444]: https://github.com/tokio-rs/mio/issues/1444
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ Currently supported platforms:
 * Windows
 * iOS
 * macOS
-* Wine (version 7.13+, see [issue #1444])
 
 There are potentially others. If you find that Mio works on another
 platform, submit a PR to update the list!
@@ -150,15 +149,16 @@ The Windows implementation for polling sockets is using the [wepoll] strategy.
 This uses the Windows AFD system to access socket readiness events.
 
 [wepoll]: https://github.com/piscisaureus/wepoll
-[issue #1444]: https://github.com/tokio-rs/mio/issues/1444
 
 ### Unsupported
 
 * Haiku, see [issue #1472]
 * Solaris, see [issue #1152]
+* Wine, see [issue #1444]
 
 [issue #1472]: https://github.com/tokio-rs/mio/issues/1472
 [issue #1152]: https://github.com/tokio-rs/mio/issues/1152
+[issue #1444]: https://github.com/tokio-rs/mio/issues/1444
 
 ## Community
 

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -348,6 +348,7 @@ fn shutdown_write() {
     thread_handle.join().expect("unable to join thread");
 }
 
+#[cfg_attr(wine, ignore = "fails on Wine")]
 #[test]
 fn shutdown_both() {
     let (mut poll, mut events) = init_with_poll();

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -384,6 +384,7 @@ fn smoke_test_connected_udp_socket(mut socket1: UdpSocket, mut socket2: UdpSocke
     assert!(socket2.take_error().unwrap().is_none());
 }
 
+#[cfg_attr(wine, ignore = "fails on Wine")]
 #[test]
 fn reconnect_udp_socket_sending() {
     let (mut poll, mut events) = init_with_poll();
@@ -447,6 +448,7 @@ fn reconnect_udp_socket_sending() {
     assert!(socket3.take_error().unwrap().is_none());
 }
 
+#[cfg_attr(wine, ignore = "fails on Wine")]
 #[test]
 fn reconnect_udp_socket_receiving() {
     let (mut poll, mut events) = init_with_poll();
@@ -531,6 +533,7 @@ fn reconnect_udp_socket_receiving() {
     assert!(socket3.take_error().unwrap().is_none());
 }
 
+#[cfg_attr(wine, ignore = "fails on Wine")]
 #[test]
 fn unconnected_udp_socket_connected_methods() {
     let (mut poll, mut events) = init_with_poll();

--- a/tests/waker.rs
+++ b/tests/waker.rs
@@ -109,8 +109,8 @@ fn waker_multiple_wakeups_different_thread() {
 
 #[test]
 #[cfg_attr(
-    not(debug_assertions),
-    ignore = "only works with debug_assertions enabled"
+    any(not(debug_assertions), wine),
+    ignore = "only works with debug_assertions enabled and non-Wine"
 )]
 #[should_panic = "Only a single `Waker` can be active per `Poll` instance"]
 fn using_multiple_wakers_panics() {


### PR DESCRIPTION
This adds test for x86_64-pc-windows-gnu with Wine 7.13 on CI.

~~This also documents that Wine 7.13+ is supported.~~ EDIT: see https://github.com/tokio-rs/mio/pull/1637#issuecomment-1428318706

cc https://github.com/tokio-rs/mio/issues/1444