### PR TITLE
Emit a better error when using mio on wasm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,9 @@
 //!
 //! The available features are described in the [`features`] module.
 
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+compile_error!("This wasm target is unsupported by mio. If using Tokio, disable the net feature.");
+
 // macros used internally
 #[macro_use]
 mod macros;


### PR DESCRIPTION
This configuration currently triggers a really bad error. See #1850 and #1681 for more info.