### PR TITLE
Add recv_with_ancillary_data for udp socket

### DIFF
--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -303,6 +303,13 @@ impl UdpSocket {
         self.inner.do_io(|inner| inner.recv(buf))
     }
 
+    /// Receives IP_PKTINFO ancillary message that contains a pktinfo structure that supplies some information 
+    /// about the incoming packet. This works only for datagram oriented sockets.
+    #[cfg(unix)]
+    pub fn set_pktinfo(&self, enable: bool) -> io::Result<()> {
+        self.inner.do_io(|inner| sys::udp::set_pktinfo(inner, enable))
+    }
+
     /// Receives in-band and ancillary data from the socket previously bound with connect(). On success, returns
     /// the number of bytes read.
     #[cfg(unix)]

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -303,6 +303,13 @@ impl UdpSocket {
         self.inner.do_io(|inner| inner.recv(buf))
     }
 
+    /// Receives in-band and ancillary data from the socket previously bound with connect(). On success, returns
+    /// the number of bytes read.
+    #[cfg(unix)]
+    pub fn recv_with_ancillary_data(&self, buf: &mut [u8], ancillary_data: &mut [u8]) -> io::Result<usize> {
+        self.inner.do_io(|inner| sys::udp::recv_with_ancillary_data(inner, buf, ancillary_data))
+    }
+
     /// Receives data from the socket, without removing it from the input queue.
     /// On success, returns the number of bytes read.
     ///

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -51,3 +51,14 @@ pub(crate) fn recv_with_ancillary_data(
     syscall!(recvmsg(socket.as_raw_fd(), &mut msg_hdr, 0)).map(|n| n as usize)
 }
 
+pub(crate) fn set_pktinfo(socket: &net::UdpSocket, enable: bool) -> io::Result<()> {
+    let val: libc::c_int = i32::from(enable);
+    syscall!(setsockopt(
+        socket.as_raw_fd(),
+        libc::IPPROTO_IP,
+        libc::IP_PKTINFO,
+        &val as *const libc::c_int as *const libc::c_void,
+        core::mem::size_of::<libc::c_int>() as libc::socklen_t,
+    ))?;
+    Ok(())
+}


### PR DESCRIPTION
Add recv_with_ancillary_data for udp socket to facilitate IP_PKTINFO and IP_RECVORIGDSTADDR usage.

IP_RECVORIGDSTADDR is very handly for UDP transparent proxy with tproxy, and these patches are precondition for tokio to support ancillary data receiving.

`struct cmsghdr` parsing is not included in these patches on purpose, to avoid introducing addtional dependencies.