### PR TITLE
Expand checks on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,9 +136,14 @@ jobs:
           - aarch64-apple-visionos
           - aarch64-apple-watchos
           - aarch64-linux-android
+          - aarch64-unknown-freebsd
           - aarch64-unknown-hermit
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - aarch64-unknown-netbsd
           - aarch64-unknown-nto-qnx710
           - aarch64-unknown-openbsd
+          - aarch64-unknown-redox
           - arm-linux-androideabi
           - arm64_32-apple-watchos
           - armv7-sony-vita-newlibeabihf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,7 @@ jobs:
           - arm64_32-apple-watchos
           - armv7-sony-vita-newlibeabihf
           - i686-unknown-linux-gnu
+          - riscv32imc-esp-espidf
           - sparcv9-sun-solaris
           - wasm32-wasi
           - x86_64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
           - aarch64-apple-ios
           - aarch64-apple-tvos
           - aarch64-apple-visionos
+          - aarch64-apple-watchos
           - aarch64-linux-android
           - aarch64-unknown-openbsd
           - arm-linux-androideabi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
           - aarch64-apple-watchos
           - aarch64-linux-android
           - aarch64-unknown-hermit
+          - aarch64-unknown-nto-qnx710
           - aarch64-unknown-openbsd
           - arm-linux-androideabi
           - arm64_32-apple-watchos
@@ -146,6 +147,7 @@ jobs:
           - wasm32-wasi
           - x86_64-apple-darwin
           - x86_64-apple-ios
+          - x86_64-pc-nto-qnx710
           - x86_64-pc-solaris
           # TODO: solve the following err:
           # `Error calling dlltool 'x86_64-w64-mingw32-dlltool'`, build log:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
           - aarch64-apple-visionos
           - aarch64-apple-watchos
           - aarch64-linux-android
+          - aarch64-unknown-hermit
           - aarch64-unknown-openbsd
           - arm-linux-androideabi
           - arm64_32-apple-watchos
@@ -153,6 +154,7 @@ jobs:
           - x86_64-pc-windows-msvc
           - x86_64-unknown-dragonfly
           - x86_64-unknown-freebsd
+          - x86_64-unknown-hermit
           - x86_64-unknown-illumos
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl


### PR DESCRIPTION
Expand our checking of various OS on the CI. Mainly watchOS, Hermit, QNX OS and ESP-IDF.