### PR TITLE
fix Wasm example instructions

### DIFF
--- a/examples/tcp_listenfd_server.rs
+++ b/examples/tcp_listenfd_server.rs
@@ -1,8 +1,8 @@
 // You can run this example from the root of the mio repo:
 // cargo run --example tcp_listenfd_server --features="os-poll net"
 // or with wasi:
-// cargo +nightly build --target wasm32-wasi  --example tcp_listenfd_server --features="os-poll net"
-// wasmtime run --tcplisten 127.0.0.1:9000 --env 'LISTEN_FDS=1' target/wasm32-wasi/debug/examples/tcp_listenfd_server.wasm
+// cargo build --target wasm32-wasi --example tcp_listenfd_server --features="os-poll net"
+// wasmtime run -S preview2=n -S tcplisten=127.0.0.1:9000 --env 'LISTEN_FDS=1' ./target/wasm32-wasi/debug/examples/tcp_listenfd_server.wasm
 
 use mio::event::Event;
 use mio::net::{TcpListener, TcpStream};


### PR DESCRIPTION
With these two new versions of the lines that state how to build the Wasm module and then how to run it with `wasmtime`, the Wasm demo of an `mio` `TcpListener` again works.

Note this crate still uses the `wasi` 0.11.0 dependency. The 0.12.0 and most recent 0.13.0 versions are built on a new WASI paradigm given the name WASI Preview 2, or WASI 0.2 for short. Those are likely going to require a lot more work again.

I'm just guessing the build will require the `wasm32-wasip2` target but the `std` library doesn't build with that target yet, so this is just a small intermediate step.

Also worth noting is the recommended `build` step has been changed. Now `+nightly` is not needed and in fact causes the build to fail due to clippy warnings being treated as errors.