### PR TITLE
fix(force_waker_pipe): swap receiver and sender fd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,18 @@ jobs:
       run: cargo test --all-features
     - name: Tests release build
       run: cargo test --release --all-features
+  TestWakerPipe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      RUSTFLAGS: "--cfg mio_unsupported_force_waker_pipe"
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+    - name: Tests
+      run: cargo test --all-features
+    - name: Tests release build
+      run: cargo test --release --all-features
   MinimalVersions:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/src/sys/unix/waker.rs
+++ b/src/sys/unix/waker.rs
@@ -224,7 +224,7 @@ mod pipe {
 
     impl WakerInternal {
         pub fn new() -> io::Result<WakerInternal> {
-            let [sender, receiver] = pipe::new_raw()?;
+            let [receiver, sender] = pipe::new_raw()?;
             let sender = unsafe { File::from_raw_fd(sender) };
             let receiver = unsafe { File::from_raw_fd(receiver) };
             Ok(WakerInternal { sender, receiver })


### PR DESCRIPTION
Sender and receiver fd where swapped resulting in:
```
❯ RUSTFLAGS="--cfg mio_unsupported_force_waker_pipe" cargo test --test events events_all --all-features
   Compiling mio v0.8.8 (/home/harald/git/mio)
    Finished test [unoptimized + debuginfo] target(s) in 0.35s
     Running tests/events.rs (target/debug/deps/events-c745c521d9f052e3)

running 1 test
test events_all ... FAILED

failures:

---- events_all stdout ----
thread 'events_all' panicked at 'unable to wake: Os { code: 9, kind: Uncategorized, message: "Bad file descriptor" }', tests/events.rs:30:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    events_all

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s

error: test failed, to rerun pass `--test events`
```

Fixed that and added a CI test.