### PR TITLE
Run the MSRV CI check on more platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,12 @@ jobs:
     - name: Tests
       run: cargo test --all-features
   MSRV:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "windows-latest"]
+        # TODO: once we update our MSRV above 1.53 add macOS again. Currently
+        # macOS, specifically Xcode 14, broke support for rustc < 1.53. See
+        # https://github.com/rust-lang/rust/issues/105167.
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
Since we have fairly complex dependencies now I think it's best to run the check on more platforms.

Backport of https://github.com/tokio-rs/mio/pull/1709, commit 2856112500284f83dcdfa6de20dda2516caa59fb.