### PR TITLE
Fix overflow in duration

### DIFF
--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -92,7 +92,10 @@ impl Selector {
                 // turning sub-millisecond timeouts into a zero timeout, unless
                 // the caller explicitly requests that by specifying a zero
                 // timeout.
-                let to_ms = to.saturating_add(Duration::from_nanos(999_999)).as_millis();
+                let to_ms = to
+                    .checked_add(Duration::from_nanos(999_999))
+                    .unwrap_or(to)
+                    .as_millis();
                 cmp::min(MAX_SAFE_TIMEOUT, to_ms) as libc::c_int
             })
             .unwrap_or(-1);

--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -92,7 +92,7 @@ impl Selector {
                 // turning sub-millisecond timeouts into a zero timeout, unless
                 // the caller explicitly requests that by specifying a zero
                 // timeout.
-                let to_ms = (to + Duration::from_nanos(999_999)).as_millis();
+                let to_ms = to.saturating_add(Duration::from_nanos(999_999)).as_millis();
                 cmp::min(MAX_SAFE_TIMEOUT, to_ms) as libc::c_int
             })
             .unwrap_or(-1);

--- a/src/sys/windows/iocp.rs
+++ b/src/sys/windows/iocp.rs
@@ -228,7 +228,7 @@ fn duration_millis(dur: Option<Duration>) -> u32 {
         // turning sub-millisecond timeouts into a zero timeout, unless
         // the caller explicitly requests that by specifying a zero
         // timeout.
-        let dur_ms = (dur + Duration::from_nanos(999_999)).as_millis();
+        let dur_ms = dur.saturating_add(Duration::from_nanos(999_999)).as_millis();
         cmp::min(dur_ms, u32::MAX as u128) as u32
     } else {
         u32::MAX

--- a/src/sys/windows/iocp.rs
+++ b/src/sys/windows/iocp.rs
@@ -228,7 +228,9 @@ fn duration_millis(dur: Option<Duration>) -> u32 {
         // turning sub-millisecond timeouts into a zero timeout, unless
         // the caller explicitly requests that by specifying a zero
         // timeout.
-        let dur_ms = dur.saturating_add(Duration::from_nanos(999_999)).as_millis();
+        let dur_ms = dur
+            .saturating_add(Duration::from_nanos(999_999))
+            .as_millis();
         cmp::min(dur_ms, u32::MAX as u128) as u32
     } else {
         u32::MAX

--- a/src/sys/windows/iocp.rs
+++ b/src/sys/windows/iocp.rs
@@ -229,7 +229,8 @@ fn duration_millis(dur: Option<Duration>) -> u32 {
         // the caller explicitly requests that by specifying a zero
         // timeout.
         let dur_ms = dur
-            .saturating_add(Duration::from_nanos(999_999))
+            .checked_add(Duration::from_nanos(999_999))
+            .unwrap_or(dur)
             .as_millis();
         cmp::min(dur_ms, u32::MAX as u128) as u32
     } else {


### PR DESCRIPTION
When trying to wait for `Duration::MAX`, mio will panic with an overflow. This is a work-around for that behavior.