### PR TITLE
Fix build failure of uds tests on android

### DIFF
--- a/src/sys/unix/uds/mod.rs
+++ b/src/sys/unix/uds/mod.rs
@@ -158,6 +158,9 @@ mod tests {
     #[test]
     #[cfg(any(target_os = "android", target_os = "linux"))]
     fn abstract_address() {
+        #[cfg(target_os = "android")]
+        use std::os::android::net::SocketAddrExt;
+        #[cfg(target_os = "linux")]
         use std::os::linux::net::SocketAddrExt;
 
         const PATH: &[u8] = &[0, 116, 111, 107, 105, 111];


### PR DESCRIPTION
Android provides SocketAddrExt at a different path than other Linuxes, so from_abstract_name needs to be imported differently. This mirrors the imports at the top of the file.