### PR TITLE
Add do_io on peek for TcpStream

### DIFF
--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -208,7 +208,7 @@ impl TcpStream {
     /// Successive calls return the same data. This is accomplished by passing
     /// `MSG_PEEK` as a flag to the underlying recv system call.
     pub fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.inner.peek(buf)
+        self.inner.do_io(|inner| inner.peek(buf))
     }
 
     /// Execute an I/O operation ensuring that the socket receives more events


### PR DESCRIPTION
Fixes #1755 
I am not sure of the implications of this change for all platforms, but it fixes the issue on windows. I believe it should be fine on unix too, but more tests are needed.