### PR TITLE
Bump MSRV to v1.74

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
-      with:
-        components: clippy
     - name: Install all targets
       run: make install_targets
     - name: Install Cargo-hack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,7 @@ jobs:
       with:
         components: clippy
     - name: Clippy
-      # NOTE: `clippy::uninlined-format-args` is enabled due to MSRV.
-      run: cargo clippy --all-targets --all-features -- -D warnings -A clippy::cognitive-complexity -A clippy::uninlined-format-args
+      run: cargo clippy --all-targets --all-features -- -D warnings
   Docs:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,22 +75,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
-        # TODO: once we update our MSRV above 1.53 add macOS again. Currently
-        # macOS, specifically Xcode 14, broke support for rustc < 1.53. See
-        # https://github.com/rust-lang/rust/issues/105167.
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@master
       with:
-        # NOTE: When updating also update Clippy flags, some are disabled due to
-        # MSRV.
-        toolchain: 1.46.0
+        toolchain: 1.74.0
     - name: Check
       # We only run check allowing us to use newer features in tests.
-      # We enable all features except for the `log` feature as since log v0.4.19
-      # it requires a MSRV later then rustc 1.46.
-      run: cargo check --no-default-features --features os-poll,os-ext,net
+      run: cargo check --all-features
   Nightly:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 name = "mio"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 edition = "2021"
+rust-version = "1.74"
 name = "mio"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.

--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -581,7 +581,7 @@ fn poll_registration() {
     let interests = Interest::READABLE;
     registry.register(&mut source, token, interests).unwrap();
     assert_eq!(source.registrations.len(), 1);
-    assert_eq!(source.registrations.get(0), Some(&(token, interests)));
+    assert_eq!(source.registrations.first(), Some(&(token, interests)));
     assert!(source.reregistrations.is_empty());
     assert_eq!(source.deregister_count, 0);
 
@@ -593,7 +593,7 @@ fn poll_registration() {
     assert_eq!(source.registrations.len(), 1);
     assert_eq!(source.reregistrations.len(), 1);
     assert_eq!(
-        source.reregistrations.get(0),
+        source.reregistrations.first(),
         Some(&(re_token, re_interests))
     );
     assert_eq!(source.deregister_count, 0);


### PR DESCRIPTION
We can lower it later on when we decide we don't need the latest
version, this is being discussed in #1732.