### PR TITLE
Replace max_value with MAX constant

### DIFF
--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -92,7 +92,7 @@ impl Selector {
 
     pub fn select(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<()> {
         let timeout = timeout.map(|to| libc::timespec {
-            tv_sec: cmp::min(to.as_secs(), libc::time_t::max_value() as u64) as libc::time_t,
+            tv_sec: cmp::min(to.as_secs(), libc::time_t::MAX as u64) as libc::time_t,
             // `Duration::subsec_nanos` is guaranteed to be less than one
             // billion (the number of nanoseconds in a second), making the
             // cast to i32 safe. The cast itself is needed for platforms

--- a/src/sys/unix/selector/poll.rs
+++ b/src/sys/unix/selector/poll.rs
@@ -507,7 +507,7 @@ fn poll(fds: &mut [PollFd], timeout: Option<Duration>) -> io::Result<usize> {
         #[cfg(target_pointer_width = "32")]
         const MAX_SAFE_TIMEOUT: u128 = 1789569;
         #[cfg(not(target_pointer_width = "32"))]
-        const MAX_SAFE_TIMEOUT: u128 = libc::c_int::max_value() as u128;
+        const MAX_SAFE_TIMEOUT: u128 = libc::c_int::MAX as u128;
 
         let timeout = timeout
             .map(|to| {

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -37,7 +37,7 @@ pub(crate) fn connect(socket: &net::TcpStream, addr: SocketAddr) -> io::Result<(
 }
 
 pub(crate) fn listen(socket: &net::TcpListener, backlog: u32) -> io::Result<()> {
-    let backlog = backlog.try_into().unwrap_or(i32::max_value());
+    let backlog = backlog.try_into().unwrap_or(i32::MAX);
     syscall!(listen(socket.as_raw_fd(), backlog))?;
     Ok(())
 }

--- a/src/sys/wasi/mod.rs
+++ b/src/sys/wasi/mod.rs
@@ -207,7 +207,7 @@ impl Selector {
 }
 
 /// Token used to a add a timeout subscription, also used in removing it again.
-const TIMEOUT_TOKEN: wasi::Userdata = wasi::Userdata::max_value();
+const TIMEOUT_TOKEN: wasi::Userdata = wasi::Userdata::MAX;
 
 /// Returns a `wasi::Subscription` for `timeout`.
 fn timeout_subscription(timeout: Duration) -> wasi::Subscription {

--- a/src/sys/windows/iocp.rs
+++ b/src/sys/windows/iocp.rs
@@ -96,7 +96,7 @@ impl CompletionPort {
         );
         let mut removed = 0;
         let timeout = duration_millis(timeout);
-        let len = cmp::min(list.len(), <u32>::max_value() as usize) as u32;
+        let len = cmp::min(list.len(), u32::MAX as usize) as u32;
         let ret = unsafe {
             GetQueuedCompletionStatusEx(
                 self.handle.raw(),

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -50,7 +50,7 @@ pub(crate) fn listen(socket: &net::TcpListener, backlog: u32) -> io::Result<()> 
     use std::convert::TryInto;
     use WinSock::listen;
 
-    let backlog = backlog.try_into().unwrap_or(i32::max_value());
+    let backlog = backlog.try_into().unwrap_or(i32::MAX);
     syscall!(
         listen(socket.as_raw_socket() as _, backlog),
         PartialEq::eq,


### PR DESCRIPTION
Fixes clippy::legacy_numeric_constants.