### PR TITLE
Add AIX operating system support

### DIFF
--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -94,9 +94,19 @@ cfg_os_poll! {
         pub(crate) use self::selector::IoSourceState;
     }
 
-    cfg_os_ext! {
-        pub(crate) mod pipe;
-    }
+    #[cfg(any(
+        // For the public `pipe` module, must match `cfg_os_ext` macro.
+        feature = "os-ext",
+        // For the `Waker` type based on a pipe.
+        mio_unsupported_force_waker_pipe,
+        target_os = "aix",
+        target_os = "dragonfly",
+        target_os = "illumos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "redox",
+    ))]
+    pub(crate) mod pipe;
 }
 
 cfg_not_os_poll! {

--- a/src/sys/unix/net.rs
+++ b/src/sys/unix/net.rs
@@ -99,6 +99,7 @@ pub(crate) fn socket_addr(addr: &SocketAddr) -> (SocketAddrCRepr, libc::socklen_
                 sin_addr,
                 sin_zero: [0; 8],
                 #[cfg(any(
+                    target_os = "aix",
                     target_os = "dragonfly",
                     target_os = "freebsd",
                     target_os = "ios",
@@ -126,6 +127,7 @@ pub(crate) fn socket_addr(addr: &SocketAddr) -> (SocketAddrCRepr, libc::socklen_
                 sin6_flowinfo: addr.flowinfo(),
                 sin6_scope_id: addr.scope_id(),
                 #[cfg(any(
+                    target_os = "aix",
                     target_os = "dragonfly",
                     target_os = "freebsd",
                     target_os = "ios",

--- a/src/sys/unix/pipe.rs
+++ b/src/sys/unix/pipe.rs
@@ -164,6 +164,7 @@ pub fn new() -> io::Result<(Sender, Receiver)> {
     }
 
     #[cfg(any(
+        target_os = "aix",
         target_os = "ios",
         target_os = "macos",
         target_os = "tvos",

--- a/src/sys/unix/pipe.rs
+++ b/src/sys/unix/pipe.rs
@@ -191,6 +191,7 @@ pub fn new() -> io::Result<(Sender, Receiver)> {
     }
 
     #[cfg(not(any(
+        target_os = "aix",
         target_os = "android",
         target_os = "dragonfly",
         target_os = "freebsd",

--- a/src/sys/unix/pipe.rs
+++ b/src/sys/unix/pipe.rs
@@ -2,9 +2,81 @@
 //!
 //! See the [`new`] function for documentation.
 
+use std::io;
+use std::os::unix::io::RawFd;
+
+pub(crate) fn new_raw() -> io::Result<[RawFd; 2]> {
+    let mut fds: [RawFd; 2] = [-1, -1];
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "illumos",
+        target_os = "redox",
+    ))]
+    unsafe {
+        if libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC | libc::O_NONBLOCK) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+
+    #[cfg(any(
+        target_os = "aix",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "espidf",
+    ))]
+    unsafe {
+        // For platforms that don't have `pipe2(2)` we need to manually set the
+        // correct flags on the file descriptor.
+        if libc::pipe(fds.as_mut_ptr()) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        for fd in &fds {
+            if libc::fcntl(*fd, libc::F_SETFL, libc::O_NONBLOCK) != 0
+                || libc::fcntl(*fd, libc::F_SETFD, libc::FD_CLOEXEC) != 0
+            {
+                let err = io::Error::last_os_error();
+                // Don't leak file descriptors. Can't handle closing error though.
+                let _ = libc::close(fds[0]);
+                let _ = libc::close(fds[1]);
+                return Err(err);
+            }
+        }
+    }
+
+    #[cfg(not(any(
+        target_os = "aix",
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "illumos",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "redox",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "espidf",
+    )))]
+    compile_error!("unsupported target for `mio::unix::pipe`");
+
+    Ok(fds)
+}
+
+cfg_os_ext! {
 use std::fs::File;
-use std::io::{self, IoSlice, IoSliceMut, Read, Write};
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::io::{IoSlice, IoSliceMut, Read, Write};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::process::{ChildStderr, ChildStdin, ChildStdout};
 
 use crate::io_source::IoSource;
@@ -145,74 +217,10 @@ use crate::{event, Interest, Registry, Token};
 /// # }
 /// ```
 pub fn new() -> io::Result<(Sender, Receiver)> {
-    let mut fds: [RawFd; 2] = [-1, -1];
-
-    #[cfg(any(
-        target_os = "android",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "linux",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "illumos",
-        target_os = "redox",
-    ))]
-    unsafe {
-        if libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC | libc::O_NONBLOCK) != 0 {
-            return Err(io::Error::last_os_error());
-        }
-    }
-
-    #[cfg(any(
-        target_os = "aix",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "tvos",
-        target_os = "watchos",
-        target_os = "espidf",
-    ))]
-    unsafe {
-        // For platforms that don't have `pipe2(2)` we need to manually set the
-        // correct flags on the file descriptor.
-        if libc::pipe(fds.as_mut_ptr()) != 0 {
-            return Err(io::Error::last_os_error());
-        }
-
-        for fd in &fds {
-            if libc::fcntl(*fd, libc::F_SETFL, libc::O_NONBLOCK) != 0
-                || libc::fcntl(*fd, libc::F_SETFD, libc::FD_CLOEXEC) != 0
-            {
-                let err = io::Error::last_os_error();
-                // Don't leak file descriptors. Can't handle closing error though.
-                let _ = libc::close(fds[0]);
-                let _ = libc::close(fds[1]);
-                return Err(err);
-            }
-        }
-    }
-
-    #[cfg(not(any(
-        target_os = "aix",
-        target_os = "android",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "illumos",
-        target_os = "ios",
-        target_os = "linux",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "redox",
-        target_os = "tvos",
-        target_os = "watchos",
-        target_os = "espidf",
-    )))]
-    compile_error!("unsupported target for `mio::unix::pipe`");
-
-    // SAFETY: we just initialised the `fds` above.
+    let fds = new_raw()?;
+    // SAFETY: `new_raw` initialised the `fds` above.
     let r = unsafe { Receiver::from_raw_fd(fds[0]) };
     let w = unsafe { Sender::from_raw_fd(fds[1]) };
-
     Ok((w, r))
 }
 
@@ -579,3 +587,4 @@ fn set_nonblocking(fd: RawFd, nonblocking: bool) -> io::Result<()> {
 
     Ok(())
 }
+} // `cfg_os_ext!`.

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -82,6 +82,7 @@ pub(crate) fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream,
     // OSes inherit the non-blocking flag from the listener, so we just have to
     // set `CLOEXEC`.
     #[cfg(any(
+        target_os = "aix",
         target_os = "ios",
         target_os = "macos",
         target_os = "redox",

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -35,6 +35,7 @@ pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, So
     let mut socklen = mem::size_of_val(&sockaddr) as libc::socklen_t;
 
     #[cfg(not(any(
+        target_os = "aix",
         target_os = "ios",
         target_os = "macos",
         target_os = "netbsd",
@@ -58,6 +59,7 @@ pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, So
     };
 
     #[cfg(any(
+        target_os = "aix",
         target_os = "ios",
         target_os = "macos",
         target_os = "netbsd",

--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -78,6 +78,7 @@ cfg_os_poll! {
         where T: FromRawFd,
     {
         #[cfg(not(any(
+            target_os = "aix",
             target_os = "ios",
             target_os = "macos",
             target_os = "tvos",
@@ -97,6 +98,7 @@ cfg_os_poll! {
         // the file descriptors will leak. Creating `pair` above ensures that if
         // there is an error, the file descriptors are closed.
         #[cfg(any(
+            target_os = "aix",
             target_os = "ios",
             target_os = "macos",
             target_os = "tvos",

--- a/src/sys/unix/waker.rs
+++ b/src/sys/unix/waker.rs
@@ -207,7 +207,7 @@ pub use self::kqueue::Waker;
     target_os = "redox",
 ))]
 mod pipe {
-    use crate::unix::pipe::new as new_pipe;
+    use crate::sys::unix::pipe;
     use std::fs::File;
     use std::io::{self, Read, Write};
     use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
@@ -224,9 +224,9 @@ mod pipe {
 
     impl WakerInternal {
         pub fn new() -> io::Result<WakerInternal> {
-            let (sender, receiver) = new_pipe()?;
-            let sender = unsafe { File::from_raw_fd(sender.as_raw_fd()) };
-            let receiver = unsafe { File::from_raw_fd(receiver.as_raw_fd()) };
+            let [sender, receiver] = pipe::new_raw()?;
+            let sender = unsafe { File::from_raw_fd(sender) };
+            let receiver = unsafe { File::from_raw_fd(receiver) };
             Ok(WakerInternal { sender, receiver })
         }
 


### PR DESCRIPTION
AIX does not have `epoll` or `kqueue` functionality, so it relies on `force_poll_poll` feature.