### PR TITLE
remove `log` dependency

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,7 +7,7 @@ env:
 task:
   name: FreeBSD
   setup_script:
-    - pkg install -y curl
+    - pkg install -y libnghttp2 curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh -y --profile minimal
   cargo_cache:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,6 @@ os-ext = [
 # Enables `mio::net` module containing networking primitives.
 net = []
 
-[dependencies]
-log = "0.4.8"
-
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.121"
 
@@ -63,7 +60,6 @@ wasi = "0.11.0"
 libc = "0.2.121"
 
 [dev-dependencies]
-env_logger = { version = "0.9.3", default-features = false }
 rand = "0.8"
 
 [package.metadata.docs.rs]

--- a/examples/tcp_listenfd_server.rs
+++ b/examples/tcp_listenfd_server.rs
@@ -36,8 +36,6 @@ fn get_first_listen_fd_listener() -> Option<std::net::TcpListener> {
 }
 
 fn main() -> io::Result<()> {
-    env_logger::init();
-
     std::env::var("LISTEN_FDS").expect("LISTEN_FDS environment variable unset");
 
     // Create a poll instance.

--- a/examples/tcp_server.rs
+++ b/examples/tcp_server.rs
@@ -15,8 +15,6 @@ const DATA: &[u8] = b"Hello world!\n";
 
 #[cfg(not(target_os = "wasi"))]
 fn main() -> io::Result<()> {
-    env_logger::init();
-
     // Create a poll instance.
     let mut poll = Poll::new()?;
     // Create storage for events.

--- a/examples/udp_server.rs
+++ b/examples/udp_server.rs
@@ -1,6 +1,5 @@
 // You can run this example from the root of the mio repo:
 // cargo run --example udp_server --features="os-poll net"
-use log::warn;
 use mio::{Events, Interest, Poll, Token};
 use std::io;
 
@@ -10,8 +9,6 @@ const UDP_SOCKET: Token = Token(0);
 #[cfg(not(target_os = "wasi"))]
 fn main() -> io::Result<()> {
     use mio::net::UdpSocket;
-
-    env_logger::init();
 
     // Create a poll instance.
     let mut poll = Poll::new()?;
@@ -72,7 +69,7 @@ fn main() -> io::Result<()> {
                     // This should never happen as we only registered our
                     // `UdpSocket` using the `UDP_SOCKET` token, but if it ever
                     // does we'll log it.
-                    warn!("Got event for unexpected token: {:?}", event);
+                    eprintln!("Got event for unexpected token: {:?}", event);
                 }
             }
         }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,5 +1,4 @@
 use crate::{event, sys, Events, Interest, Token};
-use log::trace;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::time::Duration;
@@ -529,11 +528,6 @@ impl Registry {
     where
         S: event::Source + ?Sized,
     {
-        trace!(
-            "registering event source with poller: token={:?}, interests={:?}",
-            token,
-            interests
-        );
         source.register(self, token, interests)
     }
 
@@ -597,11 +591,6 @@ impl Registry {
     where
         S: event::Source + ?Sized,
     {
-        trace!(
-            "reregistering event source with poller: token={:?}, interests={:?}",
-            token,
-            interests
-        );
         source.reregister(self, token, interests)
     }
 
@@ -660,7 +649,6 @@ impl Registry {
     where
         S: event::Source + ?Sized,
     {
-        trace!("deregistering event source from poller");
         source.deregister(self)
     }
 

--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -1,7 +1,6 @@
 use crate::{Interest, Token};
 
 use libc::{EPOLLET, EPOLLIN, EPOLLOUT, EPOLLPRI, EPOLLRDHUP};
-use log::error;
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -163,9 +162,7 @@ impl AsRawFd for Selector {
 
 impl Drop for Selector {
     fn drop(&mut self) {
-        if let Err(err) = syscall!(close(self.ep)) {
-            error!("error closing epoll: {}", err);
-        }
+        let _ = syscall!(close(self.ep));
     }
 }
 

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -1,5 +1,4 @@
 use crate::{Interest, Token};
-use log::error;
 use std::mem::{self, MaybeUninit};
 use std::ops::{Deref, DerefMut};
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -332,9 +331,7 @@ impl AsRawFd for Selector {
 
 impl Drop for Selector {
     fn drop(&mut self) {
-        if let Err(err) = syscall!(close(self.kq)) {
-            error!("error closing kqueue: {}", err);
-        }
+        let _ = syscall!(close(self.kq));
     }
 }
 

--- a/src/sys/wasi/mod.rs
+++ b/src/sys/wasi/mod.rs
@@ -77,12 +77,6 @@ impl Selector {
         events.reserve(length);
 
         debug_assert!(events.capacity() >= length);
-        #[cfg(debug_assertions)]
-        if length == 0 {
-            log::warn!(
-                "calling mio::Poll::poll with empty subscriptions, this likely not what you want"
-            );
-        }
 
         let res = unsafe { wasi::poll_oneoff(subscriptions.as_ptr(), events.as_mut_ptr(), length) };
 

--- a/tests/close_on_drop.rs
+++ b/tests/close_on_drop.rs
@@ -3,7 +3,6 @@
 
 use std::io::Read;
 
-use log::debug;
 use mio::net::{TcpListener, TcpStream};
 use mio::{Events, Interest, Poll, Token};
 
@@ -39,20 +38,15 @@ impl TestHandler {
     }
 
     fn handle_read(&mut self, poll: &mut Poll, tok: Token) {
-        debug!("readable; tok={:?}", tok);
-
         match tok {
             SERVER => {
-                debug!("server connection ready for accept");
                 let _ = self.srv.accept().unwrap();
             }
             CLIENT => {
-                debug!("client readable");
-
                 match self.state {
                     Initial => {
                         let mut buf = [0; 4096];
-                        debug!("GOT={:?}", self.cli.read(&mut buf[..]));
+                        let _ = self.cli.read(&mut buf[..]);
                         self.state = AfterRead;
                     }
                     AfterRead => {}
@@ -76,7 +70,6 @@ impl TestHandler {
         match tok {
             SERVER => panic!("received writable for token 0"),
             CLIENT => {
-                debug!("client connected");
                 poll.registry()
                     .reregister(&mut self.cli, CLIENT, Interest::READABLE)
                     .unwrap();
@@ -89,7 +82,6 @@ impl TestHandler {
 #[test]
 pub fn close_on_drop() {
     init();
-    debug!("Starting TEST_CLOSE_ON_DROP");
     let mut poll = Poll::new().unwrap();
 
     // == Create & setup server socket

--- a/tests/registering.rs
+++ b/tests/registering.rs
@@ -5,7 +5,6 @@ use std::io::{self, Write};
 use std::thread::sleep;
 use std::time::Duration;
 
-use log::{debug, info, trace};
 #[cfg(debug_assertions)]
 use mio::net::UdpSocket;
 use mio::net::{TcpListener, TcpStream};
@@ -37,7 +36,6 @@ impl TestHandler {
     fn handle_read(&mut self, registry: &Registry, token: Token) {
         match token {
             SERVER => {
-                trace!("handle_read; token=SERVER");
                 let mut sock = self.server.accept().unwrap().0;
                 if let Err(err) = sock.write(b"foobar") {
                     if err.kind() != io::ErrorKind::WouldBlock {
@@ -46,7 +44,6 @@ impl TestHandler {
                 }
             }
             CLIENT => {
-                trace!("handle_read; token=CLIENT");
                 assert!(self.state == 0, "unexpected state {}", self.state);
                 self.state = 1;
                 registry
@@ -58,8 +55,6 @@ impl TestHandler {
     }
 
     fn handle_write(&mut self, registry: &Registry, token: Token) {
-        debug!("handle_write; token={:?}; state={:?}", token, self.state);
-
         assert!(token == CLIENT, "unexpected token {:?}", token);
         assert!(self.state == 1, "unexpected state {}", self.state);
 
@@ -73,14 +68,12 @@ impl TestHandler {
 pub fn register_deregister() {
     init();
 
-    debug!("Starting TEST_REGISTER_DEREGISTER");
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
 
     let mut server = TcpListener::bind(any_local_address()).unwrap();
     let addr = server.local_addr().unwrap();
 
-    info!("register server socket");
     poll.registry()
         .register(&mut server, SERVER, Interest::READABLE)
         .unwrap();

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -13,7 +13,6 @@ use std::sync::Once;
 use std::time::Duration;
 use std::{env, fmt, fs, io};
 
-use log::{error, warn};
 use mio::event::Event;
 use mio::net::TcpStream;
 use mio::{Events, Interest, Poll, Token};
@@ -22,8 +21,6 @@ pub fn init() {
     static INIT: Once = Once::new();
 
     INIT.call_once(|| {
-        env_logger::try_init().expect("unable to initialise logger");
-
         // Remove all temporary files from previous test runs.
         let dir = temp_dir();
         let _ = fs::remove_dir_all(&dir);
@@ -147,9 +144,6 @@ pub fn expect_events(poll: &mut Poll, events: &mut Events, mut expected: Vec<Exp
 
             if let Some(index) = index {
                 expected.swap_remove(index);
-            } else {
-                // Must accept sporadic events.
-                warn!("got unexpected event: {:?}", event);
             }
         }
 
@@ -169,10 +163,7 @@ pub fn expect_no_events(poll: &mut Poll, events: &mut Events) {
     poll.poll(events, Some(Duration::from_millis(50)))
         .expect("unable to poll");
     if !events.is_empty() {
-        for event in events.iter() {
-            error!("unexpected event: {:?}", event);
-        }
-        panic!("received events, but didn't expect any, see above");
+        panic!("received events, but didn't expect any");
     }
 }
 


### PR DESCRIPTION
Currently, Mio depends on `log`. In rust-lang/log#552, the `log` maintainers aim to increase `log`'s MSRV to 1.60. This MSRV increase would impact Mio, which in turn, would impact Tokio. As of 1.25, Tokio supports Rust 1.49 with the intent of supporting it until March 2024.

Mio mostly uses the `log` dependency for debugging/tracing. Removing the `log` dependency has minimal impact and is the easiest way to resolve the MSRV issue. Additionally, this is another step towards minimizing Tokio's dependencies.