### PR TITLE
Copy illumos waker pipe work around to eventfd

### DIFF
--- a/src/sys/unix/waker/eventfd.rs
+++ b/src/sys/unix/waker/eventfd.rs
@@ -47,7 +47,7 @@ impl Waker {
         // generated.
         // See https://www.illumos.org/issues/16700.
         #[cfg(target_os = "illumos")]
-        self.reset();
+        self.reset()?;
 
         let buf: [u8; 8] = 1u64.to_ne_bytes();
         match (&self.fd).write(&buf) {

--- a/src/sys/unix/waker/pipe.rs
+++ b/src/sys/unix/waker/pipe.rs
@@ -40,7 +40,7 @@ impl Waker {
         // The epoll emulation on some illumos systems currently requires
         // the pipe buffer to be completely empty for an edge-triggered
         // wakeup on the pipe read side.
-        // See https://www.illumos.org/issues/16700.
+        // See https://www.illumos.org/issues/13436.
         #[cfg(target_os = "illumos")]
         self.empty();
 

--- a/src/sys/unix/waker/pipe.rs
+++ b/src/sys/unix/waker/pipe.rs
@@ -40,6 +40,7 @@ impl Waker {
         // The epoll emulation on some illumos systems currently requires
         // the pipe buffer to be completely empty for an edge-triggered
         // wakeup on the pipe read side.
+        // See https://www.illumos.org/issues/16700.
         #[cfg(target_os = "illumos")]
         self.empty();
 


### PR DESCRIPTION
It seems the same behaviour we seen for pipe waker implementation is also true for eventfd. Work around this by resetting the waker before writing to it.