### PR TITLE
Fix clippy warn

### DIFF
--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -216,7 +216,7 @@ impl fmt::Debug for Event {
         if alternate {
             struct EventDetails<'a>(&'a sys::Event);
 
-            impl<'a> fmt::Debug for EventDetails<'a> {
+            impl fmt::Debug for EventDetails<'_> {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     sys::event::debug_details(f, self.0)
                 }


### PR DESCRIPTION
When running the latest rust version (1.85).
https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes is being issued by clippy