### PR TITLE
Implement more I/O safety traits.

### DIFF
--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -1,12 +1,14 @@
 use std::net::{self, SocketAddr};
 #[cfg(any(unix, target_os = "wasi"))]
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 // TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
 // can use `std::os::fd` and be merged with the above.
 #[cfg(target_os = "hermit")]
-use std::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd, OwnedFd};
+use std::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 #[cfg(windows)]
-use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket, OwnedSocket, BorrowedSocket, AsSocket};
+use std::os::windows::io::{
+    AsRawSocket, AsSocket, BorrowedSocket, FromRawSocket, IntoRawSocket, OwnedSocket, RawSocket,
+};
 use std::{fmt, io};
 
 use crate::io_source::IoSource;

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -1,12 +1,12 @@
 use std::net::{self, SocketAddr};
 #[cfg(any(unix, target_os = "wasi"))]
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd, OwnedFd};
 // TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
 // can use `std::os::fd` and be merged with the above.
 #[cfg(target_os = "hermit")]
-use std::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
+use std::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd, OwnedFd};
 #[cfg(windows)]
-use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
+use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket, OwnedSocket, BorrowedSocket, AsSocket};
 use std::{fmt, io};
 
 use crate::io_source::IoSource;
@@ -196,9 +196,29 @@ impl FromRawFd for TcpListener {
 }
 
 #[cfg(any(unix, target_os = "hermit", target_os = "wasi"))]
+impl From<TcpListener> for OwnedFd {
+    fn from(tcp_listener: TcpListener) -> Self {
+        tcp_listener.inner.into_inner().into()
+    }
+}
+
+#[cfg(any(unix, target_os = "hermit", target_os = "wasi"))]
 impl AsFd for TcpListener {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.as_fd()
+    }
+}
+
+#[cfg(any(unix, target_os = "hermit", target_os = "wasi"))]
+impl From<OwnedFd> for TcpListener {
+    /// Converts a `RawFd` to a `TcpListener`.
+    ///
+    /// # Notes
+    ///
+    /// The caller is responsible for ensuring that the socket is in
+    /// non-blocking mode.
+    fn from(fd: OwnedFd) -> Self {
+        TcpListener::from_std(From::from(fd))
     }
 }
 
@@ -226,6 +246,33 @@ impl FromRawSocket for TcpListener {
     /// non-blocking mode.
     unsafe fn from_raw_socket(socket: RawSocket) -> TcpListener {
         TcpListener::from_std(FromRawSocket::from_raw_socket(socket))
+    }
+}
+
+#[cfg(windows)]
+impl From<TcpListener> for OwnedSocket {
+    fn from(tcp_listener: TcpListener) -> Self {
+        tcp_listener.inner.into_inner().into()
+    }
+}
+
+#[cfg(windows)]
+impl AsSocket for TcpListener {
+    fn as_socket(&self) -> BorrowedSocket<'_> {
+        self.inner.as_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedSocket> for TcpListener {
+    /// Converts a `RawSocket` to a `TcpListener`.
+    ///
+    /// # Notes
+    ///
+    /// The caller is responsible for ensuring that the socket is in
+    /// non-blocking mode.
+    fn from(socket: OwnedSocket) -> Self {
+        TcpListener::from_std(From::from(socket))
     }
 }
 

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -2,13 +2,15 @@ use std::fmt;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::{self, Shutdown, SocketAddr};
 #[cfg(any(unix, target_os = "wasi"))]
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 // TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
 // can use `std::os::fd` and be merged with the above.
 #[cfg(target_os = "hermit")]
-use std::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd, OwnedFd};
+use std::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 #[cfg(windows)]
-use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket, OwnedSocket, BorrowedSocket, AsSocket};
+use std::os::windows::io::{
+    AsRawSocket, AsSocket, BorrowedSocket, FromRawSocket, IntoRawSocket, OwnedSocket, RawSocket,
+};
 
 use crate::io_source::IoSource;
 #[cfg(not(target_os = "wasi"))]

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -9,13 +9,15 @@
 
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 #[cfg(any(unix, target_os = "wasi"))]
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 // TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
 // can use `std::os::fd` and be merged with the above.
 #[cfg(target_os = "hermit")]
-use std::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd, OwnedFd};
+use std::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 #[cfg(windows)]
-use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket, AsSocket, OwnedSocket, BorrowedSocket};
+use std::os::windows::io::{
+    AsRawSocket, AsSocket, BorrowedSocket, FromRawSocket, IntoRawSocket, OwnedSocket, RawSocket,
+};
 use std::{fmt, io, net};
 
 use crate::io_source::IoSource;

--- a/src/net/uds/datagram.rs
+++ b/src/net/uds/datagram.rs
@@ -1,5 +1,5 @@
 use std::net::Shutdown;
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use std::os::unix::net::{self, SocketAddr};
 use std::path::Path;
 use std::{fmt, io};

--- a/src/net/uds/datagram.rs
+++ b/src/net/uds/datagram.rs
@@ -1,5 +1,5 @@
 use std::net::Shutdown;
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd, OwnedFd};
 use std::os::unix::net::{self, SocketAddr};
 use std::path::Path;
 use std::{fmt, io};
@@ -249,8 +249,20 @@ impl From<UnixDatagram> for net::UnixDatagram {
     }
 }
 
+impl From<UnixDatagram> for OwnedFd {
+    fn from(unix_datagram: UnixDatagram) -> Self {
+        unix_datagram.inner.into_inner().into()
+    }
+}
+
 impl AsFd for UnixDatagram {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.as_fd()
+    }
+}
+
+impl From<OwnedFd> for UnixDatagram {
+    fn from(fd: OwnedFd) -> Self {
+        UnixDatagram::from_std(From::from(fd))
     }
 }

--- a/src/net/uds/listener.rs
+++ b/src/net/uds/listener.rs
@@ -1,4 +1,4 @@
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use std::os::unix::net::{self, SocketAddr};
 use std::path::Path;
 use std::{fmt, io};

--- a/src/net/uds/listener.rs
+++ b/src/net/uds/listener.rs
@@ -1,4 +1,4 @@
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd, OwnedFd};
 use std::os::unix::net::{self, SocketAddr};
 use std::path::Path;
 use std::{fmt, io};
@@ -118,8 +118,20 @@ impl From<UnixListener> for net::UnixListener {
     }
 }
 
+impl From<UnixListener> for OwnedFd {
+    fn from(unix_listener: UnixListener) -> Self {
+        unix_listener.inner.into_inner().into()
+    }
+}
+
 impl AsFd for UnixListener {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.as_fd()
+    }
+}
+
+impl From<OwnedFd> for UnixListener {
+    fn from(fd: OwnedFd) -> Self {
+        UnixListener::from_std(From::from(fd))
     }
 }

--- a/src/net/uds/stream.rs
+++ b/src/net/uds/stream.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::Shutdown;
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use std::os::unix::net::{self, SocketAddr};
 use std::path::Path;
 

--- a/src/net/uds/stream.rs
+++ b/src/net/uds/stream.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::Shutdown;
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd, OwnedFd};
 use std::os::unix::net::{self, SocketAddr};
 use std::path::Path;
 
@@ -262,8 +262,20 @@ impl From<UnixStream> for net::UnixStream {
     }
 }
 
+impl From<UnixStream> for OwnedFd {
+    fn from(unix_stream: UnixStream) -> Self {
+        unix_stream.inner.into_inner().into()
+    }
+}
+
 impl AsFd for UnixStream {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.as_fd()
+    }
+}
+
+impl From<OwnedFd> for UnixStream {
+    fn from(fd: OwnedFd) -> Self {
+        UnixStream::from_std(From::from(fd))
     }
 }

--- a/src/sys/unix/pipe.rs
+++ b/src/sys/unix/pipe.rs
@@ -65,7 +65,7 @@ pub(crate) fn new_raw() -> io::Result<[RawFd; 2]> {
 cfg_os_ext! {
 use std::fs::File;
 use std::io::{IoSlice, IoSliceMut, Read, Write};
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd};
 use std::process::{ChildStderr, ChildStdin, ChildStdout};
 
 use crate::io_source::IoSource;
@@ -378,9 +378,23 @@ impl IntoRawFd for Sender {
     }
 }
 
+impl From<Sender> for OwnedFd {
+    fn from(sender: Sender) -> Self {
+        sender.inner.into_inner().into()
+    }
+}
+
 impl AsFd for Sender {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.as_fd()
+    }
+}
+
+impl From<OwnedFd> for Sender {
+    fn from(fd: OwnedFd) -> Self {
+        Sender {
+            inner: IoSource::new(File::from(fd)),
+        }
     }
 }
 
@@ -551,9 +565,23 @@ impl FromRawFd for Receiver {
     }
 }
 
+impl From<Receiver> for OwnedFd {
+    fn from(receiver: Receiver) -> Self {
+        receiver.inner.into_inner().into()
+    }
+}
+
 impl AsFd for Receiver {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.inner.as_fd()
+    }
+}
+
+impl From<OwnedFd> for Receiver {
+    fn from(fd: OwnedFd) -> Self {
+        Receiver {
+            inner: IoSource::new(File::from(fd)),
+        }
     }
 }
 


### PR DESCRIPTION
Implement `From<OwnedFd>` and `Into<OwnedFd>` for types that implement `FromRawFd` and `IntoRawFd`.

And on Windows, implement `From<OwnedSocket>`, `Into<OwnedSocket>`, and `AsSocket` for types that implement `FromRawSocket`, `IntoRawSocket`, and `AsRawSocket`.