### PR TITLE
Don't drop Copy type in example

### DIFF
--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -79,7 +79,7 @@ use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket}
 ///                 let num_recv = echoer_socket.recv(&mut buffer)?;
 ///                 println!("echo {:?} -> {:?}", buffer, num_recv);
 ///                 buffer = [0; 9];
-///                 # drop(buffer); // Silence unused assignment warning.
+///                 # _ = buffer; // Silence unused assignment warning.
 ///                 # return Ok(());
 ///             }
 ///             _ => unreachable!()


### PR DESCRIPTION
Assign it to _ to silence the unused variable warning.