### PR TITLE
Reduce MSRV to v1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.74.0
+        toolchain: 1.70
     - name: Check
       # We only run check allowing us to use newer features in tests.
       run: cargo check --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,9 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.70
+        # NOTE: full version (including .0) to work around
+        # <https://github.com/dtolnay/rust-toolchain/issues/112>.
+        toolchain: 1.70.0
     - name: Check
       # We only run check allowing us to use newer features in tests.
       run: cargo check --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.70"
 name = "mio"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Rust version can an older minor version instead. Below is a list of Mio versions
 and their MSRV:
 
  * v0.8: Rust 1.46.
- * v1.0: Rust 1.74.
+ * v1.0: Rust 1.70.
 
 Note however that Mio also has dependencies, which might have different MSRV
 policies. We try to stick to the above policy when updating dependencies, but


### PR DESCRIPTION
Released on 1 June 2023, gives us 1 year of supported Rust versions.

Closes #1732