### PR TITLE
Backport: make `log` an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ include       = [
 # For documentation of features see the `mio::features` module.
 [features]
 # By default Mio only provides a shell implementation.
-default = []
+default = ["log"]
 
 # Enables the `Poll` and `Registry` types.
 os-poll = []
@@ -50,7 +50,7 @@ pipe = ["os-ext"] # Replaced with "os-ext" feature.
 os-util = ["os-ext"]# Replaced with "os-ext" feature.
 
 [dependencies]
-log = "0.4.8"
+log = { version = "0.4.8", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.86"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -68,3 +68,27 @@ macro_rules! cfg_any_os_ext {
         )*
     }
 }
+
+macro_rules! trace {
+    ($($t:tt)*) => {
+        #[cfg(feature = "log")]
+        log::trace!($($t)*)
+    }
+}
+
+macro_rules! error {
+    ($($t:tt)*) => {
+        #[cfg(feature = "log")]
+        {
+            log::error!($($t)*)
+        }
+
+        // Silence warnings
+        #[cfg(not(feature = "log"))]
+        {
+            if false {
+                format!($($t)*);
+            }
+        }
+    }
+}

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,5 +1,4 @@
 use crate::{event, sys, Events, Interest, Token};
-use log::trace;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::time::Duration;

--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -1,7 +1,6 @@
 use crate::{Interest, Token};
 
 use libc::{EPOLLET, EPOLLIN, EPOLLOUT, EPOLLRDHUP};
-use log::error;
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -1,5 +1,4 @@
 use crate::{Interest, Token};
-use log::error;
 use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
 use std::os::unix::io::{AsRawFd, RawFd};


### PR DESCRIPTION
Currently, Mio depends on `log`. In rust-lang/log#552, the `log` maintainers aim to increase `log`'s MSRV to 1.60. This MSRV increase would impact Mio, which in turn, would impact Tokio. As of 1.25, Tokio supports Rust 1.49 with the intent of supporting it until March 2024.

This commit makes `log` an optional dependency for those who wish to maintain a lower MSRV.

Backport of https://github.com/tokio-rs/mio/pull/1673, commit 44df449467af5b8b255f99b85f89d6bf666e1956