### PR TITLE
feat: add no_eventfd cfg switch

### DIFF
--- a/src/sys/unix/waker.rs
+++ b/src/sys/unix/waker.rs
@@ -1,4 +1,4 @@
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(all(not(no_eventfd), any(target_os = "linux", target_os = "android")))]
 mod eventfd {
     use crate::sys::Selector;
     use crate::{Interest, Token};
@@ -55,7 +55,7 @@ mod eventfd {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(all(not(no_eventfd), any(target_os = "linux", target_os = "android")))]
 pub use self::eventfd::Waker;
 
 #[cfg(any(
@@ -106,6 +106,7 @@ mod kqueue {
 pub use self::kqueue::Waker;
 
 #[cfg(any(
+    no_eventfd,
     target_os = "dragonfly",
     target_os = "illumos",
     target_os = "netbsd",
@@ -176,6 +177,7 @@ mod pipe {
 }
 
 #[cfg(any(
+    no_eventfd,
     target_os = "dragonfly",
     target_os = "illumos",
     target_os = "netbsd",


### PR DESCRIPTION
This disables the use of `eventfd` on linux for the `Waker` implementation. Instead `pipe` is used as a fallback.

Because some SGX runtimes like gramine do not have a secure emulation of the `eventfd` syscall, compiling with `RUSTFLAGS='--cfg no_eventfd'` will produce a more secure SGX application.

See also:
https://gramine.readthedocs.io/en/stable/manifest-syntax.html#allowing-eventfd

Resolves: #1682