### PR TITLE
add cygwin support

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -10,7 +10,8 @@
         target_os = "hurd",
         target_os = "nto",
         target_os = "solaris",
-        target_os = "vita"
+        target_os = "vita",
+        target_os = "cygwin",
     )),
 ))]
 use std::os::fd::{AsRawFd, RawFd};
@@ -449,7 +450,8 @@ impl Poll {
         target_os = "hurd",
         target_os = "nto",
         target_os = "solaris",
-        target_os = "vita"
+        target_os = "vita",
+        target_os = "cygwin",
     )),
 ))]
 impl AsRawFd for Poll {
@@ -750,7 +752,8 @@ impl fmt::Debug for Registry {
         target_os = "hurd",
         target_os = "nto",
         target_os = "solaris",
-        target_os = "vita"
+        target_os = "vita",
+        target_os = "cygwin",
     )),
 ))]
 impl AsRawFd for Registry {
@@ -770,7 +773,8 @@ cfg_os_poll! {
             target_os = "hurd",
             target_os = "nto",
             target_os = "solaris",
-            target_os = "vita"
+            target_os = "vita",
+            target_os = "cygwin",
         )),
     ))]
     #[test]

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -49,6 +49,7 @@ cfg_os_poll! {
         target_os = "nto",
         target_os = "solaris",
         target_os = "vita",
+        target_os = "cygwin",
     ), path = "selector/poll.rs")]
     mod selector;
     pub(crate) use self::selector::*;
@@ -101,6 +102,7 @@ cfg_os_poll! {
         target_os = "redox",
         target_os = "solaris",
         target_os = "vita",
+        target_os = "cygwin",
     ), path = "waker/pipe.rs")]
     mod waker;
     // NOTE: the `Waker` type is expected in the selector module as the
@@ -148,6 +150,7 @@ cfg_os_poll! {
             target_os = "redox",
             target_os = "solaris",
             target_os = "vita",
+            target_os = "cygwin",
         ),
         // Hermit doesn't support pipes.
         not(target_os = "hermit"),

--- a/src/sys/unix/net.rs
+++ b/src/sys/unix/net.rs
@@ -24,6 +24,7 @@ pub(crate) fn new_socket(domain: libc::c_int, socket_type: libc::c_int) -> io::R
         target_os = "openbsd",
         target_os = "solaris",
         target_os = "hermit",
+        target_os = "cygwin",
     ))]
     let socket_type = socket_type | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
     #[cfg(target_os = "nto")]

--- a/src/sys/unix/pipe.rs
+++ b/src/sys/unix/pipe.rs
@@ -21,6 +21,7 @@ pub(crate) fn new_raw() -> io::Result<[RawFd; 2]> {
         target_os = "redox",
         target_os = "solaris",
         target_os = "vita",
+        target_os = "cygwin",
     ))]
     unsafe {
         if libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC | libc::O_NONBLOCK) != 0 {

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -75,6 +75,7 @@ pub(crate) fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream,
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "solaris",
+        target_os = "cygwin",
     ))]
     let stream = {
         syscall!(accept4(

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -563,7 +563,7 @@ fn connect_error() {
                 // Without fastopen we would be getting the connection error
                 assert!(event.is_writable() || event.is_error());
                 // Solaris poll(2) says POLLHUP and POLLOUT are mutually exclusive.
-                #[cfg(not(target_os = "solaris"))]
+                #[cfg(not(any(target_os = "solaris", target_os = "cygwin")))]
                 assert!(event.is_write_closed());
                 break 'outer;
             }
@@ -695,7 +695,8 @@ fn write_shutdown() {
     if cfg!(any(
         target_os = "hurd",
         target_os = "solaris",
-        target_os = "nto"
+        target_os = "nto",
+        target_os = "cygwin",
     )) {
         wait!(poll, is_readable, false);
     } else {

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -550,7 +550,10 @@ fn tcp_shutdown_client_read_close_event() {
 }
 
 #[test]
-#[cfg_attr(any(windows, target_os = "cygwin"), ignore = "fails; client write_closed events are not found")]
+#[cfg_attr(
+    any(windows, target_os = "cygwin"),
+    ignore = "fails; client write_closed events are not found"
+)]
 #[cfg_attr(
     any(
         target_os = "android",
@@ -731,7 +734,14 @@ fn echo_listener(addr: SocketAddr, n_connections: usize) -> (thread::JoinHandle<
                     // error when the reading side of the peer connection is
                     // shutdown, we don't consider it an actual here.
                     .or_else(|err| match err {
-                        ref err if matches!(err.kind(), io::ErrorKind::ConnectionReset | io::ErrorKind::ConnectionAborted) => Ok(0),
+                        ref err
+                            if matches!(
+                                err.kind(),
+                                io::ErrorKind::ConnectionReset | io::ErrorKind::ConnectionAborted
+                            ) =>
+                        {
+                            Ok(0)
+                        }
                         err => Err(err),
                     })
                     .expect("error reading");

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -561,7 +561,7 @@ fn unconnected_udp_socket_connected_methods() {
     );
 
     // Socket is unconnected, but we're using an connected method.
-    if cfg!(not(any(target_os = "hurd", target_os = "windows"))) {
+    if cfg!(not(any(target_os = "hurd", target_os = "windows", target_os = "cygwin"))) {
         assert_error(socket1.send(DATA1), "address required");
     }
     if cfg!(target_os = "windows") {
@@ -630,7 +630,8 @@ fn connected_udp_socket_unconnected_methods() {
         target_os = "android",
         target_os = "hurd",
         target_os = "linux",
-        target_os = "windows"
+        target_os = "windows",
+        target_os = "cygwin",
     )))]
     assert_error(socket1.send_to(DATA1, address2), "already connected");
     // Even if the address is the same.
@@ -638,7 +639,8 @@ fn connected_udp_socket_unconnected_methods() {
         target_os = "android",
         target_os = "hurd",
         target_os = "linux",
-        target_os = "windows"
+        target_os = "windows",
+        target_os = "cygwin",
     )))]
     assert_error(socket1.send_to(DATA1, address3), "already connected");
 

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -561,7 +561,11 @@ fn unconnected_udp_socket_connected_methods() {
     );
 
     // Socket is unconnected, but we're using an connected method.
-    if cfg!(not(any(target_os = "hurd", target_os = "windows", target_os = "cygwin"))) {
+    if cfg!(not(any(
+        target_os = "hurd",
+        target_os = "windows",
+        target_os = "cygwin"
+    ))) {
         assert_error(socket1.send(DATA1), "address required");
     }
     if cfg!(target_os = "windows") {

--- a/tests/unix_datagram.rs
+++ b/tests/unix_datagram.rs
@@ -31,6 +31,10 @@ fn is_send_and_sync() {
     target_os = "hurd",
     ignore = "getting pathname isn't supported on GNU/Hurd"
 )]
+#[cfg_attr(
+    target_os = "cygwin",
+    ignore = "getting pathname isn't supported on Cygwin"
+)]
 fn unix_datagram_smoke_unconnected() {
     init();
     let path1 = temp_file("unix_datagram_smoke_unconnected1");
@@ -59,6 +63,10 @@ fn unix_datagram_smoke_connected() {
 #[cfg_attr(
     target_os = "hurd",
     ignore = "getting pathname isn't supported on GNU/Hurd"
+)]
+#[cfg_attr(
+    target_os = "cygwin",
+    ignore = "getting pathname isn't supported on Cygwin"
 )]
 fn unix_datagram_smoke_unconnected_from_std() {
     init();
@@ -181,6 +189,7 @@ fn unix_datagram_pair() {
 #[cfg_attr(target_os = "hurd", ignore = "POLLRDHUP isn't supported on GNU/Hurd")]
 #[cfg_attr(target_os = "solaris", ignore = "POLLRDHUP isn't supported on Solaris")]
 #[cfg_attr(target_os = "nto", ignore = "POLLRDHUP isn't supported on NTO")]
+#[cfg_attr(target_os = "cygwin", ignore = "POLLRDHUP isn't supported on Cygwin")]
 fn unix_datagram_shutdown() {
     let (mut poll, mut events) = init_with_poll();
     let path1 = temp_file("unix_datagram_shutdown1");

--- a/tests/unix_listener.rs
+++ b/tests/unix_listener.rs
@@ -89,6 +89,7 @@ fn unix_listener_register() {
 }
 
 #[test]
+#[cfg_attr(target_os = "cygwin", ignore)]
 fn unix_listener_reregister() {
     let (mut poll, mut events) = init_with_poll();
     let barrier = Arc::new(Barrier::new(2));
@@ -116,6 +117,7 @@ fn unix_listener_reregister() {
 }
 
 #[test]
+#[cfg_attr(target_os = "cygwin", ignore)]
 fn unix_listener_deregister() {
     let (mut poll, mut events) = init_with_poll();
     let barrier = Arc::new(Barrier::new(2));

--- a/tests/unix_pipe.rs
+++ b/tests/unix_pipe.rs
@@ -54,7 +54,7 @@ fn smoke() {
 
 #[test]
 #[cfg_attr(
-    any(target_os = "hurd", target_os = "nto"),
+    any(target_os = "hurd", target_os = "nto", target_os = "cygwin"),
     ignore = "Writer fd close events do not trigger POLLHUP on nto and GNU/Hurd targets"
 )]
 fn event_when_sender_is_dropped() {
@@ -96,7 +96,7 @@ fn event_when_sender_is_dropped() {
 
 #[test]
 #[cfg_attr(
-    any(target_os = "hurd", target_os = "nto"),
+    any(target_os = "hurd", target_os = "nto", target_os = "cygwin"),
     ignore = "Writer fd close events do not trigger POLLHUP on nto and GNU/Hurd targets"
 )]
 fn event_when_receiver_is_dropped() {
@@ -133,7 +133,7 @@ fn event_when_receiver_is_dropped() {
 
 #[test]
 #[cfg_attr(
-    any(target_os = "hurd", target_os = "nto"),
+    any(target_os = "hurd", target_os = "nto", target_os = "cygwin"),
     ignore = "Writer fd close events do not trigger POLLHUP on nto and GNU/Hurd targets"
 )]
 fn from_child_process_io() {

--- a/tests/unix_stream.rs
+++ b/tests/unix_stream.rs
@@ -37,12 +37,14 @@ fn unix_stream_send_and_sync() {
     target_os = "hurd",
     ignore = "getting pathname isn't supported on GNU/Hurd"
 )]
+#[cfg_attr(target_os = "cygwin", ignore)]
 fn unix_stream_smoke() {
     #[allow(clippy::redundant_closure)]
     smoke_test(|path| UnixStream::connect(path), "unix_stream_smoke");
 }
 
 #[test]
+#[cfg_attr(target_os = "cygwin", ignore)]
 fn unix_stream_connect() {
     let (mut poll, mut events) = init_with_poll();
     let barrier = Arc::new(Barrier::new(2));
@@ -86,6 +88,7 @@ fn unix_stream_connect() {
     target_os = "hurd",
     ignore = "getting pathname isn't supported on GNU/Hurd"
 )]
+#[cfg_attr(target_os = "cygwin", ignore)]
 fn unix_stream_connect_addr() {
     let (mut poll, mut events) = init_with_poll();
     let barrier = Arc::new(Barrier::new(2));
@@ -132,6 +135,7 @@ fn unix_stream_connect_addr() {
     target_os = "hurd",
     ignore = "getting pathname isn't supported on GNU/Hurd"
 )]
+#[cfg_attr(target_os = "cygwin", ignore)]
 fn unix_stream_from_std() {
     smoke_test(
         |path| {
@@ -183,6 +187,7 @@ fn unix_stream_pair() {
     target_os = "hurd",
     ignore = "getting pathname isn't supported on GNU/Hurd"
 )]
+#[cfg_attr(target_os = "cygwin", ignore)]
 fn unix_stream_peer_addr() {
     init();
     let (handle, expected_addr) = new_echo_listener(1, "unix_stream_peer_addr");
@@ -205,6 +210,7 @@ fn unix_stream_peer_addr() {
 #[cfg_attr(target_os = "hurd", ignore = "POLLRDHUP isn't supported on GNU/Hurd")]
 #[cfg_attr(target_os = "solaris", ignore = "POLLRDHUP isn't supported on Solaris")]
 #[cfg_attr(target_os = "nto", ignore = "POLLRDHUP isn't supported on NTO")]
+#[cfg_attr(target_os = "cygwin", ignore = "POLLRDHUP isn't supported on Cygwin")]
 fn unix_stream_shutdown_read() {
     let (mut poll, mut events) = init_with_poll();
     let (handle, remote_addr) = new_echo_listener(1, "unix_stream_shutdown_read");
@@ -266,6 +272,7 @@ fn unix_stream_shutdown_read() {
     target_os = "hurd",
     ignore = "getting pathname isn't supported on GNU/Hurd"
 )]
+#[cfg_attr(target_os = "cygwin", ignore)]
 fn unix_stream_shutdown_write() {
     let (mut poll, mut events) = init_with_poll();
     let (handle, remote_addr) = new_echo_listener(1, "unix_stream_shutdown_write");
@@ -328,6 +335,7 @@ fn unix_stream_shutdown_write() {
     target_os = "hurd",
     ignore = "getting pathname isn't supported on GNU/Hurd"
 )]
+#[cfg_attr(target_os = "cygwin", ignore)]
 fn unix_stream_shutdown_both() {
     let (mut poll, mut events) = init_with_poll();
     let (handle, remote_addr) = new_echo_listener(1, "unix_stream_shutdown_both");
@@ -396,6 +404,7 @@ fn unix_stream_shutdown_both() {
 #[cfg_attr(target_os = "hurd", ignore = "POLLRDHUP isn't supported on GNU/Hurd")]
 #[cfg_attr(target_os = "solaris", ignore = "POLLRDHUP isn't supported on Solaris")]
 #[cfg_attr(target_os = "nto", ignore = "POLLRDHUP isn't supported on NTO")]
+#[cfg_attr(target_os = "cygwin", ignore = "POLLRDHUP isn't supported on Cygwin")]
 fn unix_stream_shutdown_listener_write() {
     let (mut poll, mut events) = init_with_poll();
     let barrier = Arc::new(Barrier::new(2));
@@ -433,6 +442,7 @@ fn unix_stream_shutdown_listener_write() {
     target_os = "hurd",
     ignore = "getting pathname isn't supported on GNU/Hurd"
 )]
+#[cfg_attr(target_os = "cygwin", ignore)]
 fn unix_stream_register() {
     let (mut poll, mut events) = init_with_poll();
     let (handle, remote_addr) = new_echo_listener(1, "unix_stream_register");
@@ -454,6 +464,7 @@ fn unix_stream_register() {
     target_os = "hurd",
     ignore = "getting pathname isn't supported on GNU/Hurd"
 )]
+#[cfg_attr(target_os = "cygwin", ignore)]
 fn unix_stream_reregister() {
     let (mut poll, mut events) = init_with_poll();
     let (handle, remote_addr) = new_echo_listener(1, "unix_stream_reregister");
@@ -482,6 +493,7 @@ fn unix_stream_reregister() {
     target_os = "hurd",
     ignore = "getting pathname isn't supported on GNU/Hurd"
 )]
+#[cfg_attr(target_os = "cygwin", ignore)]
 fn unix_stream_deregister() {
     let (mut poll, mut events) = init_with_poll();
     let (handle, remote_addr) = new_echo_listener(1, "unix_stream_deregister");


### PR DESCRIPTION
This PR adds cygwin support. It uses the POSIX poll as backend. I tried my best to fix the tests. Some of them are ignored reasonably, while some of them are not - related to the `UnixListener` and `UnixStream`. I don't understand them yet.