### PR TITLE
build: update `windows-sys` to 0.59.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ libc = "0.2.159"
 libc = "0.2.159"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.52"
+version = "0.59"
 features = [
   "Wdk_Foundation",                   # Required for AFD.
   "Wdk_Storage_FileSystem",           # Required for AFD.

--- a/src/sys/windows/afd.rs
+++ b/src/sys/windows/afd.rs
@@ -66,7 +66,7 @@ impl Afd {
         (*iosb).Anonymous.Status = STATUS_PENDING;
         let status = NtDeviceIoControlFile(
             self.fd.as_raw_handle() as HANDLE,
-            0,
+            std::ptr::null_mut(),
             None,
             overlapped,
             iosb,
@@ -131,7 +131,7 @@ cfg_io_source! {
 
     const AFD_HELPER_ATTRIBUTES: OBJECT_ATTRIBUTES = OBJECT_ATTRIBUTES {
         Length: size_of::<OBJECT_ATTRIBUTES>() as u32,
-        RootDirectory: 0,
+        RootDirectory: null_mut(),
         ObjectName: &AFD_OBJ_NAME as *const _ as *mut _,
         Attributes: 0,
         SecurityDescriptor: null_mut(),

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -92,6 +92,14 @@ struct Inner {
     pool: Mutex<BufferPool>,
 }
 
+// SAFETY: `Handles`s are, in general, not thread-safe. However, we only used `Handle`s for
+// resources that are thread-safe in `Inner`.
+unsafe impl Send for Inner {}
+
+// SAFETY: `Handles`s are, in general, not thread-safe. However, we only used `Handle`s for
+// resources that are thread-safe in `Inner`.
+unsafe impl Sync for Inner {}
+
 impl Inner {
     /// Converts a pointer to `Inner.connect` to a pointer to `Inner`.
     ///


### PR DESCRIPTION
Carries on the effort from #1820, with some fixes that _should_ make tests compile now.