### PR TITLE
Fix FreeBSD CI test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,8 +7,7 @@ env:
 task:
   name: FreeBSD
   setup_script:
-    - pkg install -y curl
-    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - fetch https://sh.rustup.rs -o rustup.sh
     - sh rustup.sh -y --profile minimal
   cargo_cache:
     folder: $HOME/.cargo/registry


### PR DESCRIPTION
Curl is failing on CI causing FreeBSD CI test to fail on my other PR https://github.com/tokio-rs/mio/pull/1667/checks?check_run_id=13155549454

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=270940 I found other references to the same bug

Curl 7.88.1 up fails. Curl is already installed on FreeBSD so removing the command to update it fixes this issue