### PR TITLE
Update FreeBSD CI image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-12-4-release-amd64
+  image: freebsd-13-2-release-amd64
 
 env:
   RUST_BACKTRACE: full


### PR DESCRIPTION
FreeBSD 12 will officially be EoL at the end of the month.  Let's update the CI image to the oldest supported release: 13.2.