### PR TITLE
Bump ntapi to 0.4 to get rid of rejected code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ libc = "0.2.86"
 [target.'cfg(windows)'.dependencies]
 miow   = "0.3.6"
 winapi = { version = "0.3", features = ["winsock2", "mswsock", "mstcpip"] }
-ntapi  = "0.3"
+ntapi  = "0.4"
 
 [dev-dependencies]
 env_logger = { version = "0.6.2", default-features = false }


### PR DESCRIPTION
[`ntapi`](https://crates.io/crates/ntapi/0.3.7) version `0.3.7` cotains code which is rejected using the latest version of rust.
I am unable to upgrade `mio` to `0.8` at the moment so it would be great if it was possible to release another `0.7.x` version with this dependency upgrade.

For reference, [here](https://github.com/MSxDOS/ntapi/issues/19) is the related issue in `ntapi`.