### PR TITLE
Add Interest::PRIORITY

### DIFF
--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -1,6 +1,6 @@
 use crate::{Interest, Token};
 
-use libc::{EPOLLET, EPOLLIN, EPOLLOUT, EPOLLRDHUP};
+use libc::{EPOLLET, EPOLLIN, EPOLLOUT, EPOLLPRI, EPOLLRDHUP};
 use log::error;
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(debug_assertions)]
@@ -175,6 +175,10 @@ fn interests_to_epoll(interests: Interest) -> u32 {
 
     if interests.is_writable() {
         kind |= EPOLLOUT;
+    }
+
+    if interests.is_priority() {
+        kind |= EPOLLPRI;
     }
 
     kind as u32


### PR DESCRIPTION
To trigger Event::is_priority on Linux and Android.

In the future we might want to include EV_OOBAND for kqueue, but that seems to be Apple only (FreeBSD and OpenBSD don't implement it at least).

Closes #1645

Does this solve the problem @poeschel, @Urist-McGit?