### PR TITLE
[illumos] switch waker impl back to being pipe-based

### DIFF
--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -59,7 +59,6 @@ cfg_os_poll! {
             target_os = "espidf",
             target_os = "fuchsia",
             target_os = "hermit",
-            target_os = "illumos",
             target_os = "linux",
         )
     ), path = "waker/eventfd.rs")]
@@ -94,6 +93,7 @@ cfg_os_poll! {
         target_os = "dragonfly",
         target_os = "haiku",
         target_os = "hurd",
+        target_os = "illumos",
         target_os = "netbsd",
         target_os = "nto",
         target_os = "openbsd",
@@ -146,6 +146,7 @@ cfg_os_poll! {
             target_os = "openbsd",
             target_os = "redox",
             target_os = "solaris",
+            target_os = "illumos",
             target_os = "vita",
         ),
         // Hermit doesn't support pipes.


### PR DESCRIPTION
In 1133ed006b9e2a6dcf27edcdf54309ce648c3a15, it looks like the waker implementation on illumos (perhaps inadvertently) got switched from being pipe-based to being eventfd-based. Unfortunately, the eventfd impl seems to break the `waker_multiple_wakeups_different_thread` test on illumos:

```
thread 'waker_multiple_wakeups_different_thread' panicked at tests/waker.rs:157:5:
assertion failed: !events.is_empty()
```

While we separately figure out what might be going wrong in the eventfd impl, it's worth switching back to the old pipe-based impl which is known to work, and which does fix this test.

See https://github.com/oxidecomputer/helios/issues/169.