### PR TITLE
Skip MSRV test for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "windows-latest"]
+        # TODO: once we update our MSRV above 1.53 add macOS again. Currently
+        # macOS, specifically Xcode 14, broke support for rustc < 1.53. See
+        # https://github.com/rust-lang/rust/issues/105167.
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
According to https://github.com/rust-lang/rust/issues/105167 and https://github.com/rust-lang/rust/issues/107252#issuecomment-1555913390, Xcode 14 broke support for rustc < 1.53.