### PR TITLE
(mio v0.7) Fix compiling net::udp::UdpSocket doctest with Rust 1.71

### DIFF
--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -79,7 +79,7 @@ use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket}
 ///                 let num_recv = echoer_socket.recv(&mut buffer)?;
 ///                 println!("echo {:?} -> {:?}", buffer, num_recv);
 ///                 buffer = [0; 9];
-///                 # drop(buffer); // Silence unused assignment warning.
+///                 # let _ = buffer; // Silence unused assignment warning.
 ///                 # return Ok(());
 ///             }
 ///             _ => unreachable!()


### PR DESCRIPTION
With Rust 1.71 this doctest fails to compile because of a new `dropping_copy_types` warning, which is elevated to a hard error because of "deny(warnings)".

```
---- src/net/udp.rs - net::udp::UdpSocket (line 30) stdout ----
error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
  --> src/net/udp.rs:82:1
   |
54 | drop(buffer); // Silence unused assignment warning.
   | ^^^^^------^
   |      |
   |      argument has type `[u8; 9]`
   |
   = note: use `let _ = ...` to ignore the expression or result
note: the lint level is defined here
  --> src/net/udp.rs:29:9
   |
1  | #![deny(warnings)]
   |         ^^^^^^^^
   = note: `#[deny(dropping_copy_types)]` implied by `#[deny(warnings)]`
error: aborting due to previous error
Couldn't compile the test.
failures:
    src/net/udp.rs - net::udp::UdpSocket (line 30)
```

This PR changes the doctest from calling "drop(buffer)" to using the "assign to underscore to drop" trick.