### PR TITLE
Fix compilation on Hermit

### DIFF
--- a/src/io_source.rs
+++ b/src/io_source.rs
@@ -1,6 +1,10 @@
 use std::ops::{Deref, DerefMut};
-#[cfg(any(unix, target_os = "hermit", target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi"))]
 use std::os::fd::AsRawFd;
+// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
+// can use `std::os::fd` and be merged with the above.
+#[cfg(target_os = "hermit")]
+use std::os::hermit::io::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawSocket;
 #[cfg(debug_assertions)]

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -1,6 +1,10 @@
 use std::net::{self, SocketAddr};
-#[cfg(any(unix, target_os = "hermit", target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi"))]
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
+// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
+// can use `std::os::fd` and be merged with the above.
+#[cfg(target_os = "hermit")]
+use std::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
 use std::{fmt, io};

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -1,8 +1,12 @@
 use std::fmt;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::{self, Shutdown, SocketAddr};
-#[cfg(any(unix, target_os = "hermit", target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi"))]
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
+// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
+// can use `std::os::fd` and be merged with the above.
+#[cfg(target_os = "hermit")]
+use std::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -8,8 +8,12 @@
 //! [portability guidelines]: ../struct.Poll.html#portability
 
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
-#[cfg(any(unix, target_os = "hermit", target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi"))]
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
+// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
+// can use `std::os::fd` and be merged with the above.
+#[cfg(target_os = "hermit")]
+use std::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
 use std::{fmt, io, net};

--- a/src/sys/shell/mod.rs
+++ b/src/sys/shell/mod.rs
@@ -21,12 +21,16 @@ cfg_net! {
 
 cfg_io_source! {
     use std::io;
+    #[cfg(any(unix))]
+    use std::os::fd::RawFd;
+    // TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
+    // can use `std::os::fd` and be merged with the above.
+    #[cfg(target_os = "hermit")]
+    use std::os::hermit::io::RawFd;
     #[cfg(windows)]
     use std::os::windows::io::RawSocket;
-    #[cfg(unix)]
-    use std::os::fd::RawFd;
 
-    #[cfg(any(windows, unix))]
+    #[cfg(any(windows, unix, target_os = "hermit"))]
     use crate::{Registry, Token, Interest};
 
     pub(crate) struct IoSourceState;
@@ -46,7 +50,7 @@ cfg_io_source! {
         }
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, target_os = "hermit"))]
     impl IoSourceState {
         pub fn register(
             &mut self,

--- a/src/sys/shell/tcp.rs
+++ b/src/sys/shell/tcp.rs
@@ -21,7 +21,7 @@ pub(crate) fn listen(_: &net::TcpListener, _: u32) -> io::Result<()> {
     os_required!();
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "hermit"))]
 pub(crate) fn set_reuseaddr(_: &net::TcpListener, _: bool) -> io::Result<()> {
     os_required!();
 }

--- a/src/sys/unix/selector/poll.rs
+++ b/src/sys/unix/selector/poll.rs
@@ -5,7 +5,12 @@
 
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
+#[cfg(not(target_os = "hermit"))]
 use std::os::fd::{AsRawFd, RawFd};
+// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
+// can use `std::os::fd` and be merged with the above.
+#[cfg(target_os = "hermit")]
+use std::os::hermit::io::{AsRawFd, RawFd};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;

--- a/src/sys/unix/sourcefd.rs
+++ b/src/sys/unix/sourcefd.rs
@@ -1,5 +1,10 @@
 use std::io;
+#[cfg(not(target_os = "hermit"))]
 use std::os::fd::RawFd;
+// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
+// can use `std::os::fd` and be merged with the above.
+#[cfg(target_os = "hermit")]
+use std::os::hermit::io::RawFd;
 
 use crate::{event, Interest, Registry, Token};
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -2,7 +2,12 @@ use std::convert::TryInto;
 use std::io;
 use std::mem::{size_of, MaybeUninit};
 use std::net::{self, SocketAddr};
+#[cfg(not(target_os = "hermit"))]
 use std::os::fd::{AsRawFd, FromRawFd};
+// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
+// can use `std::os::fd` and be merged with the above.
+#[cfg(target_os = "hermit")]
+use std::os::hermit::io::{AsRawFd, FromRawFd};
 
 use crate::sys::unix::net::{new_socket, socket_addr, to_socket_addr};
 

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,7 +1,12 @@
 use std::io;
 use std::mem;
 use std::net::{self, SocketAddr};
+#[cfg(not(target_os = "hermit"))]
 use std::os::fd::{AsRawFd, FromRawFd};
+// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
+// can use `std::os::fd` and be merged with the above.
+#[cfg(target_os = "hermit")]
+use std::os::hermit::io::{AsRawFd, FromRawFd};
 
 use crate::sys::unix::net::{new_ip_socket, socket_addr};
 

--- a/src/sys/unix/waker.rs
+++ b/src/sys/unix/waker.rs
@@ -90,7 +90,12 @@ pub use self::fdbased::Waker;
 mod eventfd {
     use std::fs::File;
     use std::io::{self, Read, Write};
+    #[cfg(not(target_os = "hermit"))]
     use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+    // TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
+    // can use `std::os::fd` and be merged with the above.
+    #[cfg(target_os = "hermit")]
+    use std::os::hermit::io::{AsRawFd, FromRawFd, RawFd};
 
     /// Waker backed by `eventfd`.
     ///


### PR DESCRIPTION
For some reason the `std::os::fd` module is not available on Hermit. It seems like an oversight and I've opened rust-lang/rust#126198 to track a fix.