### PR TITLE
Fix Hermit build

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -51,8 +51,8 @@ macro_rules! cfg_net {
 macro_rules! cfg_io_source {
     ($($item:item)*) => {
         $(
-            #[cfg(any(feature = "net", all(any(unix, target_os = "hermit"), feature = "os-ext")))]
-            #[cfg_attr(docsrs, doc(cfg(any(feature = "net", all(any(unix, target_os = "hermit"), feature = "os-ext")))))]
+            #[cfg(any(feature = "net", all(unix, feature = "os-ext")))]
+            #[cfg_attr(docsrs, doc(cfg(any(feature = "net", all(unix, feature = "os-ext")))))]
             $item
         )*
     }


### PR DESCRIPTION
The Hermit build would fail if --no-default-features --features os-ext were passed as flags. This is because the cfg_io_source! macro assumed that IoSource was needed for os-ext, which is true for Unix due to the usage of the Unix pipe, but not true for Hermit (it doesn't support Unix pipes).