### PR TITLE
fix: insufficient buf size when reading windows named pipe message

### DIFF
--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -27,6 +27,8 @@ use crate::sys::windows::{Event, Handle, Overlapped};
 use crate::Registry;
 use crate::{Interest, Token};
 
+const MAX_BUFFER_SZ: usize = 65536;
+
 /// Non-blocking windows named pipe.
 ///
 /// This structure internally contains a `HANDLE` which represents the named
@@ -748,7 +750,8 @@ impl Inner {
         let mut buf = match mem::replace(&mut io.read, State::None) {
             State::None => me.get_buffer(),
             State::InsufficientBufferSize(mut buf, rem) => {
-                buf.reserve_exact(rem);
+                let sz_rem = std::cmp::min(rem, MAX_BUFFER_SZ);
+                buf.reserve_exact(sz_rem);
                 buf
             }
             e @ _ => {
@@ -955,9 +958,12 @@ fn read_done(status: &OVERLAPPED_ENTRY, events: Option<&mut Vec<Event>>) {
                 io.read = State::Ok(buf, 0);
             }
             Err(e) if e.raw_os_error() == Some(ERROR_MORE_DATA as i32) => {
+                buf.set_len(status.bytes_transferred() as usize);
                 match me.remaining_size() {
+                    Ok(rem) if rem == 0 => {
+                        io.read = State::Ok(buf, 0);
+                    }
                     Ok(rem) => {
-                        buf.set_len(status.bytes_transferred() as usize);
                         io.read = State::InsufficientBufferSize(buf, rem);
                         Inner::schedule_read(&me, &mut io, None);
                         return;

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, Mutex};
 use std::{fmt, mem, slice};
 
 use windows_sys::Win32::Foundation::{
-    ERROR_BROKEN_PIPE, ERROR_IO_INCOMPLETE, ERROR_IO_PENDING, ERROR_NO_DATA, ERROR_PIPE_CONNECTED, ERROR_MORE_DATA,
-    ERROR_PIPE_LISTENING, ERROR_MORE_DATA, HANDLE, INVALID_HANDLE_VALUE,
+    ERROR_BROKEN_PIPE, ERROR_IO_INCOMPLETE, ERROR_IO_PENDING, ERROR_MORE_DATA, ERROR_NO_DATA,
+    ERROR_PIPE_CONNECTED, ERROR_PIPE_LISTENING, HANDLE, INVALID_HANDLE_VALUE,
 };
 use windows_sys::Win32::Storage::FileSystem::{
     ReadFile, WriteFile, FILE_FLAG_FIRST_PIPE_INSTANCE, FILE_FLAG_OVERLAPPED, PIPE_ACCESS_DUPLEX,
@@ -320,7 +320,14 @@ impl Inner {
     #[inline]
     unsafe fn remaining_size(&self) -> io::Result<usize> {
         let mut remaining = 0;
-        let r = PeekNamedPipe(self.handle.raw(), std::ptr::null_mut(), 0, std::ptr::null_mut(), std::ptr::null_mut(), &mut remaining);
+        let r = PeekNamedPipe(
+            self.handle.raw(),
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut remaining,
+        );
         if r == 0 {
             Err(io::Error::last_os_error())
         } else {
@@ -579,12 +586,9 @@ impl<'a> Read for &'a NamedPipe {
                 Ok(n)
             }
 
-            // Schedule another read with a bigger buffer
-            e @ State::InsufficientBufferSize(..) => {
-                state.read = e;
-                Inner::schedule_read(&self.inner, &mut state, None);
-                Err(would_block())
-            }
+            // We scheduled another read with a bigger buffer after the first read (see `read_done`)
+            // This is not possible in theory, just like `State::None` case, but return would block for now.
+            State::InsufficientBufferSize(..) => Err(would_block()),
 
             // Looks like an in-flight read hit an error, return that here while
             // we schedule a new one.
@@ -740,10 +744,11 @@ impl Inner {
     /// returned and no read is scheduled.
     fn schedule_read(me: &Arc<Inner>, io: &mut Io, events: Option<&mut Vec<Event>>) -> bool {
         // Check to see if a read is already scheduled/completed
+
         let mut buf = match mem::replace(&mut io.read, State::None) {
             State::None => me.get_buffer(),
             State::InsufficientBufferSize(mut buf, rem) => {
-                buf.reserve(rem);
+                buf.reserve_exact(rem);
                 buf
             }
             e @ _ => {
@@ -756,7 +761,7 @@ impl Inner {
         let e = unsafe {
             let overlapped = me.read.as_ptr() as *mut _;
             let slice = slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.capacity());
-            me.read_overlapped(slice, overlapped)
+            me.read_overlapped(&mut slice[buf.len()..], overlapped)
         };
         match e {
             // See `NamedPipe::connect` above for the rationale behind `forget`
@@ -949,25 +954,18 @@ fn read_done(status: &OVERLAPPED_ENTRY, events: Option<&mut Vec<Event>>) {
                 buf.set_len(buf.len() + status.bytes_transferred() as usize);
                 io.read = State::Ok(buf, 0);
             }
-<<<<<<< HEAD
-            // This is non-fatal. The buffer was simply too small for the entire message.
-            // Deliver the bytes we got, and if the caller wants to read the rest of the
-            // message, they can initiate another read.
-            Err(e) if e.raw_os_error() == Some(ERROR_MORE_DATA as i32) => {
-                buf.set_len(status.bytes_transferred() as usize);
-                io.read = State::Ok(buf, 0);
-=======
             Err(e) if e.raw_os_error() == Some(ERROR_MORE_DATA as i32) => {
                 match me.remaining_size() {
                     Ok(rem) => {
                         buf.set_len(status.bytes_transferred() as usize);
                         io.read = State::InsufficientBufferSize(buf, rem);
+                        Inner::schedule_read(&me, &mut io, None);
+                        return;
                     }
                     Err(e) => {
                         io.read = State::Err(e);
                     }
                 }
->>>>>>> 1a84e47 (fix: insufficient buf size when reading windows named pipe message)
             }
             Err(e) => {
                 debug_assert_eq!(status.bytes_transferred(), 0);

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -554,7 +554,6 @@ impl Write for NamedPipe {
 impl<'a> Read for &'a NamedPipe {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut state = self.inner.io.lock().unwrap();
-
         if state.token.is_none() {
             return Err(would_block());
         }
@@ -746,15 +745,18 @@ impl Inner {
     /// returned and no read is scheduled.
     fn schedule_read(me: &Arc<Inner>, io: &mut Io, events: Option<&mut Vec<Event>>) -> bool {
         // Check to see if a read is already scheduled/completed
-
         let mut buf = match mem::replace(&mut io.read, State::None) {
             State::None => me.get_buffer(),
             State::InsufficientBufferSize(mut buf, rem) => {
-                let sz_rem = std::cmp::min(rem, MAX_BUFFER_SZ);
-                buf.reserve_exact(sz_rem);
+                let sz_rem = std::cmp::min(rem, MAX_BUFFER_SZ - buf.len());
+                if buf.try_reserve_exact(sz_rem).is_err() {
+                    io.read = State::Ok(buf, 0);
+                    return true;
+                }
+
                 buf
             }
-            e @ _ => {
+            e => {
                 io.read = e;
                 return true;
             }
@@ -766,6 +768,7 @@ impl Inner {
             let slice = slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.capacity());
             me.read_overlapped(&mut slice[buf.len()..], overlapped)
         };
+
         match e {
             // See `NamedPipe::connect` above for the rationale behind `forget`
             Ok(_) => {
@@ -779,15 +782,11 @@ impl Inner {
             Err(ref e) if e.raw_os_error() == Some(ERROR_PIPE_LISTENING as i32) => false,
 
             // If ERROR_MORE_DATA is returned, it means the slice of unused capacity of the
-            // buffer provided is less than the amount of data available to be read. So
-            // prioritize draining the buffer before scheduling a new read.
-            //
-            // Return `true` to indicate that an overlapped read was scheduled "successfully",
-            // without actually scheduling it. Instead, update `io.read` to `State::Ok(buf, 0)`
-            // to ensure that the next `std::io::Read::read` call is presented still with the
-            // unread data to read from.
+            // buffer provided is less than the amount of data available to be read.
+            // We might be able to resize the buffer to accommodate this,
+            // so put to `Pending` and let `read_done` handle it.
             Err(ref e) if e.raw_os_error() == Some(ERROR_MORE_DATA as i32) => {
-                io.read = State::Ok(buf, 0);
+                io.read = State::Pending(buf, 0);
                 mem::forget(me.clone());
                 true
             }
@@ -930,22 +929,9 @@ fn read_done(status: &OVERLAPPED_ENTRY, events: Option<&mut Vec<Event>>) {
 
     let mut io = me.io.lock().unwrap();
     let mut buf = match mem::replace(&mut io.read, State::None) {
-        State::Ok(buf, pos) => {
-            io.read = State::Ok(buf, pos);
-
-            // Flag readiness that we have undelivered data to be read.
-            io.notify_readable(&me, events);
-            return;
-        }
+        // The state after a read should always be `Pending`. Other states means that we have some logic error.
         State::Pending(buf, _) => buf,
-        State::Err(e) => {
-            io.read = State::Err(e);
-
-            // Flag readiness that the error needs to be delivered.
-            io.notify_readable(&me, events);
-            return;
-        }
-        State::None => unreachable!(),
+        _ => unreachable!(),
     };
     unsafe {
         match me.result(status.overlapped()) {
@@ -958,21 +944,18 @@ fn read_done(status: &OVERLAPPED_ENTRY, events: Option<&mut Vec<Event>>) {
                 io.read = State::Ok(buf, 0);
             }
             Err(e) if e.raw_os_error() == Some(ERROR_MORE_DATA as i32) => {
-                buf.set_len(status.bytes_transferred() as usize);
-                match me.remaining_size() {
-                    Ok(rem) if rem == 0 => {
-                        io.read = State::Ok(buf, 0);
-                    }
-                    Ok(rem) => {
-                        io.read = State::InsufficientBufferSize(buf, rem);
-                        Inner::schedule_read(&me, &mut io, None);
-                        return;
-                    }
-                    Err(_e) => {
-                        // When `PeekNamedPipe` encountered an error, truncate and return whatever is recoverable from the bytes
-                        io.read = State::Ok(buf, 0);
+                buf.set_len(buf.len() +  status.bytes_transferred() as usize);
+                if buf.len() < MAX_BUFFER_SZ {
+                    if let Ok(rem) = me.remaining_size() {
+                        if rem > 0 {
+                            // Our default buffer size is too small. Schedule another read, but with a bigger buffer capacity.
+                            io.read = State::InsufficientBufferSize(buf, rem);
+                            Inner::schedule_read(&me, &mut io, None);
+                            return;
+                        }
                     }
                 }
+                io.read = State::Ok(buf, 0);
             }
             Err(e) => {
                 debug_assert_eq!(status.bytes_transferred(), 0);
@@ -1012,7 +995,7 @@ fn write_done(status: &OVERLAPPED_ENTRY, events: Option<&mut Vec<Event>>) {
             io.notify_writable(&me, events);
             return;
         }
-        State::None => unreachable!(),
+        State::InsufficientBufferSize(..) | State::None => unreachable!(),
     };
 
     unsafe {

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -968,8 +968,9 @@ fn read_done(status: &OVERLAPPED_ENTRY, events: Option<&mut Vec<Event>>) {
                         Inner::schedule_read(&me, &mut io, None);
                         return;
                     }
-                    Err(e) => {
-                        io.read = State::Err(e);
+                    Err(_e) => {
+                        // When `PeekNamedPipe` encountered an error, truncate and return whatever is recoverable from the bytes
+                        io.read = State::Ok(buf, 0);
                     }
                 }
             }

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -7,14 +7,14 @@ use std::sync::{Arc, Mutex};
 use std::{fmt, mem, slice};
 
 use windows_sys::Win32::Foundation::{
-    ERROR_BROKEN_PIPE, ERROR_IO_INCOMPLETE, ERROR_IO_PENDING, ERROR_MORE_DATA, ERROR_NO_DATA,
-    ERROR_PIPE_CONNECTED, ERROR_PIPE_LISTENING, HANDLE, INVALID_HANDLE_VALUE,
+    ERROR_BROKEN_PIPE, ERROR_IO_INCOMPLETE, ERROR_IO_PENDING, ERROR_NO_DATA, ERROR_PIPE_CONNECTED, ERROR_MORE_DATA,
+    ERROR_PIPE_LISTENING, ERROR_MORE_DATA, HANDLE, INVALID_HANDLE_VALUE,
 };
 use windows_sys::Win32::Storage::FileSystem::{
     ReadFile, WriteFile, FILE_FLAG_FIRST_PIPE_INSTANCE, FILE_FLAG_OVERLAPPED, PIPE_ACCESS_DUPLEX,
 };
 use windows_sys::Win32::System::Pipes::{
-    ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, PIPE_TYPE_BYTE,
+    ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, PeekNamedPipe, PIPE_TYPE_BYTE,
     PIPE_UNLIMITED_INSTANCES,
 };
 use windows_sys::Win32::System::IO::{
@@ -315,6 +315,18 @@ impl Inner {
             Ok(transferred as usize)
         }
     }
+
+    /// Calls the `PeekNamedPipe` function to get the remaining size of message in NamedPipe
+    #[inline]
+    unsafe fn remaining_size(&self) -> io::Result<usize> {
+        let mut remaining = 0;
+        let r = PeekNamedPipe(self.handle.raw(), std::ptr::null_mut(), 0, std::ptr::null_mut(), std::ptr::null_mut(), &mut remaining);
+        if r == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(remaining as usize)
+        }
+    }
 }
 
 #[test]
@@ -357,6 +369,7 @@ enum State {
     Pending(Vec<u8>, usize),
     Ok(Vec<u8>, usize),
     Err(io::Error),
+    InsufficientBufferSize(Vec<u8>, usize),
 }
 
 // Odd tokens are for named pipes
@@ -549,7 +562,7 @@ impl<'a> Read for &'a NamedPipe {
             }
 
             // We previously read something into `data`, try to copy out some
-            // data. If we copy out all the data schedule a new read and
+            // data. If we copy out all the data, schedule a new read
             // otherwise store the buffer to get read later.
             State::Ok(data, cur) => {
                 let n = {
@@ -564,6 +577,13 @@ impl<'a> Read for &'a NamedPipe {
                     Inner::schedule_read(&self.inner, &mut state, None);
                 }
                 Ok(n)
+            }
+
+            // Schedule another read with a bigger buffer
+            e @ State::InsufficientBufferSize(..) => {
+                state.read = e;
+                Inner::schedule_read(&self.inner, &mut state, None);
+                Err(would_block())
             }
 
             // Looks like an in-flight read hit an error, return that here while
@@ -720,19 +740,24 @@ impl Inner {
     /// returned and no read is scheduled.
     fn schedule_read(me: &Arc<Inner>, io: &mut Io, events: Option<&mut Vec<Event>>) -> bool {
         // Check to see if a read is already scheduled/completed
-        match io.read {
-            State::None => {}
-            _ => return true,
-        }
+        let mut buf = match mem::replace(&mut io.read, State::None) {
+            State::None => me.get_buffer(),
+            State::InsufficientBufferSize(mut buf, rem) => {
+                buf.reserve(rem);
+                buf
+            }
+            e @ _ => {
+                io.read = e;
+                return true;
+            }
+        };
 
         // Allocate a buffer and schedule the read.
-        let mut buf = me.get_buffer();
         let e = unsafe {
             let overlapped = me.read.as_ptr() as *mut _;
             let slice = slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.capacity());
             me.read_overlapped(slice, overlapped)
         };
-
         match e {
             // See `NamedPipe::connect` above for the rationale behind `forget`
             Ok(_) => {
@@ -918,15 +943,31 @@ fn read_done(status: &OVERLAPPED_ENTRY, events: Option<&mut Vec<Event>>) {
         match me.result(status.overlapped()) {
             Ok(n) => {
                 debug_assert_eq!(status.bytes_transferred() as usize, n);
-                buf.set_len(status.bytes_transferred() as usize);
+                // Extend the len depending on the initial len is necessary
+                // when we call `ReadFile` again after resizing
+                // our internal buffer
+                buf.set_len(buf.len() + status.bytes_transferred() as usize);
                 io.read = State::Ok(buf, 0);
             }
+<<<<<<< HEAD
             // This is non-fatal. The buffer was simply too small for the entire message.
             // Deliver the bytes we got, and if the caller wants to read the rest of the
             // message, they can initiate another read.
             Err(e) if e.raw_os_error() == Some(ERROR_MORE_DATA as i32) => {
                 buf.set_len(status.bytes_transferred() as usize);
                 io.read = State::Ok(buf, 0);
+=======
+            Err(e) if e.raw_os_error() == Some(ERROR_MORE_DATA as i32) => {
+                match me.remaining_size() {
+                    Ok(rem) => {
+                        buf.set_len(status.bytes_transferred() as usize);
+                        io.read = State::InsufficientBufferSize(buf, rem);
+                    }
+                    Err(e) => {
+                        io.read = State::Err(e);
+                    }
+                }
+>>>>>>> 1a84e47 (fix: insufficient buf size when reading windows named pipe message)
             }
             Err(e) => {
                 debug_assert_eq!(status.bytes_transferred(), 0);

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -2,7 +2,8 @@
 
 use std::ffi::OsStr;
 use std::fs::OpenOptions;
-use std::io::{self, Read, Write};
+use std::io::{self, ErrorKind, Read, Write};
+use std::iter;
 use std::os::windows::ffi::OsStrExt;
 use std::os::windows::fs::OpenOptionsExt;
 use std::os::windows::io::{FromRawHandle, IntoRawHandle, RawHandle};
@@ -189,6 +190,52 @@ fn read_sz_greater_than_default_buf_size() {
     let mut buf = [0; 15314];
     assert_eq!(t!(server.read(&mut buf)), 15314);
     assert_eq!(&buf[..15314], msg.as_bytes());
+}
+
+#[test]
+fn multi_read_sz_greater_than_default_buf_size() {
+    let (mut server, mut client) = pipe_msg_mode();
+    let mut poll = t!(Poll::new());
+    t!(poll.registry().register(
+        &mut server,
+        Token(0),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
+
+    std::thread::spawn(move || {
+        let msgs = vec!["hello".repeat(10), "world".repeat(100), "mio".repeat(1000)];
+
+        let mut poll = t!(Poll::new());
+        t!(poll.registry().register(
+            &mut client,
+            Token(1),
+            Interest::READABLE | Interest::WRITABLE,
+        ));
+        let mut events = Events::with_capacity(128);
+        for msg in msgs.iter() {
+            t!(poll.poll(&mut events, None));
+            t!(client.write(msg.as_bytes()));
+        }
+    });
+
+    let mut events = Events::with_capacity(128);
+    let msgs = vec!["hello".repeat(10), "world".repeat(100), "mio".repeat(1000)];
+    for m in msgs.into_iter() {
+        let m = m.as_bytes();
+        loop {
+            t!(poll.poll(&mut events, None));
+            let events = events.iter().collect::<Vec<_>>();
+            if let Some(event) = events.iter().find(|e| e.token() == Token(0)) {
+                let mut buf = [0; 3000];
+                let Ok(read) = server.read(&mut buf) else {
+                    continue;
+                };
+                assert_eq!(read, m.len());
+                assert_eq!(buf[..read], *m);
+                break;
+            }
+        }
+    }
 }
 
 #[test]

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -2,8 +2,7 @@
 
 use std::ffi::OsStr;
 use std::fs::OpenOptions;
-use std::io::{self, ErrorKind, Read, Write};
-use std::iter;
+use std::io::{self, Read, Write};
 use std::os::windows::ffi::OsStrExt;
 use std::os::windows::fs::OpenOptionsExt;
 use std::os::windows::io::{FromRawHandle, IntoRawHandle, RawHandle};
@@ -57,7 +56,7 @@ fn client(name: &str) -> NamedPipe {
 }
 
 fn pipe_msg_mode() -> (NamedPipe, NamedPipe) {
-    let num: u64 = rand::thread_rng().gen();
+    let num: u64 = rand::rng().random();
     let name = format!(r"\\.\pipe\my-pipe-{}", num);
     let name: Vec<_> = OsStr::new(&name).encode_wide().chain(Some(0)).collect();
     unsafe {
@@ -81,7 +80,7 @@ fn pipe_msg_mode() -> (NamedPipe, NamedPipe) {
             std::ptr::null_mut(),
             OPEN_EXISTING,
             FILE_FLAG_OVERLAPPED,
-            0,
+            std::ptr::null_mut(),
         );
         let client = NamedPipe::from_raw_handle(h as RawHandle);
         (server, client)
@@ -193,6 +192,44 @@ fn read_sz_greater_than_default_buf_size() {
 }
 
 #[test]
+fn read_sz_greater_than_max_buf_size() {
+    let (mut server, mut client) = pipe_msg_mode();
+    let mut poll = t!(Poll::new());
+    t!(poll.registry().register(
+        &mut server,
+        Token(0),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
+    t!(poll.registry().register(
+        &mut client,
+        Token(1),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
+
+    let mut events = Events::with_capacity(128);
+    let msg = (0..1000000)
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join("");
+
+    t!(poll.poll(&mut events, None));
+    assert_eq!(t!(client.write(msg.as_bytes())), 5888890);
+
+    loop {
+        t!(poll.poll(&mut events, None));
+        let events = events.iter().collect::<Vec<_>>();
+        if let Some(event) = events.iter().find(|e| e.token() == Token(0)) {
+            if event.is_readable() {
+                break;
+            }
+        }
+    }
+
+    let mut buf = [0; 65535];
+    assert_eq!(t!(server.read(&mut buf)), 65535);
+}
+
+#[test]
 fn multi_read_sz_greater_than_default_buf_size() {
     let (mut server, mut client) = pipe_msg_mode();
     let mut poll = t!(Poll::new());
@@ -225,7 +262,7 @@ fn multi_read_sz_greater_than_default_buf_size() {
         loop {
             t!(poll.poll(&mut events, None));
             let events = events.iter().collect::<Vec<_>>();
-            if let Some(event) = events.iter().find(|e| e.token() == Token(0)) {
+            if events.iter().find(|e| e.token() == Token(0)).is_some() {
                 let mut buf = [0; 3000];
                 let Ok(read) = server.read(&mut buf) else {
                     continue;

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -1,14 +1,24 @@
 #![cfg(all(windows, feature = "os-poll", feature = "os-ext"))]
 
+use std::ffi::OsStr;
 use std::fs::OpenOptions;
 use std::io::{self, Read, Write};
+use std::os::windows::ffi::OsStrExt;
 use std::os::windows::fs::OpenOptionsExt;
-use std::os::windows::io::{FromRawHandle, IntoRawHandle};
+use std::os::windows::io::{FromRawHandle, IntoRawHandle, RawHandle};
 use std::time::Duration;
 
 use mio::windows::NamedPipe;
 use mio::{Events, Interest, Poll, Token};
-use windows_sys::Win32::{Foundation::ERROR_NO_DATA, Storage::FileSystem::FILE_FLAG_OVERLAPPED};
+use rand::Rng;
+use windows_sys::Win32::Foundation::ERROR_NO_DATA;
+use windows_sys::Win32::Storage::FileSystem::{
+    CreateFileW, FILE_FLAG_FIRST_PIPE_INSTANCE, FILE_FLAG_OVERLAPPED, OPEN_EXISTING,
+    PIPE_ACCESS_DUPLEX,
+};
+use windows_sys::Win32::System::Pipes::{
+    CreateNamedPipeW, PIPE_READMODE_MESSAGE, PIPE_TYPE_MESSAGE, PIPE_UNLIMITED_INSTANCES,
+};
 
 mod util;
 use util::{expect_events, ExpectEvent};
@@ -43,6 +53,38 @@ fn client(name: &str) -> NamedPipe {
         .custom_flags(FILE_FLAG_OVERLAPPED);
     let file = t!(opts.open(name));
     unsafe { NamedPipe::from_raw_handle(file.into_raw_handle()) }
+}
+
+fn pipe_msg_mode() -> (NamedPipe, NamedPipe) {
+    let num: u64 = rand::thread_rng().gen();
+    let name = format!(r"\\.\pipe\my-pipe-{}", num);
+    let name: Vec<_> = OsStr::new(&name).encode_wide().chain(Some(0)).collect();
+    unsafe {
+        let h = CreateNamedPipeW(
+            name.as_ptr(),
+            PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE | FILE_FLAG_OVERLAPPED,
+            PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE,
+            PIPE_UNLIMITED_INSTANCES,
+            65536,
+            65536,
+            0,
+            std::ptr::null_mut(),
+        );
+
+        let server = NamedPipe::from_raw_handle(h as RawHandle);
+
+        let h = CreateFileW(
+            name.as_ptr(),
+            PIPE_ACCESS_DUPLEX,
+            0,
+            std::ptr::null_mut(),
+            OPEN_EXISTING,
+            FILE_FLAG_OVERLAPPED,
+            0,
+        );
+        let client = NamedPipe::from_raw_handle(h as RawHandle);
+        (server, client)
+    }
 }
 
 fn pipe() -> (NamedPipe, NamedPipe) {
@@ -108,6 +150,45 @@ fn write_then_read() {
     let mut buf = [0; 10];
     assert_eq!(t!(server.read(&mut buf)), 4);
     assert_eq!(&buf[..4], b"1234");
+}
+
+#[test]
+fn read_sz_greater_than_default_buf_size() {
+    let (mut server, mut client) = pipe_msg_mode();
+    let mut poll = t!(Poll::new());
+    t!(poll.registry().register(
+        &mut server,
+        Token(0),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
+    t!(poll.registry().register(
+        &mut client,
+        Token(1),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
+
+    let mut events = Events::with_capacity(128);
+    let msg = (0..4106)
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join("");
+
+    t!(poll.poll(&mut events, None));
+    assert_eq!(t!(client.write(msg.as_bytes())), 15314);
+
+    loop {
+        t!(poll.poll(&mut events, None));
+        let events = events.iter().collect::<Vec<_>>();
+        if let Some(event) = events.iter().find(|e| e.token() == Token(0)) {
+            if event.is_readable() {
+                break;
+            }
+        }
+    }
+
+    let mut buf = [0; 15314];
+    assert_eq!(t!(server.read(&mut buf)), 15314);
+    assert_eq!(&buf[..15314], msg.as_bytes());
 }
 
 #[test]


### PR DESCRIPTION
Closes https://github.com/tokio-rs/tokio/issues/6460

This PR allows handling `ERROR_MORE_DATA` when the internal buffer size is less than the message in NamedPipe. When `ERROR_MORE_DATA` is hit, the internal buffer will be resized according to `PeekNamedPipe` and the remaining message will be read through subsequent call to `ReadFile`.

Also see https://github.com/tokio-rs/mio/pull/1772 for more context.