### PR TITLE
Implemented the From trait for converting mio socket types into std

### DIFF
--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -255,7 +255,7 @@ impl From<TcpListener> for net::TcpListener {
         // mio::net::TcpListener which ensures that we actually pass in a valid file
         // descriptor/socket
         unsafe {
-            #[cfg(any(unix, target_os = "hermit"))]
+            #[cfg(any(unix, target_os = "hermit", target_os = "wasi"))]
             {
                 net::TcpListener::from_raw_fd(listener.into_raw_fd())
             }

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -248,3 +248,21 @@ impl FromRawFd for TcpListener {
         TcpListener::from_std(FromRawFd::from_raw_fd(fd))
     }
 }
+
+impl From<TcpListener> for net::TcpListener {
+    /// Converts a `mio::net::TcpListener` into a `std::net::TcpListener`
+    fn from(listener: TcpListener) -> Self {
+        // Safety: This is safe since we are extracting the raw fd from a well-constructed
+        // mio::net::TcpListener which ensures that we actually pass in a valid file
+        // descriptor/socket
+        unsafe {
+            #[cfg(any(unix, target_os = "hermit"))]
+            let std_listener = net::TcpListener::from_raw_fd(listener.into_raw_fd());
+
+            #[cfg(windows)]
+            let std_listener = net::TcpListener::from_raw_socket(listener.into_raw_socket());
+
+            std_listener
+        }
+    }
+}

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -256,9 +256,13 @@ impl From<TcpListener> for net::TcpListener {
         // descriptor/socket
         unsafe {
             #[cfg(any(unix, target_os = "hermit"))]
-            net::TcpListener::from_raw_fd(listener.into_raw_fd())
+            {
+                net::TcpListener::from_raw_fd(listener.into_raw_fd())
+            }
             #[cfg(windows)]
-            net::TcpListener::from_raw_socket(listener.into_raw_socket())
+            {
+                net::TcpListener::from_raw_socket(listener.into_raw_socket())
+            }
         }
     }
 }

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -250,19 +250,15 @@ impl FromRawFd for TcpListener {
 }
 
 impl From<TcpListener> for net::TcpListener {
-    /// Converts a `mio::net::TcpListener` into a `std::net::TcpListener`
     fn from(listener: TcpListener) -> Self {
         // Safety: This is safe since we are extracting the raw fd from a well-constructed
         // mio::net::TcpListener which ensures that we actually pass in a valid file
         // descriptor/socket
         unsafe {
             #[cfg(any(unix, target_os = "hermit"))]
-            let std_listener = net::TcpListener::from_raw_fd(listener.into_raw_fd());
-
+            net::TcpListener::from_raw_fd(listener.into_raw_fd())
             #[cfg(windows)]
-            let std_listener = net::TcpListener::from_raw_socket(listener.into_raw_socket());
-
-            std_listener
+            net::TcpListener::from_raw_socket(listener.into_raw_socket())
         }
     }
 }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -437,7 +437,7 @@ impl From<TcpStream> for net::TcpStream {
         // mio::net::TcpStream which ensures that we actually pass in a valid file
         // descriptor/socket
         unsafe {
-            #[cfg(any(unix, target_os = "hermit"))]
+            #[cfg(any(unix, target_os = "hermit", target_os = "wasi"))]
             {
                 net::TcpStream::from_raw_fd(stream.into_raw_fd())
             }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -430,3 +430,21 @@ impl FromRawFd for TcpStream {
         TcpStream::from_std(FromRawFd::from_raw_fd(fd))
     }
 }
+
+impl From<TcpStream> for net::TcpStream {
+    /// Converts a `mio::net::TcpStream` into a `std::net::TcpStream`
+    fn from(stream: TcpStream) -> Self {
+        // Safety: This is safe since we are extracting the raw fd from a well-constructed
+        // mio::net::TcpStream which ensures that we actually pass in a valid file
+        // descriptor/socket
+        unsafe {
+            #[cfg(any(unix, target_os = "hermit"))]
+            let std_stream = net::TcpStream::from_raw_fd(stream.into_raw_fd());
+
+            #[cfg(windows)]
+            let std_stream = net::TcpStream::from_raw_socket(stream.into_raw_socket());
+
+            std_stream
+        }
+    }
+}

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -438,9 +438,13 @@ impl From<TcpStream> for net::TcpStream {
         // descriptor/socket
         unsafe {
             #[cfg(any(unix, target_os = "hermit"))]
-            net::TcpStream::from_raw_fd(stream.into_raw_fd())
+            {
+                net::TcpStream::from_raw_fd(stream.into_raw_fd())
+            }
             #[cfg(windows)]
-            net::TcpStream::from_raw_socket(stream.into_raw_socket())
+            {
+                net::TcpStream::from_raw_socket(stream.into_raw_socket())
+            }
         }
     }
 }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -432,19 +432,15 @@ impl FromRawFd for TcpStream {
 }
 
 impl From<TcpStream> for net::TcpStream {
-    /// Converts a `mio::net::TcpStream` into a `std::net::TcpStream`
     fn from(stream: TcpStream) -> Self {
         // Safety: This is safe since we are extracting the raw fd from a well-constructed
         // mio::net::TcpStream which ensures that we actually pass in a valid file
         // descriptor/socket
         unsafe {
             #[cfg(any(unix, target_os = "hermit"))]
-            let std_stream = net::TcpStream::from_raw_fd(stream.into_raw_fd());
-
+            net::TcpStream::from_raw_fd(stream.into_raw_fd())
             #[cfg(windows)]
-            let std_stream = net::TcpStream::from_raw_socket(stream.into_raw_socket());
-
-            std_stream
+            net::TcpStream::from_raw_socket(stream.into_raw_socket())
         }
     }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -705,9 +705,13 @@ impl From<UdpSocket> for net::UdpSocket {
         // descriptor/socket
         unsafe {
             #[cfg(any(unix, target_os = "hermit"))]
-            net::UdpSocket::from_raw_fd(socket.into_raw_fd())
+            {
+                net::UdpSocket::from_raw_fd(socket.into_raw_fd())
+            }
             #[cfg(windows)]
-            net::UdpSocket::from_raw_socket(socket.into_raw_socket())
+            {
+                net::UdpSocket::from_raw_socket(socket.into_raw_socket())
+            }
         }
     }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -699,19 +699,15 @@ impl FromRawSocket for UdpSocket {
 }
 
 impl From<UdpSocket> for net::UdpSocket {
-    /// Converts a `mio::net::UdpSocket` into a `std::net::UdpSocket`
     fn from(socket: UdpSocket) -> Self {
         // Safety: This is safe since we are extracting the raw fd from a well-constructed
         // mio::net::UdpSocket which ensures that we actually pass in a valid file
         // descriptor/socket
         unsafe {
             #[cfg(any(unix, target_os = "hermit"))]
-            let std_sock = net::UdpSocket::from_raw_fd(socket.into_raw_fd());
-
+            net::UdpSocket::from_raw_fd(socket.into_raw_fd())
             #[cfg(windows)]
-            let std_sock = net::UdpSocket::from_raw_socket(socket.into_raw_socket());
-
-            std_sock
+            net::UdpSocket::from_raw_socket(socket.into_raw_socket())
         }
     }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -704,7 +704,7 @@ impl From<UdpSocket> for net::UdpSocket {
         // mio::net::UdpSocket which ensures that we actually pass in a valid file
         // descriptor/socket
         unsafe {
-            #[cfg(any(unix, target_os = "hermit"))]
+            #[cfg(any(unix, target_os = "hermit", target_os = "wasi"))]
             {
                 net::UdpSocket::from_raw_fd(socket.into_raw_fd())
             }

--- a/src/net/uds/datagram.rs
+++ b/src/net/uds/datagram.rs
@@ -234,3 +234,12 @@ impl FromRawFd for UnixDatagram {
         UnixDatagram::from_std(FromRawFd::from_raw_fd(fd))
     }
 }
+
+impl From<UnixDatagram> for net::UnixDatagram {
+    fn from(datagram: UnixDatagram) -> Self {
+        // Safety: This is safe since we are extracting the raw fd from a well-constructed
+        // mio::net::uds::UnixListener which ensures that we actually pass in a valid file
+        // descriptor/socket
+        unsafe { net::UnixDatagram::from_raw_fd(datagram.into_raw_fd()) }
+    }
+}

--- a/src/net/uds/listener.rs
+++ b/src/net/uds/listener.rs
@@ -107,3 +107,12 @@ impl FromRawFd for UnixListener {
         UnixListener::from_std(FromRawFd::from_raw_fd(fd))
     }
 }
+
+impl From<UnixListener> for net::UnixListener {
+    fn from(listener: UnixListener) -> Self {
+        // Safety: This is safe since we are extracting the raw fd from a well-constructed
+        // mio::net::uds::UnixListener which ensures that we actually pass in a valid file
+        // descriptor/socket
+        unsafe { net::UnixListener::from_raw_fd(listener.into_raw_fd()) }
+    }
+}

--- a/src/net/uds/stream.rs
+++ b/src/net/uds/stream.rs
@@ -252,3 +252,12 @@ impl FromRawFd for UnixStream {
         UnixStream::from_std(FromRawFd::from_raw_fd(fd))
     }
 }
+
+impl From<UnixStream> for net::UnixStream {
+    fn from(stream: UnixStream) -> Self {
+        // Safety: This is safe since we are extracting the raw fd from a well-constructed
+        // mio::net::uds::UnixStream which ensures that we actually pass in a valid file
+        // descriptor/socket
+        unsafe { net::UnixStream::from_raw_fd(stream.into_raw_fd()) }
+    }
+}


### PR DESCRIPTION
Implemented the following traits for conversion between the mio socket types and the std socket types:
`From<mio::net::UdpSocket> for std::net::UdpSocket;`
`From<mio::net::TcpListener> for std::net::TcpListener;`
`From<mio::net::TcpStream> for std::net::TcpStream;`

This allows the conversion without using the unsafe keyword in the user code. Inside of the trait function we use the `unsafe` keyword to access the raw underlying socket of the mic sockets. But since the mid socket types are in a well-defined state after construction, the use of unsafe here should be safe.

Closes #1754 