### PR TITLE
Remove Solaris from unsupported list

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,8 @@ This uses the Windows AFD system to access socket readiness events.
 
 ### Unsupported
 
-* Solaris, see [issue #1152]
 * Wine, see [issue #1444]
 
-[issue #1152]: https://github.com/tokio-rs/mio/issues/1152
 [issue #1444]: https://github.com/tokio-rs/mio/issues/1444
 
 ## MSRV Policy


### PR DESCRIPTION
We now support it via the poll(2) implementation.

It's also `cargo check`ed in our CI already.

Closes #1152