### PR TITLE
[AIX] fix incorrectly set nonblocking socket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           - i686-unknown-linux-gnu
           # TODO: reenable <https://github.com/tokio-rs/mio/issues/1844>.
           #- i686-unknown-hurd-gnu
-          # - powerpc64-ibm-aix Enable CI runs once aix has full stdlib upstreamed
+          - powerpc64-ibm-aix
           - riscv32imc-esp-espidf
           - sparcv9-sun-solaris
           - wasm32-wasip1

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -764,6 +764,7 @@ cfg_os_poll! {
         unix,
         not(mio_unsupported_force_poll_poll),
         not(any(
+            target_os = "aix",
             target_os = "espidf",
             target_os = "hermit",
             target_os = "hurd",

--- a/src/sys/unix/net.rs
+++ b/src/sys/unix/net.rs
@@ -52,6 +52,7 @@ pub(crate) fn new_socket(domain: libc::c_int, socket_type: libc::c_int) -> io::R
 
     // Darwin (and others) doesn't have SOCK_NONBLOCK or SOCK_CLOEXEC.
     #[cfg(any(
+        target_os = "aix",
         target_os = "ios",
         target_os = "macos",
         target_os = "tvos",

--- a/src/sys/unix/pipe.rs
+++ b/src/sys/unix/pipe.rs
@@ -585,7 +585,7 @@ impl From<OwnedFd> for Receiver {
     }
 }
 
-#[cfg(not(any(target_os = "illumos", target_os = "solaris", target_os = "vita")))]
+#[cfg(not(any(target_os = "aix", target_os = "illumos", target_os = "solaris", target_os = "vita")))]
 fn set_nonblocking(fd: RawFd, nonblocking: bool) -> io::Result<()> {
     let value = nonblocking as libc::c_int;
     if unsafe { libc::ioctl(fd, libc::FIONBIO, &value) } == -1 {
@@ -595,7 +595,7 @@ fn set_nonblocking(fd: RawFd, nonblocking: bool) -> io::Result<()> {
     }
 }
 
-#[cfg(any(target_os = "illumos", target_os = "solaris", target_os = "vita"))]
+#[cfg(any(target_os = "aix", target_os = "illumos", target_os = "solaris", target_os = "vita"))]
 fn set_nonblocking(fd: RawFd, nonblocking: bool) -> io::Result<()> {
     let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
     if flags < 0 {

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -118,6 +118,7 @@ pub(crate) fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream,
             // See https://github.com/tokio-rs/mio/issues/1450
             #[cfg(any(
                 all(target_arch = "x86", target_os = "android"),
+                target_os = "aix",
                 target_os = "espidf",
                 target_os = "vita",
                 target_os = "hermit",


### PR DESCRIPTION
During the initial port, setting `O_NONBLOCK` was missed in some places for AIX causing unexpected hangs in the initial port. So we are adding them back now. 

Also re-enable ci as per https://github.com/tokio-rs/mio/issues/1834 we have fully implemented all missing items for `std` on AIX.