### PR TITLE
chore: use `std::os::fd` for `HermitOS`

### DIFF
--- a/src/io_source.rs
+++ b/src/io_source.rs
@@ -1,10 +1,6 @@
 use std::ops::{Deref, DerefMut};
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 use std::os::fd::AsRawFd;
-// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
-// can use `std::os::fd` and be merged with the above.
-#[cfg(target_os = "hermit")]
-use std::os::hermit::io::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawSocket;
 #[cfg(debug_assertions)]

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -1,10 +1,6 @@
 use std::net::{self, SocketAddr};
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
-// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
-// can use `std::os::fd` and be merged with the above.
-#[cfg(target_os = "hermit")]
-use std::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{
     AsRawSocket, AsSocket, BorrowedSocket, FromRawSocket, IntoRawSocket, OwnedSocket, RawSocket,

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -1,12 +1,8 @@
 use std::fmt;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::net::{self, Shutdown, SocketAddr};
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
-// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
-// can use `std::os::fd` and be merged with the above.
-#[cfg(target_os = "hermit")]
-use std::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{
     AsRawSocket, AsSocket, BorrowedSocket, FromRawSocket, IntoRawSocket, OwnedSocket, RawSocket,

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -8,12 +8,8 @@
 //! [portability guidelines]: ../struct.Poll.html#portability
 
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
-// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
-// can use `std::os::fd` and be merged with the above.
-#[cfg(target_os = "hermit")]
-use std::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{
     AsRawSocket, AsSocket, BorrowedSocket, FromRawSocket, IntoRawSocket, OwnedSocket, RawSocket,

--- a/src/sys/shell/mod.rs
+++ b/src/sys/shell/mod.rs
@@ -21,12 +21,8 @@ cfg_net! {
 
 cfg_io_source! {
     use std::io;
-    #[cfg(any(unix))]
+    #[cfg(any(unix, target_os = "hermit"))]
     use std::os::fd::RawFd;
-    // TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
-    // can use `std::os::fd` and be merged with the above.
-    #[cfg(target_os = "hermit")]
-    use std::os::hermit::io::RawFd;
     #[cfg(windows)]
     use std::os::windows::io::RawSocket;
 

--- a/src/sys/unix/selector/poll.rs
+++ b/src/sys/unix/selector/poll.rs
@@ -5,12 +5,7 @@
 
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
-#[cfg(not(target_os = "hermit"))]
 use std::os::fd::{AsRawFd, RawFd};
-// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
-// can use `std::os::fd` and be merged with the above.
-#[cfg(target_os = "hermit")]
-use std::os::hermit::io::{AsRawFd, RawFd};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;

--- a/src/sys/unix/sourcefd.rs
+++ b/src/sys/unix/sourcefd.rs
@@ -1,10 +1,5 @@
 use std::io;
-#[cfg(not(target_os = "hermit"))]
 use std::os::fd::RawFd;
-// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
-// can use `std::os::fd` and be merged with the above.
-#[cfg(target_os = "hermit")]
-use std::os::hermit::io::RawFd;
 
 use crate::{event, Interest, Registry, Token};
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -2,12 +2,7 @@ use std::convert::TryInto;
 use std::io;
 use std::mem::{size_of, MaybeUninit};
 use std::net::{self, SocketAddr};
-#[cfg(not(target_os = "hermit"))]
 use std::os::fd::{AsRawFd, FromRawFd};
-// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
-// can use `std::os::fd` and be merged with the above.
-#[cfg(target_os = "hermit")]
-use std::os::hermit::io::{AsRawFd, FromRawFd};
 
 use crate::sys::unix::net::{new_socket, socket_addr, to_socket_addr};
 

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,12 +1,7 @@
 use std::io;
 use std::mem;
 use std::net::{self, SocketAddr};
-#[cfg(not(target_os = "hermit"))]
 use std::os::fd::{AsRawFd, FromRawFd};
-// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
-// can use `std::os::fd` and be merged with the above.
-#[cfg(target_os = "hermit")]
-use std::os::hermit::io::{AsRawFd, FromRawFd};
 
 use crate::sys::unix::net::{new_ip_socket, socket_addr};
 

--- a/src/sys/unix/waker/eventfd.rs
+++ b/src/sys/unix/waker/eventfd.rs
@@ -1,11 +1,6 @@
 use std::fs::File;
 use std::io::{self, Read, Write};
-#[cfg(not(target_os = "hermit"))]
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
-// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
-// can use `std::os::fd` and be merged with the above.
-#[cfg(target_os = "hermit")]
-use std::os::hermit::io::{AsRawFd, FromRawFd, RawFd};
 
 use crate::sys::Selector;
 use crate::{Interest, Token};

--- a/src/sys/unix/waker/pipe.rs
+++ b/src/sys/unix/waker/pipe.rs
@@ -1,11 +1,6 @@
 use std::fs::File;
 use std::io::{self, Read, Write};
-#[cfg(not(target_os = "hermit"))]
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
-// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
-// can use `std::os::fd` and be merged with the above.
-#[cfg(target_os = "hermit")]
-use std::os::hermit::io::{AsRawFd, FromRawFd, RawFd};
 
 use crate::sys::unix::pipe;
 use crate::sys::Selector;


### PR DESCRIPTION
Given that [rust-lang#126198](https://github.com/rust-lang/rust/issues/126198) was finally resolved, `HermitOS` should use `std::os::fd`. This PR complete this to-do.