### PR TITLE
Add a test to tcp_stream that tests if priority events work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,9 @@ libc = "0.2.121"
 env_logger = { version = "0.8.4", default-features = false }
 rand = "0.8"
 
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+nix = { version = "0", features = ["socket", "uio"] }
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
This adds a test to the tcp_stream to test if priority events are working. This only works on linux. Linux sets the EPOLLPRI event type for those events.
This works by sending a tcp packet with the MSG_OOB flag set.