### PR TITLE
Add mio_unsupported_force_waker_pipe cfg flag

### DIFF
--- a/src/sys/unix/waker.rs
+++ b/src/sys/unix/waker.rs
@@ -1,4 +1,7 @@
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(all(
+    not(mio_unsupported_force_waker_pipe),
+    any(target_os = "linux", target_os = "android")
+))]
 mod eventfd {
     use crate::sys::Selector;
     use crate::{Interest, Token};
@@ -55,15 +58,21 @@ mod eventfd {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(all(
+    not(mio_unsupported_force_waker_pipe),
+    any(target_os = "linux", target_os = "android")
+))]
 pub use self::eventfd::Waker;
 
-#[cfg(any(
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "tvos",
-    target_os = "watchos",
+#[cfg(all(
+    not(mio_unsupported_force_waker_pipe),
+    any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos",
+    )
 ))]
 mod kqueue {
     use crate::sys::Selector;
@@ -96,16 +105,20 @@ mod kqueue {
     }
 }
 
-#[cfg(any(
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "tvos",
-    target_os = "watchos",
+#[cfg(all(
+    not(mio_unsupported_force_waker_pipe),
+    any(
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos",
+    )
 ))]
 pub use self::kqueue::Waker;
 
 #[cfg(any(
+    mio_unsupported_force_waker_pipe,
     target_os = "dragonfly",
     target_os = "illumos",
     target_os = "netbsd",
@@ -176,6 +189,7 @@ mod pipe {
 }
 
 #[cfg(any(
+    mio_unsupported_force_waker_pipe,
     target_os = "dragonfly",
     target_os = "illumos",
     target_os = "netbsd",


### PR DESCRIPTION
This, unuspported, flag forces the Waker implementation to use the pipe implementation.

This is required because some SGX runtimes like gramine do not have a secure emulation of the `eventfd` syscall, compiling with this flag will produce a more secure SGX application.

See also:
https://gramine.readthedocs.io/en/stable/manifest-syntax.html#allowing-eventfd

@haraldh I used your commit, but expanded it to also disable kqueue. I added myself as co-author and removed your sign off (as you didn't sign off the changes).

Fixes https://github.com/tokio-rs/mio/issues/1682