### PR TITLE
Update `windows-sys` 0.52

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ log = { version = "0.4.8", optional = true }
 libc = "0.2.149"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.48"
+version = "0.52"
 features = [
   "Win32_Foundation",                 # Basic types eg HANDLE
   "Win32_Networking_WinSock",         # winsock2 types/functions


### PR DESCRIPTION
This is the first update to the `windows-sys` crate in 8 months.  https://github.com/microsoft/windows-rs/releases/tag/0.52.0