### PR TITLE
Remove outdated doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ overhead as possible over the OS abstractions.
 
 **API documentation**
 
-* [master](https://tokio-rs.github.io/mio/doc/mio/)
 * [v0.8](https://docs.rs/mio/^0.8)
 * [v0.7](https://docs.rs/mio/^0.7)
 


### PR DESCRIPTION
I think we should also remove the `gh-pages` branch, which is two years old, to disable the GitHub pages. But I don't know what else is needed.

Fixes #1652.