### PR TITLE
Fallback to poll(2) implementation without rust flags

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,7 +1,7 @@
 #[cfg(all(
     unix,
     not(mio_unsupported_force_poll_poll),
-    not(any(target_os = "solaris", target_os = "vita"))
+    not(any(target_os = "espidf", target_os = "solaris", target_os = "vita")),
 ))]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(all(debug_assertions, not(target_os = "wasi")))]
@@ -430,7 +430,7 @@ impl Poll {
 #[cfg(all(
     unix,
     not(mio_unsupported_force_poll_poll),
-    not(any(target_os = "solaris", target_os = "vita"))
+    not(any(target_os = "espidf", target_os = "solaris", target_os = "vita")),
 ))]
 impl AsRawFd for Poll {
     fn as_raw_fd(&self) -> RawFd {
@@ -721,7 +721,7 @@ impl fmt::Debug for Registry {
 #[cfg(all(
     unix,
     not(mio_unsupported_force_poll_poll),
-    not(any(target_os = "solaris", target_os = "vita"))
+    not(any(target_os = "espidf", target_os = "solaris", target_os = "vita")),
 ))]
 impl AsRawFd for Registry {
     fn as_raw_fd(&self) -> RawFd {
@@ -733,7 +733,7 @@ cfg_os_poll! {
     #[cfg(all(
         unix,
         not(mio_unsupported_force_poll_poll),
-        not(any(target_os = "solaris", target_os = "vita")),
+        not(any(target_os = "espidf", target_os = "solaris", target_os = "vita")),
     ))]
     #[test]
     pub fn as_raw_fd() {

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,7 +1,12 @@
 #[cfg(all(
     unix,
     not(mio_unsupported_force_poll_poll),
-    not(any(target_os = "espidf", target_os = "solaris", target_os = "vita")),
+    not(any(
+        target_os = "espidf",
+        target_os = "hermit",
+        target_os = "solaris",
+        target_os = "vita"
+    )),
 ))]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(all(debug_assertions, not(target_os = "wasi")))]
@@ -430,7 +435,12 @@ impl Poll {
 #[cfg(all(
     unix,
     not(mio_unsupported_force_poll_poll),
-    not(any(target_os = "espidf", target_os = "solaris", target_os = "vita")),
+    not(any(
+        target_os = "espidf",
+        target_os = "hermit",
+        target_os = "solaris",
+        target_os = "vita"
+    )),
 ))]
 impl AsRawFd for Poll {
     fn as_raw_fd(&self) -> RawFd {
@@ -721,7 +731,12 @@ impl fmt::Debug for Registry {
 #[cfg(all(
     unix,
     not(mio_unsupported_force_poll_poll),
-    not(any(target_os = "espidf", target_os = "solaris", target_os = "vita")),
+    not(any(
+        target_os = "espidf",
+        target_os = "hermit",
+        target_os = "solaris",
+        target_os = "vita"
+    )),
 ))]
 impl AsRawFd for Registry {
     fn as_raw_fd(&self) -> RawFd {
@@ -733,7 +748,7 @@ cfg_os_poll! {
     #[cfg(all(
         unix,
         not(mio_unsupported_force_poll_poll),
-        not(any(target_os = "espidf", target_os = "solaris", target_os = "vita")),
+        not(any(target_os = "espidf", target_os = "hermit", target_os = "solaris", target_os = "vita")),
     ))]
     #[test]
     pub fn as_raw_fd() {

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -37,7 +37,7 @@ cfg_os_poll! {
 
     cfg_io_source! {
         // Both `kqueue` and `epoll` don't need to hold any user space state.
-        #[cfg(not(any(mio_unsupported_force_poll_poll, target_os = "hermit", target_os = "solaris", target_os = "vita")))]
+        #[cfg(not(any(mio_unsupported_force_poll_poll, target_os = "espidf", target_os = "hermit", target_os = "solaris", target_os = "vita")))]
         mod stateless_io_source {
             use std::io;
             #[cfg(target_os = "hermit")]
@@ -93,10 +93,10 @@ cfg_os_poll! {
             }
         }
 
-        #[cfg(not(any(mio_unsupported_force_poll_poll, target_os = "hermit", target_os = "solaris",target_os = "vita")))]
+        #[cfg(not(any(mio_unsupported_force_poll_poll, target_os = "espidf", target_os = "hermit", target_os = "solaris", target_os = "vita")))]
         pub(crate) use self::stateless_io_source::IoSourceState;
 
-        #[cfg(any(mio_unsupported_force_poll_poll, target_os = "hermit", target_os = "solaris", target_os = "vita"))]
+        #[cfg(any(mio_unsupported_force_poll_poll, target_os = "espidf", target_os = "hermit", target_os = "solaris", target_os = "vita"))]
         pub(crate) use self::selector::IoSourceState;
     }
 

--- a/src/sys/unix/selector/mod.rs
+++ b/src/sys/unix/selector/mod.rs
@@ -22,22 +22,30 @@ pub(crate) use self::epoll::{event, Event, Events, Selector};
 
 #[cfg(any(
     mio_unsupported_force_poll_poll,
+    target_os = "espidf",
+    target_os = "hermit",
     target_os = "solaris",
     target_os = "vita",
-    target_os = "hermit"
 ))]
 mod poll;
 
 #[cfg(any(
     mio_unsupported_force_poll_poll,
+    target_os = "espidf",
+    target_os = "hermit",
     target_os = "solaris",
     target_os = "vita",
-    target_os = "hermit"
 ))]
 pub(crate) use self::poll::{event, Event, Events, Selector};
 
 cfg_io_source! {
-    #[cfg(any(mio_unsupported_force_poll_poll, target_os = "hermit", target_os = "solaris", target_os = "vita"))]
+    #[cfg(any(
+        mio_unsupported_force_poll_poll,
+        target_os = "espidf",
+        target_os = "hermit",
+        target_os = "solaris",
+        target_os = "vita",
+    ))]
     pub(crate) use self::poll::IoSourceState;
 }
 

--- a/src/sys/unix/selector/poll.rs
+++ b/src/sys/unix/selector/poll.rs
@@ -3,20 +3,20 @@
 // Permission to use this code has been granted by original author:
 // https://github.com/tokio-rs/mio/pull/1602#issuecomment-1218441031
 
-use crate::sys::unix::selector::LOWEST_FD;
-use crate::sys::unix::waker::WakerInternal;
-use crate::{Interest, Token};
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 #[cfg(target_os = "hermit")]
 use std::os::hermit::io::{AsRawFd, RawFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 use std::{cmp, fmt, io};
+
+use crate::sys::unix::selector::LOWEST_FD;
+use crate::sys::unix::waker::WakerInternal;
+use crate::{Interest, Token};
 
 /// Unique id for use as `SelectorId`.
 #[cfg(debug_assertions)]
@@ -74,6 +74,7 @@ impl Selector {
     pub fn wake(&self, token: Token) -> io::Result<()> {
         self.state.wake(token)
     }
+
     cfg_io_source! {
         #[cfg(debug_assertions)]
         pub fn id(&self) -> usize {

--- a/src/sys/unix/waker.rs
+++ b/src/sys/unix/waker.rs
@@ -168,12 +168,10 @@ mod eventfd {
     any(
         target_os = "android",
         target_os = "espidf",
+        target_os = "hermit",
         target_os = "linux",
     )
 ))]
-pub(crate) use self::eventfd::WakerInternal;
-
-#[cfg(target_os = "hermit")]
 pub(crate) use self::eventfd::WakerInternal;
 
 #[cfg(all(

--- a/src/sys/unix/waker.rs
+++ b/src/sys/unix/waker.rs
@@ -10,7 +10,12 @@
             target_os = "watchos",
         )
     )),
-    not(any(target_os = "solaris", target_os = "vita", target_os = "hermit")),
+    not(any(
+        target_os = "espidf",
+        target_os = "hermit",
+        target_os = "solaris",
+        target_os = "vita"
+    )),
 ))]
 mod fdbased {
     #[cfg(all(
@@ -63,17 +68,22 @@ mod fdbased {
             target_os = "watchos",
         )
     )),
-    not(any(target_os = "solaris", target_os = "vita", target_os = "hermit")),
+    not(any(
+        target_os = "espidf",
+        target_os = "hermit",
+        target_os = "solaris",
+        target_os = "vita"
+    )),
 ))]
 pub use self::fdbased::Waker;
 
 #[cfg(all(
     not(mio_unsupported_force_waker_pipe),
     any(
-        target_os = "linux",
         target_os = "android",
         target_os = "espidf",
-        target_os = "hermit"
+        target_os = "hermit",
+        target_os = "linux",
     )
 ))]
 mod eventfd {
@@ -123,7 +133,11 @@ mod eventfd {
             }
         }
 
-        #[cfg(any(mio_unsupported_force_poll_poll, target_os = "hermit"))]
+        #[cfg(any(
+            mio_unsupported_force_poll_poll,
+            target_os = "espidf",
+            target_os = "hermit"
+        ))]
         pub fn ack_and_reset(&self) {
             let _ = self.reset();
         }
@@ -150,9 +164,12 @@ mod eventfd {
 }
 
 #[cfg(all(
-    mio_unsupported_force_poll_poll,
     not(mio_unsupported_force_waker_pipe),
-    any(target_os = "linux", target_os = "android", target_os = "espidf")
+    any(
+        target_os = "android",
+        target_os = "espidf",
+        target_os = "linux",
+    )
 ))]
 pub(crate) use self::eventfd::WakerInternal;
 
@@ -269,8 +286,9 @@ mod pipe {
 
         #[cfg(any(
             mio_unsupported_force_poll_poll,
+            target_os = "espidf",
             target_os = "solaris",
-            target_os = "vita"
+            target_os = "vita",
         ))]
         pub fn ack_and_reset(&self) {
             self.empty();
@@ -316,9 +334,10 @@ pub(crate) use self::pipe::WakerInternal;
 
 #[cfg(any(
     mio_unsupported_force_poll_poll,
+    target_os = "espidf",
+    target_os = "hermit",
     target_os = "solaris",
     target_os = "vita",
-    target_os = "hermit"
 ))]
 mod poll {
     use crate::sys::Selector;
@@ -347,8 +366,9 @@ mod poll {
 
 #[cfg(any(
     mio_unsupported_force_poll_poll,
+    target_os = "espidf",
+    target_os = "hermit",
     target_os = "solaris",
     target_os = "vita",
-    target_os = "hermit"
 ))]
 pub use self::poll::Waker;

--- a/src/sys/unix/waker.rs
+++ b/src/sys/unix/waker.rs
@@ -166,10 +166,9 @@ mod eventfd {
 #[cfg(all(
     not(mio_unsupported_force_waker_pipe),
     any(
-        target_os = "android",
+        mio_unsupported_force_poll_poll,
         target_os = "espidf",
         target_os = "hermit",
-        target_os = "linux",
     )
 ))]
 pub(crate) use self::eventfd::WakerInternal;


### PR DESCRIPTION
This makes ESP-IDF and Hermit work, using poll(2), without any cfg flags.

Updates #1703