### PR TITLE
Make spelling of "I/O" consistent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors       = [
   "Thomas de Zeeuw <thomasdezeeuw@gmail.com>",
   "Tokio Contributors <team@tokio.rs>",
 ]
-description   = "Lightweight non-blocking IO"
+description   = "Lightweight non-blocking I/O."
 homepage      = "https://github.com/tokio-rs/mio"
 repository    = "https://github.com/tokio-rs/mio"
 readme        = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mio – Metal IO
+# Mio – Metal I/O
 
 Mio is a fast, low-level I/O library for Rust focusing on non-blocking APIs and
 event notification for building high performance I/O apps with as little


### PR DESCRIPTION
"IO" and "I/O" are currently being used somewhat interchangeably. This changes them to be consistent throughout.