### PR TITLE
Cleanup import statements

### DIFF
--- a/examples/tcp_listenfd_server.rs
+++ b/examples/tcp_listenfd_server.rs
@@ -4,12 +4,13 @@
 // cargo +nightly build --target wasm32-wasi  --example tcp_listenfd_server --features="os-poll net"
 // wasmtime run --tcplisten 127.0.0.1:9000 --env 'LISTEN_FDS=1' target/wasm32-wasi/debug/examples/tcp_listenfd_server.wasm
 
-use mio::event::Event;
-use mio::net::{TcpListener, TcpStream};
-use mio::{Events, Interest, Poll, Registry, Token};
 use std::collections::HashMap;
 use std::io::{self, Read, Write};
 use std::str::from_utf8;
+
+use mio::event::Event;
+use mio::net::{TcpListener, TcpStream};
+use mio::{Events, Interest, Poll, Registry, Token};
 
 // Setup some tokens to allow us to identify which event is for which socket.
 const SERVER: Token = Token(0);

--- a/examples/tcp_server.rs
+++ b/examples/tcp_server.rs
@@ -1,11 +1,12 @@
 // You can run this example from the root of the mio repo:
 // cargo run --example tcp_server --features="os-poll net"
-use mio::event::Event;
-use mio::net::{TcpListener, TcpStream};
-use mio::{Events, Interest, Poll, Registry, Token};
 use std::collections::HashMap;
 use std::io::{self, Read, Write};
 use std::str::from_utf8;
+
+use mio::event::Event;
+use mio::net::{TcpListener, TcpStream};
+use mio::{Events, Interest, Poll, Registry, Token};
 
 // Setup some tokens to allow us to identify which event is for which socket.
 const SERVER: Token = Token(0);

--- a/examples/udp_server.rs
+++ b/examples/udp_server.rs
@@ -1,8 +1,9 @@
 // You can run this example from the root of the mio repo:
 // cargo run --example udp_server --features="os-poll net"
+use std::io;
+
 use log::warn;
 use mio::{Events, Interest, Poll, Token};
-use std::io;
 
 // A token to allow us to identify which event is for the `UdpSocket`.
 const UDP_SOCKET: Token = Token(0);

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -1,6 +1,6 @@
-use crate::{sys, Token};
-
 use std::fmt;
+
+use crate::{sys, Token};
 
 /// A readiness event.
 ///

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -1,7 +1,7 @@
+use std::fmt;
+
 use crate::event::Event;
 use crate::sys;
-
-use std::fmt;
 
 /// A collection of readiness events.
 ///

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -5,6 +5,6 @@ mod event;
 mod events;
 mod source;
 
-pub use self::event::Event;
-pub use self::events::{Events, Iter};
-pub use self::source::Source;
+pub use event::Event;
+pub use events::{Events, Iter};
+pub use source::Source;

--- a/src/event/source.rs
+++ b/src/event/source.rs
@@ -1,6 +1,6 @@
-use crate::{Interest, Registry, Token};
-
 use std::io;
+
+use crate::{Interest, Registry, Token};
 
 /// An event source that may be registered with [`Registry`].
 ///

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -26,14 +26,14 @@
 //! give is to always call receive with a large enough buffer.
 
 mod tcp;
-pub use self::tcp::{TcpListener, TcpStream};
+pub use tcp::{TcpListener, TcpStream};
 
 #[cfg(not(target_os = "wasi"))]
 mod udp;
 #[cfg(not(target_os = "wasi"))]
-pub use self::udp::UdpSocket;
+pub use udp::UdpSocket;
 
 #[cfg(unix)]
 mod uds;
 #[cfg(unix)]
-pub use self::uds::{SocketAddr, UnixDatagram, UnixListener, UnixStream};
+pub use uds::{SocketAddr, UnixDatagram, UnixListener, UnixStream};

--- a/src/net/tcp/mod.rs
+++ b/src/net/tcp/mod.rs
@@ -1,5 +1,5 @@
 mod listener;
-pub use self::listener::TcpListener;
+pub use listener::TcpListener;
 
 mod stream;
-pub use self::stream::TcpStream;
+pub use stream::TcpStream;

--- a/src/net/uds/mod.rs
+++ b/src/net/uds/mod.rs
@@ -1,10 +1,9 @@
 mod datagram;
-pub use self::datagram::UnixDatagram;
+pub use datagram::UnixDatagram;
 
 mod listener;
-pub use self::listener::UnixListener;
+pub use listener::UnixListener;
 
 mod stream;
-pub use self::stream::UnixStream;
-
 pub use crate::sys::SocketAddr;
+pub use stream::UnixStream;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -55,34 +55,34 @@ cfg_os_poll! {
 cfg_os_poll! {
     mod unix;
     #[allow(unused_imports)]
-    pub use self::unix::*;
+    pub use unix::*;
 }
 
 #[cfg(windows)]
 cfg_os_poll! {
     mod windows;
-    pub use self::windows::*;
+    pub use windows::*;
 }
 
 #[cfg(target_os = "wasi")]
 cfg_os_poll! {
     mod wasi;
-    pub(crate) use self::wasi::*;
+    pub(crate) use wasi::*;
 }
 
 cfg_not_os_poll! {
     mod shell;
-    pub(crate) use self::shell::*;
+    pub(crate) use shell::*;
 
     #[cfg(unix)]
     cfg_any_os_ext! {
         mod unix;
         #[cfg(feature = "os-ext")]
-        pub use self::unix::SourceFd;
+        pub use unix::SourceFd;
     }
 
     #[cfg(unix)]
     cfg_net! {
-        pub use self::unix::SocketAddr;
+        pub use unix::SocketAddr;
     }
 }

--- a/src/sys/shell/mod.rs
+++ b/src/sys/shell/mod.rs
@@ -5,12 +5,12 @@ macro_rules! os_required {
 }
 
 mod selector;
-pub(crate) use self::selector::{event, Event, Events, Selector};
+pub(crate) use selector::{event, Event, Events, Selector};
 
 #[cfg(not(target_os = "wasi"))]
 mod waker;
 #[cfg(not(target_os = "wasi"))]
-pub(crate) use self::waker::Waker;
+pub(crate) use waker::Waker;
 
 cfg_net! {
     pub(crate) mod tcp;

--- a/src/sys/shell/selector.rs
+++ b/src/sys/shell/selector.rs
@@ -76,9 +76,10 @@ impl AsRawFd for Selector {
 
 #[allow(clippy::trivially_copy_pass_by_ref)]
 pub mod event {
+    use std::fmt;
+
     use crate::sys::Event;
     use crate::Token;
-    use std::fmt;
 
     pub fn token(_: &Event) -> Token {
         os_required!();

--- a/src/sys/shell/uds.rs
+++ b/src/sys/shell/uds.rs
@@ -1,8 +1,9 @@
 pub(crate) mod datagram {
-    use crate::net::SocketAddr;
     use std::io;
     use std::os::unix::net;
     use std::path::Path;
+
+    use crate::net::SocketAddr;
 
     pub(crate) fn bind(_: &Path) -> io::Result<net::UnixDatagram> {
         os_required!()
@@ -33,10 +34,11 @@ pub(crate) mod datagram {
 }
 
 pub(crate) mod listener {
-    use crate::net::{SocketAddr, UnixStream};
     use std::io;
     use std::os::unix::net;
     use std::path::Path;
+
+    use crate::net::{SocketAddr, UnixStream};
 
     pub(crate) fn bind(_: &Path) -> io::Result<net::UnixListener> {
         os_required!()
@@ -56,10 +58,11 @@ pub(crate) mod listener {
 }
 
 pub(crate) mod stream {
-    use crate::net::SocketAddr;
     use std::io;
     use std::os::unix::net;
     use std::path::Path;
+
+    use crate::net::SocketAddr;
 
     pub(crate) fn connect(_: &Path) -> io::Result<net::UnixStream> {
         os_required!()

--- a/src/sys/shell/waker.rs
+++ b/src/sys/shell/waker.rs
@@ -1,6 +1,7 @@
+use std::io;
+
 use crate::sys::Selector;
 use crate::Token;
-use std::io;
 
 #[derive(Debug)]
 pub struct Waker {}

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -16,14 +16,14 @@ macro_rules! syscall {
 
 cfg_os_poll! {
     mod selector;
-    pub(crate) use self::selector::{event, Event, Events, Selector};
+    pub(crate) use selector::{event, Event, Events, Selector};
 
     mod sourcefd;
     #[cfg(feature = "os-ext")]
-    pub use self::sourcefd::SourceFd;
+    pub use sourcefd::SourceFd;
 
     mod waker;
-    pub(crate) use self::waker::Waker;
+    pub(crate) use waker::Waker;
 
     cfg_net! {
         mod net;
@@ -31,7 +31,7 @@ cfg_os_poll! {
         pub(crate) mod tcp;
         pub(crate) mod udp;
         pub(crate) mod uds;
-        pub use self::uds::SocketAddr;
+        pub use uds::SocketAddr;
     }
 
     cfg_io_source! {
@@ -40,6 +40,7 @@ cfg_os_poll! {
         mod stateless_io_source {
             use std::io;
             use std::os::fd::RawFd;
+
             use crate::Registry;
             use crate::Token;
             use crate::Interest;
@@ -90,10 +91,10 @@ cfg_os_poll! {
         }
 
         #[cfg(not(any(mio_unsupported_force_poll_poll, target_os = "solaris",target_os = "vita")))]
-        pub(crate) use self::stateless_io_source::IoSourceState;
+        pub(crate) use stateless_io_source::IoSourceState;
 
         #[cfg(any(mio_unsupported_force_poll_poll, target_os = "solaris", target_os = "vita"))]
-        pub(crate) use self::selector::IoSourceState;
+        pub(crate) use selector::IoSourceState;
     }
 
     #[cfg(any(
@@ -116,12 +117,12 @@ cfg_os_poll! {
 cfg_not_os_poll! {
     cfg_net! {
         mod uds;
-        pub use self::uds::SocketAddr;
+        pub use uds::SocketAddr;
     }
 
     cfg_any_os_ext! {
         mod sourcefd;
         #[cfg(feature = "os-ext")]
-        pub use self::sourcefd::SourceFd;
+        pub use sourcefd::SourceFd;
     }
 }

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -1,4 +1,3 @@
-use crate::{Interest, Token};
 use std::mem::{self, MaybeUninit};
 use std::ops::{Deref, DerefMut};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
@@ -6,6 +5,8 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use std::{cmp, io, ptr, slice};
+
+use crate::{Interest, Token};
 
 /// Unique id for use as `SelectorId`.
 #[cfg(debug_assertions)]
@@ -353,10 +354,9 @@ unsafe impl Sync for Events {}
 pub mod event {
     use std::fmt;
 
+    use super::{Filter, Flags};
     use crate::sys::Event;
     use crate::Token;
-
-    use super::{Filter, Flags};
 
     pub fn token(event: &Event) -> Token {
         Token(event.udata as usize)

--- a/src/sys/unix/selector/mod.rs
+++ b/src/sys/unix/selector/mod.rs
@@ -18,7 +18,7 @@ mod epoll;
         target_os = "redox",
     )
 ))]
-pub(crate) use self::epoll::{event, Event, Events, Selector};
+pub(crate) use epoll::{event, Event, Events, Selector};
 
 #[cfg(any(
     mio_unsupported_force_poll_poll,
@@ -32,11 +32,11 @@ mod poll;
     target_os = "solaris",
     target_os = "vita"
 ))]
-pub(crate) use self::poll::{event, Event, Events, Selector};
+pub(crate) use poll::{event, Event, Events, Selector};
 
 cfg_io_source! {
     #[cfg(any(mio_unsupported_force_poll_poll, target_os = "solaris", target_os = "vita"))]
-    pub(crate) use self::poll::IoSourceState;
+    pub(crate) use poll::IoSourceState;
 }
 
 #[cfg(all(
@@ -67,4 +67,4 @@ mod kqueue;
         target_os = "watchos",
     ),
 ))]
-pub(crate) use self::kqueue::{event, Event, Events, Selector};
+pub(crate) use kqueue::{event, Event, Events, Selector};

--- a/src/sys/unix/selector/poll.rs
+++ b/src/sys/unix/selector/poll.rs
@@ -3,16 +3,16 @@
 // Permission to use this code has been granted by original author:
 // https://github.com/tokio-rs/mio/pull/1602#issuecomment-1218441031
 
-use crate::sys::unix::waker::WakerInternal;
-use crate::{Interest, Token};
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::os::fd::{AsRawFd, RawFd};
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 use std::{cmp, fmt, io};
+
+use crate::sys::unix::waker::WakerInternal;
+use crate::{Interest, Token};
 
 /// Unique id for use as `SelectorId`.
 #[cfg(debug_assertions)]
@@ -540,10 +540,11 @@ pub struct Event {
 pub type Events = Vec<Event>;
 
 pub mod event {
+    use std::fmt;
+
     use crate::sys::unix::selector::poll::POLLRDHUP;
     use crate::sys::Event;
     use crate::Token;
-    use std::fmt;
 
     pub fn token(event: &Event) -> Token {
         event.token

--- a/src/sys/unix/sourcefd.rs
+++ b/src/sys/unix/sourcefd.rs
@@ -1,7 +1,7 @@
-use crate::{event, Interest, Registry, Token};
-
 use std::io;
 use std::os::fd::RawFd;
+
+use crate::{event, Interest, Registry, Token};
 
 /// Adapter for [`RawFd`] providing an [`event::Source`] implementation.
 ///

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,9 +1,8 @@
-use crate::sys::unix::net::{new_ip_socket, socket_addr};
-
-use std::io;
-use std::mem;
 use std::net::{self, SocketAddr};
 use std::os::fd::{AsRawFd, FromRawFd};
+use std::{io, mem};
+
+use crate::sys::unix::net::{new_ip_socket, socket_addr};
 
 pub fn bind(addr: SocketAddr) -> io::Result<net::UdpSocket> {
     let fd = new_ip_socket(addr, libc::SOCK_DGRAM)?;

--- a/src/sys/unix/uds/datagram.rs
+++ b/src/sys/unix/uds/datagram.rs
@@ -1,11 +1,11 @@
-use super::{socket_addr, SocketAddr};
-use crate::sys::unix::net::new_socket;
-
 use std::io;
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::net;
 use std::path::Path;
+
+use crate::sys::unix::net::new_socket;
+use crate::sys::unix::uds::{socket_addr, SocketAddr};
 
 pub(crate) fn bind(path: &Path) -> io::Result<net::UnixDatagram> {
     let (sockaddr, socklen) = socket_addr(path.as_os_str().as_bytes())?;

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -1,11 +1,12 @@
-use super::socket_addr;
-use crate::net::{SocketAddr, UnixStream};
-use crate::sys::unix::net::new_socket;
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::net;
 use std::path::Path;
 use std::{io, mem};
+
+use crate::net::{SocketAddr, UnixStream};
+use crate::sys::unix::net::new_socket;
+use crate::sys::unix::uds::socket_addr;
 
 pub(crate) fn bind(path: &Path) -> io::Result<net::UnixListener> {
     let socket_address = {

--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -1,5 +1,5 @@
 mod socketaddr;
-pub use self::socketaddr::SocketAddr;
+pub use socketaddr::SocketAddr;
 
 /// Get the `sun_path` field offset of `sockaddr_un` for the target OS.
 ///
@@ -129,10 +129,11 @@ cfg_os_poll! {
 
     #[cfg(test)]
     mod tests {
-        use super::{path_offset, socket_addr};
         use std::os::unix::ffi::OsStrExt;
         use std::path::Path;
         use std::str;
+
+        use super::{path_offset, socket_addr};
 
         #[test]
         fn pathname_address() {

--- a/src/sys/unix/uds/socketaddr.rs
+++ b/src/sys/unix/uds/socketaddr.rs
@@ -1,8 +1,9 @@
-use super::path_offset;
 use std::ffi::OsStr;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::{ascii, fmt};
+
+use crate::sys::uds::path_offset;
 
 /// An address associated with a `mio` specific Unix socket.
 ///

--- a/src/sys/unix/uds/stream.rs
+++ b/src/sys/unix/uds/stream.rs
@@ -1,11 +1,11 @@
-use super::{socket_addr, SocketAddr};
-use crate::sys::unix::net::new_socket;
-
 use std::io;
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::net;
 use std::path::Path;
+
+use crate::sys::unix::net::new_socket;
+use crate::sys::unix::uds::{socket_addr, SocketAddr};
 
 pub(crate) fn connect(path: &Path) -> io::Result<net::UnixStream> {
     let socket_address = {

--- a/src/sys/unix/waker.rs
+++ b/src/sys/unix/waker.rs
@@ -13,6 +13,9 @@
     not(any(target_os = "solaris", target_os = "vita")),
 ))]
 mod fdbased {
+    use std::io;
+    use std::os::fd::AsRawFd;
+
     #[cfg(all(
         not(mio_unsupported_force_waker_pipe),
         any(target_os = "linux", target_os = "android"),
@@ -30,8 +33,6 @@ mod fdbased {
     use crate::sys::unix::waker::pipe::WakerInternal;
     use crate::sys::Selector;
     use crate::{Interest, Token};
-    use std::io;
-    use std::os::fd::AsRawFd;
 
     #[derive(Debug)]
     pub struct Waker {
@@ -65,7 +66,7 @@ mod fdbased {
     )),
     not(any(target_os = "solaris", target_os = "vita")),
 ))]
-pub use self::fdbased::Waker;
+pub use fdbased::Waker;
 
 #[cfg(all(
     not(mio_unsupported_force_waker_pipe),
@@ -144,7 +145,7 @@ mod eventfd {
     not(mio_unsupported_force_waker_pipe),
     any(target_os = "linux", target_os = "android", target_os = "espidf")
 ))]
-pub(crate) use self::eventfd::WakerInternal;
+pub(crate) use eventfd::WakerInternal;
 
 #[cfg(all(
     not(mio_unsupported_force_waker_pipe),
@@ -157,10 +158,10 @@ pub(crate) use self::eventfd::WakerInternal;
     )
 ))]
 mod kqueue {
+    use std::io;
+
     use crate::sys::Selector;
     use crate::Token;
-
-    use std::io;
 
     /// Waker backed by kqueue user space notifications (`EVFILT_USER`).
     ///
@@ -197,7 +198,7 @@ mod kqueue {
         target_os = "watchos",
     )
 ))]
-pub use self::kqueue::Waker;
+pub use kqueue::Waker;
 
 #[cfg(any(
     mio_unsupported_force_waker_pipe,
@@ -211,10 +212,11 @@ pub use self::kqueue::Waker;
     target_os = "vita",
 ))]
 mod pipe {
-    use crate::sys::unix::pipe;
     use std::fs::File;
     use std::io::{self, Read, Write};
     use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+
+    use crate::sys::unix::pipe;
 
     /// Waker backed by a unix pipe.
     ///
@@ -299,7 +301,7 @@ mod pipe {
     target_os = "solaris",
     target_os = "vita",
 ))]
-pub(crate) use self::pipe::WakerInternal;
+pub(crate) use pipe::WakerInternal;
 
 #[cfg(any(
     mio_unsupported_force_poll_poll,
@@ -307,9 +309,10 @@ pub(crate) use self::pipe::WakerInternal;
     target_os = "vita"
 ))]
 mod poll {
+    use std::io;
+
     use crate::sys::Selector;
     use crate::Token;
-    use std::io;
 
     #[derive(Debug)]
     pub struct Waker {
@@ -336,4 +339,4 @@ mod poll {
     target_os = "solaris",
     target_os = "vita"
 ))]
-pub use self::poll::Waker;
+pub use poll::Waker;

--- a/src/sys/windows/afd.rs
+++ b/src/sys/windows/afd.rs
@@ -1,9 +1,8 @@
 use std::ffi::c_void;
-use std::fmt;
 use std::fs::File;
-use std::io;
 use std::mem::size_of;
 use std::os::windows::io::AsRawHandle;
+use std::{fmt, io};
 
 use windows_sys::Wdk::Storage::FileSystem::NtCancelIoFileEx;
 use windows_sys::Wdk::System::IO::NtDeviceIoControlFile;
@@ -127,7 +126,7 @@ cfg_io_source! {
     };
     use windows_sys::Win32::System::WindowsProgramming::FILE_SKIP_SET_EVENT_ON_HANDLE;
 
-    use super::iocp::CompletionPort;
+    use crate::sys::windows::iocp::CompletionPort;
 
     const AFD_HELPER_ATTRIBUTES: OBJECT_ATTRIBUTES = OBJECT_ATTRIBUTES {
         Length: size_of::<OBJECT_ATTRIBUTES>() as u32,

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use super::afd;
-use super::iocp::CompletionStatus;
+use crate::sys::windows::afd;
+use crate::sys::windows::iocp::CompletionStatus;
 use crate::Token;
 
 #[derive(Clone)]

--- a/src/sys/windows/handle.rs
+++ b/src/sys/windows/handle.rs
@@ -1,4 +1,5 @@
 use std::os::windows::io::RawHandle;
+
 use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
 
 /// Wrapper around a Windows HANDLE so that we close it upon drop in all scenarios

--- a/src/sys/windows/iocp.rs
+++ b/src/sys/windows/iocp.rs
@@ -1,18 +1,16 @@
 //! Bindings to IOCP, I/O Completion Ports
 
-use super::{Handle, Overlapped};
-use std::cmp;
-use std::fmt;
-use std::io;
-use std::mem;
-use std::os::windows::io::*;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle};
 use std::time::Duration;
+use std::{cmp, fmt, io, mem};
 
 use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
 use windows_sys::Win32::System::IO::{
     CreateIoCompletionPort, GetQueuedCompletionStatusEx, PostQueuedCompletionStatus, OVERLAPPED,
     OVERLAPPED_ENTRY,
 };
+
+use crate::sys::windows::{Handle, Overlapped};
 
 /// A handle to an Windows I/O Completion Port.
 #[derive(Debug)]

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -24,8 +24,7 @@ use windows_sys::Win32::System::IO::{
 use crate::event::Source;
 use crate::sys::windows::iocp::{CompletionPort, CompletionStatus};
 use crate::sys::windows::{Event, Handle, Overlapped};
-use crate::Registry;
-use crate::{Interest, Token};
+use crate::{Interest, Registry, Token};
 
 /// Non-blocking windows named pipe.
 ///

--- a/src/sys/windows/net.rs
+++ b/src/sys/windows/net.rs
@@ -1,7 +1,6 @@
-use std::io;
-use std::mem;
 use std::net::SocketAddr;
 use std::sync::Once;
+use std::{io, mem};
 
 use windows_sys::Win32::Networking::WinSock::{
     closesocket, ioctlsocket, socket, AF_INET, AF_INET6, FIONBIO, IN6_ADDR, IN6_ADDR_0,

--- a/src/sys/windows/overlapped.rs
+++ b/src/sys/windows/overlapped.rs
@@ -1,9 +1,9 @@
-use crate::sys::windows::Event;
-
 use std::cell::UnsafeCell;
 use std::fmt;
 
 use windows_sys::Win32::System::IO::{OVERLAPPED, OVERLAPPED_ENTRY};
+
+use crate::sys::windows::Event;
 
 #[repr(C)]
 pub(crate) struct Overlapped {

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -48,6 +48,7 @@ pub(crate) fn connect(socket: &net::TcpStream, addr: SocketAddr) -> io::Result<(
 
 pub(crate) fn listen(socket: &net::TcpListener, backlog: u32) -> io::Result<()> {
     use std::convert::TryInto;
+
     use WinSock::listen;
 
     let backlog = backlog.try_into().unwrap_or(i32::max_value());

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -4,10 +4,11 @@ use std::net::{self, SocketAddr};
 use std::os::windows::io::{AsRawSocket, FromRawSocket};
 use std::os::windows::raw::SOCKET as StdSocket; // windows-sys uses usize, stdlib uses u32/u64.
 
-use crate::sys::windows::net::{new_ip_socket, socket_addr};
 use windows_sys::Win32::Networking::WinSock::{
     bind as win_bind, getsockopt, IPPROTO_IPV6, IPV6_V6ONLY, SOCKET_ERROR, SOCK_DGRAM,
 };
+
+use crate::sys::windows::net::{new_ip_socket, socket_addr};
 
 pub fn bind(addr: SocketAddr) -> io::Result<net::UdpSocket> {
     let raw_socket = new_ip_socket(addr, SOCK_DGRAM)?;

--- a/src/sys/windows/waker.rs
+++ b/src/sys/windows/waker.rs
@@ -1,10 +1,9 @@
-use crate::sys::windows::Event;
-use crate::sys::windows::Selector;
-use crate::Token;
-
-use super::iocp::CompletionPort;
 use std::io;
 use std::sync::Arc;
+
+use crate::sys::windows::iocp::CompletionPort;
+use crate::sys::windows::{Event, Selector};
+use crate::Token;
 
 #[derive(Debug)]
 pub struct Waker {

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -1,6 +1,6 @@
-use crate::{sys, Registry, Token};
-
 use std::io;
+
+use crate::{sys, Registry, Token};
 
 /// Waker allows cross-thread waking of [`Poll`].
 ///

--- a/tests/aio.rs
+++ b/tests/aio.rs
@@ -4,14 +4,13 @@
 ))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
-use mio::{event::Source, Events, Interest, Poll, Registry, Token};
-use std::{
-    fs::File,
-    io, mem,
-    os::unix::io::{AsRawFd, RawFd},
-    pin::Pin,
-    ptr,
-};
+use std::fs::File;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::pin::Pin;
+use std::{io, mem, ptr};
+
+use mio::event::Source;
+use mio::{Events, Interest, Poll, Registry, Token};
 
 mod util;
 use util::{expect_events, expect_no_events, init, temp_file, ExpectEvent};

--- a/tests/close_on_drop.rs
+++ b/tests/close_on_drop.rs
@@ -10,7 +10,7 @@ use mio::{Events, Interest, Poll, Registry, Token};
 mod util;
 use util::{any_local_address, init};
 
-use self::TestState::{AfterRead, Initial};
+use TestState::{AfterRead, Initial};
 
 const SERVER: Token = Token(0);
 const CLIENT: Token = Token(1);

--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -1,11 +1,10 @@
 #![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
-use std::net;
 use std::sync::{Arc, Barrier};
 use std::thread::{self, sleep};
 use std::time::Duration;
-use std::{fmt, io};
+use std::{fmt, io, net};
 
 use mio::event::Source;
 use mio::net::{TcpListener, TcpStream, UdpSocket};
@@ -115,11 +114,11 @@ fn poll_closes_fd() {
 fn drop_cancels_interest_and_shuts_down() {
     init();
 
-    use mio::net::TcpStream;
-    use std::io;
     use std::io::Read;
     use std::net::TcpListener;
-    use std::thread;
+    use std::{io, thread};
+
+    use mio::net::TcpStream;
 
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -1,13 +1,14 @@
 #![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
-use mio::net::{TcpListener, TcpStream};
-use mio::{Events, Interest, Poll, Token};
 use std::io::{self, Read, Write};
 use std::net::{self, Shutdown};
 use std::sync::mpsc::channel;
 use std::thread::{self, sleep};
 use std::time::Duration;
+
+use mio::net::{TcpListener, TcpStream};
+use mio::{Events, Interest, Poll, Token};
 
 #[macro_use]
 mod util;
@@ -23,7 +24,6 @@ const SERVER: Token = Token(2);
 #[test]
 #[cfg(all(unix, not(mio_unsupported_force_poll_poll), not(debug_assertions)))]
 fn assert_size() {
-    use mio::net::*;
     use std::mem::size_of;
 
     // Without debug assertions enabled `TcpListener`, `TcpStream` and

--- a/tests/tcp_listener.rs
+++ b/tests/tcp_listener.rs
@@ -1,14 +1,15 @@
 #![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
-use mio::net::TcpListener;
-use mio::{Interest, Token};
 use std::io::{self, Read};
 use std::net::{self, SocketAddr};
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd};
 use std::sync::{Arc, Barrier};
 use std::thread;
+
+use mio::net::TcpListener;
+use mio::{Interest, Token};
 
 mod util;
 use util::{

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -5,7 +5,8 @@ use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::{self, Shutdown, SocketAddr};
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd};
-use std::sync::{mpsc::channel, Arc, Barrier};
+use std::sync::mpsc::channel;
+use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
 

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -1,16 +1,16 @@
 #![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
-use log::{debug, info};
-use mio::net::UdpSocket;
-use mio::{Events, Interest, Poll, Registry, Token};
 use std::net::{self, IpAddr, SocketAddr};
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd};
-use std::str;
 use std::sync::{Arc, Barrier};
-use std::thread;
 use std::time::Duration;
+use std::{str, thread};
+
+use log::{debug, info};
+use mio::net::UdpSocket;
+use mio::{Events, Interest, Poll, Registry, Token};
 
 #[macro_use]
 mod util;
@@ -32,7 +32,6 @@ const ID3: Token = Token(4);
 #[test]
 #[cfg(all(unix, not(mio_unsupported_force_poll_poll), not(debug_assertions)))]
 fn assert_size() {
-    use mio::net::*;
     use std::mem::size_of;
 
     // Without debug assertions enabled `TcpListener`, `TcpStream` and

--- a/tests/unix_datagram.rs
+++ b/tests/unix_datagram.rs
@@ -1,10 +1,11 @@
 #![cfg(all(unix, feature = "os-poll", feature = "net"))]
 
-use mio::net::UnixDatagram;
-use mio::{Interest, Token};
 use std::io;
 use std::net::Shutdown;
 use std::os::unix::net;
+
+use mio::net::UnixDatagram;
+use mio::{Interest, Token};
 
 #[macro_use]
 mod util;

--- a/tests/unix_listener.rs
+++ b/tests/unix_listener.rs
@@ -1,12 +1,13 @@
 #![cfg(all(unix, feature = "os-poll", feature = "net"))]
 
-use mio::net::UnixListener;
-use mio::{Interest, Token};
 use std::io::{self, Read};
 use std::os::unix::net;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Barrier};
 use std::thread;
+
+use mio::net::UnixListener;
+use mio::{Interest, Token};
 
 #[macro_use]
 mod util;

--- a/tests/unix_stream.rs
+++ b/tests/unix_stream.rs
@@ -1,7 +1,5 @@
 #![cfg(all(unix, feature = "os-poll", feature = "net"))]
 
-use mio::net::UnixStream;
-use mio::{Interest, Token};
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::Shutdown;
 use std::os::unix::net;
@@ -9,6 +7,9 @@ use std::path::Path;
 use std::sync::mpsc::channel;
 use std::sync::{Arc, Barrier};
 use std::thread;
+
+use mio::net::UnixStream;
+use mio::{Interest, Token};
 
 #[macro_use]
 mod util;

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -273,6 +273,7 @@ pub fn set_linger_zero(socket: &TcpStream) {
 #[cfg(windows)]
 pub fn set_linger_zero(socket: &TcpStream) {
     use std::os::windows::io::AsRawSocket;
+
     use windows_sys::Win32::Networking::WinSock::{
         setsockopt, LINGER, SOCKET_ERROR, SOL_SOCKET, SO_LINGER,
     };

--- a/tests/waker.rs
+++ b/tests/waker.rs
@@ -1,10 +1,11 @@
 #![cfg(not(target_os = "wasi"))]
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
-use mio::{Events, Poll, Token, Waker};
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
+
+use mio::{Events, Poll, Token, Waker};
 
 mod util;
 use util::{assert_send, assert_sync, expect_no_events, init};

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -9,7 +9,8 @@ use std::time::Duration;
 use mio::windows::NamedPipe;
 use mio::{Events, Interest, Poll, Token};
 use rand::Rng;
-use windows_sys::Win32::{Foundation::ERROR_NO_DATA, Storage::FileSystem::FILE_FLAG_OVERLAPPED};
+use windows_sys::Win32::Foundation::ERROR_NO_DATA;
+use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OVERLAPPED;
 
 fn _assert_kinds() {
     fn _assert_send<T: Send>() {}


### PR DESCRIPTION
Mio once started with the order of std, external crates, than crate internal imports. At some points this order was not enforce properly and we ended up with a mix imports statements.

This commit orders everything following imports from std, external crates, then crate internal (the `group_imports="StdExternalCrate"` rustfmt option).

This has no functional change.

This has been annoying me for a while, so I decide to fix all of it in one fell swoop.

Depends on #1745