### PR TITLE
Remove outdated work arounds

### DIFF
--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -234,9 +234,7 @@ pub mod event {
             libc::EPOLLET,
             libc::EPOLLRDHUP,
             libc::EPOLLONESHOT,
-            #[cfg(target_os = "linux")]
             libc::EPOLLEXCLUSIVE,
-            #[cfg(any(target_os = "android", target_os = "linux"))]
             libc::EPOLLWAKEUP,
             libc::EPOLL_CLOEXEC,
         );


### PR DESCRIPTION
Removes two work arounds for OSs versions we don't support any more.

Closes #1561