### PR TITLE
Again less truncating for timeout values in `Poll::poll`

### DIFF
--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -88,12 +88,11 @@ impl Selector {
 
         let timeout = timeout
             .map(|to| {
-                let to_ms = to.as_millis();
-                // `Duration::as_millis` truncates, so round up to 1 ms. This
-                // avoids turning sub-millisecond timeouts into a zero timeout,
-                // unless the caller explicitly requests that by specifying a
-                // zero timeout.
-                let to_ms = to_ms + u128::from(to_ms == 0 && to.subsec_nanos() != 0);
+                // `Duration::as_millis` truncates, so round up. This avoids
+                // turning sub-millisecond timeouts into a zero timeout, unless
+                // the caller explicitly requests that by specifying a zero
+                // timeout.
+                let to_ms = (to + Duration::from_nanos(999_999)).as_millis();
                 cmp::min(MAX_SAFE_TIMEOUT, to_ms) as libc::c_int
             })
             .unwrap_or(-1);

--- a/src/sys/windows/iocp.rs
+++ b/src/sys/windows/iocp.rs
@@ -224,17 +224,12 @@ impl CompletionStatus {
 #[inline]
 fn duration_millis(dur: Option<Duration>) -> u32 {
     if let Some(dur) = dur {
-        let dur_ms = dur.as_millis();
-        // as_millis() truncates, so round nonzero <1ms timeouts up to 1ms.  This avoids turning
-        // submillisecond timeouts into immediate reutrns unless the caller explictly requests that
-        // by specifiying a zero timeout.
-        let dur_ms = dur_ms
-            + if dur_ms == 0 && dur.subsec_nanos() != 0 {
-                1
-            } else {
-                0
-            };
-        std::cmp::min(dur_ms, u32::MAX as u128) as u32
+        // `Duration::as_millis` truncates, so round up. This avoids
+        // turning sub-millisecond timeouts into a zero timeout, unless
+        // the caller explicitly requests that by specifying a zero
+        // timeout.
+        let dur_ms = (dur + Duration::from_nanos(999_999)).as_millis();
+        cmp::min(dur_ms, u32::MAX as u128) as u32
     } else {
         u32::MAX
     }


### PR DESCRIPTION
Round up submillisecond wait times to the next millisecond on platforms where submillisecond sleep times aren't supported. This makes the behavior actually match the documentation.

See also #420, where this was implemented for the first time.