### PR TITLE
AIX use force poll poll Selector by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
           - armv7-sony-vita-newlibeabihf
           - i686-unknown-linux-gnu
           - i686-unknown-hurd-gnu
+          - powerpc64-ibm-aix
           - riscv32imc-esp-espidf
           - sparcv9-sun-solaris
           - wasm32-wasi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
           - armv7-sony-vita-newlibeabihf
           - i686-unknown-linux-gnu
           - i686-unknown-hurd-gnu
-          - powerpc64-ibm-aix
+          # - powerpc64-ibm-aix Enable CI runs once aix has full stdlib upstreamed
           - riscv32imc-esp-espidf
           - sparcv9-sun-solaris
           - wasm32-wasi

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -2,6 +2,7 @@
     unix,
     not(mio_unsupported_force_poll_poll),
     not(any(
+        target_os = "aix",
         target_os = "espidf",
         target_os = "fuchsia",
         target_os = "haiku",
@@ -440,6 +441,7 @@ impl Poll {
     unix,
     not(mio_unsupported_force_poll_poll),
     not(any(
+        target_os = "aix",
         target_os = "espidf",
         target_os = "fuchsia",
         target_os = "haiku",
@@ -740,6 +742,7 @@ impl fmt::Debug for Registry {
     unix,
     not(mio_unsupported_force_poll_poll),
     not(any(
+        target_os = "aix",
         target_os = "espidf",
         target_os = "haiku",
         target_os = "fuchsia",

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -40,6 +40,7 @@ cfg_os_poll! {
     ), path = "selector/kqueue.rs")]
     #[cfg_attr(any(
         mio_unsupported_force_poll_poll,
+        target_os = "aix",
         target_os = "espidf",
         target_os = "fuchsia",
         target_os = "haiku",


### PR DESCRIPTION
On AIX, we are having trouble implementing `pollset` for Selector. We would like to opt-in to the `mio_unsupported_force_poll_poll`. 