### PR TITLE
Adding support for QNX OS

### DIFF
--- a/src/sys/unix/net.rs
+++ b/src/sys/unix/net.rs
@@ -25,6 +25,8 @@ pub(crate) fn new_socket(domain: libc::c_int, socket_type: libc::c_int) -> io::R
         target_os = "hermit",
     ))]
     let socket_type = socket_type | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
+    #[cfg(target_os = "nto")]
+    let socket_type = socket_type | libc::SOCK_CLOEXEC;
 
     let socket = syscall!(socket(domain, socket_type, 0))?;
 
@@ -61,7 +63,7 @@ pub(crate) fn new_socket(domain: libc::c_int, socket_type: libc::c_int) -> io::R
             let _ = syscall!(close(socket));
             return Err(err);
         }
-        #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+        #[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "nto")))]
         if let Err(err) = syscall!(fcntl(socket, libc::F_SETFD, libc::FD_CLOEXEC)) {
             let _ = syscall!(close(socket));
             return Err(err);

--- a/src/sys/unix/net.rs
+++ b/src/sys/unix/net.rs
@@ -54,6 +54,7 @@ pub(crate) fn new_socket(domain: libc::c_int, socket_type: libc::c_int) -> io::R
         target_os = "watchos",
         target_os = "espidf",
         target_os = "vita",
+        target_os = "nto",
     ))]
     {
         if let Err(err) = syscall!(fcntl(socket, libc::F_SETFL, libc::O_NONBLOCK)) {
@@ -117,6 +118,7 @@ pub(crate) fn socket_addr(addr: &SocketAddr) -> (SocketAddrCRepr, libc::socklen_
                     target_os = "espidf",
                     target_os = "vita",
                     target_os = "hermit",
+                    target_os = "nto",
                 ))]
                 sin_len: 0,
                 #[cfg(target_os = "vita")]
@@ -148,6 +150,7 @@ pub(crate) fn socket_addr(addr: &SocketAddr) -> (SocketAddrCRepr, libc::socklen_
                     target_os = "watchos",
                     target_os = "espidf",
                     target_os = "vita",
+                    target_os = "nto",
                 ))]
                 sin6_len: 0,
                 #[cfg(target_os = "vita")]

--- a/src/sys/unix/pipe.rs
+++ b/src/sys/unix/pipe.rs
@@ -33,6 +33,7 @@ pub(crate) fn new_raw() -> io::Result<[RawFd; 2]> {
         target_os = "tvos",
         target_os = "watchos",
         target_os = "espidf",
+        target_os = "nto",
     ))]
     unsafe {
         // For platforms that don't have `pipe2(2)` we need to manually set the
@@ -71,6 +72,7 @@ pub(crate) fn new_raw() -> io::Result<[RawFd; 2]> {
         target_os = "espidf",
         target_os = "solaris",
         target_os = "vita",
+        target_os = "nto",
     )))]
     compile_error!("unsupported target for `mio::unix::pipe`");
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -115,6 +115,7 @@ pub(crate) fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream,
                 target_os = "espidf",
                 target_os = "vita",
                 target_os = "hermit",
+                target_os = "nto",
             ))]
             syscall!(fcntl(s.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK))?;
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -95,6 +95,7 @@ pub(crate) fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream,
         target_os = "espidf",
         target_os = "vita",
         target_os = "hermit",
+        target_os = "nto",
         all(target_arch = "x86", target_os = "android"),
     ))]
     let stream = {

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -99,6 +99,7 @@ pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, So
             all(target_arch = "x86", target_os = "android"),
             target_os = "espidf",
             target_os = "vita",
+            target_os = "nto",
         ))]
         syscall!(fcntl(socket, libc::F_SETFL, libc::O_NONBLOCK))?;
 

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -53,6 +53,7 @@ pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, So
         target_os = "watchos",
         target_os = "espidf",
         target_os = "vita",
+        target_os = "nto",
         // Android x86's seccomp profile forbids calls to `accept4(2)`
         // See https://github.com/tokio-rs/mio/issues/1445 for details
         all(target_arch = "x86", target_os = "android"),
@@ -78,6 +79,7 @@ pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, So
         target_os = "watchos",
         target_os = "espidf",
         target_os = "vita",
+        target_os = "nto",
         all(target_arch = "x86", target_os = "android")
     ))]
     let socket = syscall!(accept(

--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -85,6 +85,8 @@ cfg_os_poll! {
             target_os = "nto",
         )))]
         let flags = flags | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
+        #[cfg(target_os = "nto")]
+        let flags = flags | libc::SOCK_CLOEXEC;
 
         let mut fds = [-1; 2];
         syscall!(socketpair(libc::AF_UNIX, flags, 0, fds.as_mut_ptr()))?;
@@ -108,7 +110,7 @@ cfg_os_poll! {
         ))]
         {
             syscall!(fcntl(fds[0], libc::F_SETFL, libc::O_NONBLOCK))?;
-            #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+            #[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "nto")))]
             syscall!(fcntl(fds[0], libc::F_SETFD, libc::FD_CLOEXEC))?;
             syscall!(fcntl(fds[1], libc::F_SETFL, libc::O_NONBLOCK))?;
             #[cfg(not(any(target_os = "espidf", target_os = "vita")))]

--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -82,6 +82,7 @@ cfg_os_poll! {
             target_os = "watchos",
             target_os = "espidf",
             target_os = "vita",
+            target_os = "nto",
         )))]
         let flags = flags | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
 
@@ -103,6 +104,7 @@ cfg_os_poll! {
             target_os = "watchos",
             target_os = "espidf",
             target_os = "vita",
+            target_os = "nto",
         ))]
         {
             syscall!(fcntl(fds[0], libc::F_SETFL, libc::O_NONBLOCK))?;

--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -113,7 +113,7 @@ cfg_os_poll! {
             #[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "nto")))]
             syscall!(fcntl(fds[0], libc::F_SETFD, libc::FD_CLOEXEC))?;
             syscall!(fcntl(fds[1], libc::F_SETFL, libc::O_NONBLOCK))?;
-            #[cfg(not(any(target_os = "espidf", target_os = "vita")))]
+            #[cfg(not(any(target_os = "espidf", target_os = "vita", target_os = "nto")))]
             syscall!(fcntl(fds[1], libc::F_SETFD, libc::FD_CLOEXEC))?;
         }
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -701,7 +701,7 @@ fn write_shutdown() {
     // Now, shutdown the write half of the socket.
     socket.shutdown(Shutdown::Write).unwrap();
 
-    // POLLRDHUP isn't supported on Solaris, 
+    // POLLRDHUP isn't supported on Solaris,
     if cfg!(any(target_os = "solaris", target_os = "nto")) {
         wait!(poll, is_readable, false);
     } else {

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -701,8 +701,8 @@ fn write_shutdown() {
     // Now, shutdown the write half of the socket.
     socket.shutdown(Shutdown::Write).unwrap();
 
-    // POLLRDHUP isn't supported on Solaris
-    if cfg!(target_os = "solaris") {
+    // POLLRDHUP isn't supported on Solaris, 
+    if cfg!(any(target_os = "solaris", target_os = "nto")) {
         wait!(poll, is_readable, false);
     } else {
         wait!(poll, is_readable, true);

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -515,6 +515,7 @@ fn no_events_after_deregister() {
     ignore = "fails on Windows; client read closed events are not triggered"
 )]
 #[cfg_attr(target_os = "solaris", ignore = "POLLRDHUP isn't supported on Solaris")]
+#[cfg_attr(target_os = "nto", ignore = "POLLRDHUP isn't supported on NTO")]
 fn tcp_shutdown_client_read_close_event() {
     let (mut poll, mut events) = init_with_poll();
     let barrier = Arc::new(Barrier::new(2));
@@ -552,7 +553,8 @@ fn tcp_shutdown_client_read_close_event() {
         target_os = "android",
         target_os = "illumos",
         target_os = "solaris",
-        target_os = "linux"
+        target_os = "linux",
+        target_os = "nto"
     ),
     ignore = "fails; client write_closed events are not found"
 )]
@@ -588,6 +590,7 @@ fn tcp_shutdown_client_write_close_event() {
 
 #[test]
 #[cfg_attr(target_os = "solaris", ignore = "POLLRDHUP isn't supported on Solaris")]
+#[cfg_attr(target_os = "nto", ignore = "POLLRDHUP isn't supported on NTO")]
 fn tcp_shutdown_server_write_close_event() {
     let (mut poll, mut events) = init_with_poll();
     let barrier = Arc::new(Barrier::new(2));
@@ -619,6 +622,7 @@ fn tcp_shutdown_server_write_close_event() {
 
 #[test]
 #[cfg_attr(target_os = "solaris", ignore = "POLLRDHUP isn't supported on Solaris")]
+#[cfg_attr(target_os = "nto", ignore = "POLLRDHUP isn't supported on NTO")]
 fn tcp_reset_close_event() {
     let (mut poll, mut events) = init_with_poll();
 

--- a/tests/unix_datagram.rs
+++ b/tests/unix_datagram.rs
@@ -167,6 +167,7 @@ fn unix_datagram_pair() {
 
 #[test]
 #[cfg_attr(target_os = "solaris", ignore = "POLLRDHUP isn't supported on Solaris")]
+#[cfg_attr(target_os = "nto", ignore = "POLLRDHUP isn't supported on NTO")]
 fn unix_datagram_shutdown() {
     let (mut poll, mut events) = init_with_poll();
     let path1 = temp_file("unix_datagram_shutdown1");

--- a/tests/unix_pipe.rs
+++ b/tests/unix_pipe.rs
@@ -53,6 +53,7 @@ fn smoke() {
 }
 
 #[test]
+#[cfg_attr(target_os = "nto", ignore = "Read close events are detected by NTO")]
 fn event_when_sender_is_dropped() {
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(8);
@@ -91,6 +92,7 @@ fn event_when_sender_is_dropped() {
 }
 
 #[test]
+#[cfg_attr(target_os = "nto", ignore = "Read close events are detected by NTO")]
 fn event_when_receiver_is_dropped() {
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(8);
@@ -124,10 +126,10 @@ fn event_when_receiver_is_dropped() {
 }
 
 #[test]
+#[cfg_attr(target_os = "nto", ignore = "Read close events are detected by NTO")]
 fn from_child_process_io() {
     // `cat` simply echo everything that we write via standard in.
     let mut child = Command::new("cat")
-        .env_clear()
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()
@@ -175,7 +177,6 @@ fn from_child_process_io() {
 fn nonblocking_child_process_io() {
     // `cat` simply echo everything that we write via standard in.
     let mut child = Command::new("cat")
-        .env_clear()
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()

--- a/tests/unix_pipe.rs
+++ b/tests/unix_pipe.rs
@@ -53,7 +53,10 @@ fn smoke() {
 }
 
 #[test]
-#[cfg_attr(target_os = "nto", ignore = "Writer fd close events do not trigger POLLHUP on nto target")]
+#[cfg_attr(
+    target_os = "nto",
+    ignore = "Writer fd close events do not trigger POLLHUP on nto target"
+)]
 fn event_when_sender_is_dropped() {
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(8);
@@ -92,7 +95,10 @@ fn event_when_sender_is_dropped() {
 }
 
 #[test]
-#[cfg_attr(target_os = "nto", ignore = "Read fd close events do not trigger POLLHUP on nto target")]
+#[cfg_attr(
+    target_os = "nto",
+    ignore = "Read fd close events do not trigger POLLHUP on nto target"
+)]
 fn event_when_receiver_is_dropped() {
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(8);
@@ -126,7 +132,10 @@ fn event_when_receiver_is_dropped() {
 }
 
 #[test]
-#[cfg_attr(target_os = "nto", ignore = "Read/Write close eventsdo not trigger POLLHUP on nto target")]
+#[cfg_attr(
+    target_os = "nto",
+    ignore = "Read/Write close eventsdo not trigger POLLHUP on nto target"
+)]
 fn from_child_process_io() {
     // `cat` simply echo everything that we write via standard in.
     let mut child = Command::new("cat")

--- a/tests/unix_pipe.rs
+++ b/tests/unix_pipe.rs
@@ -53,7 +53,7 @@ fn smoke() {
 }
 
 #[test]
-#[cfg_attr(target_os = "nto", ignore = "Read close events are detected by NTO")]
+#[cfg_attr(target_os = "nto", ignore = "Writer fd close events do not trigger POLLHUP on nto target")]
 fn event_when_sender_is_dropped() {
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(8);
@@ -92,7 +92,7 @@ fn event_when_sender_is_dropped() {
 }
 
 #[test]
-#[cfg_attr(target_os = "nto", ignore = "Read close events are detected by NTO")]
+#[cfg_attr(target_os = "nto", ignore = "Read fd close events do not trigger POLLHUP on nto target")]
 fn event_when_receiver_is_dropped() {
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(8);
@@ -126,7 +126,7 @@ fn event_when_receiver_is_dropped() {
 }
 
 #[test]
-#[cfg_attr(target_os = "nto", ignore = "Read close events are detected by NTO")]
+#[cfg_attr(target_os = "nto", ignore = "Read/Write close eventsdo not trigger POLLHUP on nto target")]
 fn from_child_process_io() {
     // `cat` simply echo everything that we write via standard in.
     let mut child = Command::new("cat")

--- a/tests/unix_stream.rs
+++ b/tests/unix_stream.rs
@@ -187,6 +187,7 @@ fn unix_stream_peer_addr() {
 
 #[test]
 #[cfg_attr(target_os = "solaris", ignore = "POLLRDHUP isn't supported on Solaris")]
+#[cfg_attr(target_os = "nto", ignore = "POLLRDHUP isn't supported on NTO")]
 fn unix_stream_shutdown_read() {
     let (mut poll, mut events) = init_with_poll();
     let (handle, remote_addr) = new_echo_listener(1, "unix_stream_shutdown_read");
@@ -365,6 +366,7 @@ fn unix_stream_shutdown_both() {
 
 #[test]
 #[cfg_attr(target_os = "solaris", ignore = "POLLRDHUP isn't supported on Solaris")]
+#[cfg_attr(target_os = "nto", ignore = "POLLRDHUP isn't supported on NTO")]
 fn unix_stream_shutdown_listener_write() {
     let (mut poll, mut events) = init_with_poll();
     let barrier = Arc::new(Barrier::new(2));


### PR DESCRIPTION
First try to enable mio to be used on QNX operating system.

Is this the right way to go about this? Once this is in acceptable form, can/should it be backported to one of the v0.8x/0.7x

We are not that familiar with mio development, so please advise.
As mio/tokio users we would appreciate if released versions just work "out of the box"


@AkhilTThomas I added you to the fork, so you can write there as well