### PR TITLE
Expose Windows handle on Registry

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -2,6 +2,8 @@ use crate::{event, sys, Events, Interest, Token};
 use log::trace;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(windows)]
+use std::os::windows::io::{AsRawHandle, RawHandle};
 use std::time::Duration;
 use std::{fmt, io};
 
@@ -419,6 +421,13 @@ impl AsRawFd for Poll {
     }
 }
 
+#[cfg(windows)]
+impl AsRawHandle for Poll {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.registry.as_raw_handle()
+    }
+}
+
 impl fmt::Debug for Poll {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Poll").finish()
@@ -704,11 +713,25 @@ impl AsRawFd for Registry {
     }
 }
 
+#[cfg(windows)]
+impl AsRawHandle for Registry {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.selector.as_raw_handle()
+    }
+}
+
 cfg_os_poll! {
     #[cfg(unix)]
     #[test]
     pub fn as_raw_fd() {
         let poll = Poll::new().unwrap();
         assert!(poll.as_raw_fd() > 0);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    pub fn as_raw_handle() {
+        let poll = Poll::new().unwrap();
+        assert_ne!(poll.as_raw_handle(), core::ptr::null_mut());
     }
 }

--- a/src/sys/shell/selector.rs
+++ b/src/sys/shell/selector.rs
@@ -1,6 +1,8 @@
 use std::io;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(windows)]
+use std::os::windows::io::{AsRawHandle, RawHandle};
 use std::time::Duration;
 
 pub type Event = usize;
@@ -75,6 +77,13 @@ cfg_io_source! {
 #[cfg(unix)]
 impl AsRawFd for Selector {
     fn as_raw_fd(&self) -> RawFd {
+        os_required!()
+    }
+}
+
+#[cfg(windows)]
+impl AsRawHandle for Selector {
+    fn as_raw_handle(&self) -> RawHandle {
         os_required!()
     }
 }

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -15,7 +15,7 @@ use std::collections::VecDeque;
 use std::ffi::c_void;
 use std::io;
 use std::marker::PhantomPinned;
-use std::os::windows::io::RawSocket;
+use std::os::windows::io::{AsRawHandle, RawHandle, RawSocket};
 use std::pin::Pin;
 #[cfg(debug_assertions)]
 use std::sync::atomic::AtomicUsize;
@@ -407,6 +407,12 @@ cfg_io_source! {
         pub fn id(&self) -> usize {
             self.id
         }
+    }
+}
+
+impl AsRawHandle for Selector {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.inner.cp.as_raw_handle()
     }
 }
 


### PR DESCRIPTION
This PR implements `AsRawHandle` on `Registry`. I believe the implications of this are the same as having `AsRawFd` on unix, but of course I could be wrong.

Closes #1669