### PR TITLE
Make `Poll` a `Source` itself

### DIFF
--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -663,3 +663,18 @@ pub fn assert_error<T, E: fmt::Display>(result: Result<T, E>, expected_msg: &str
         ),
     }
 }
+
+#[cfg(all(unix, feature = "os-ext"))]
+#[test]
+fn double_poll() {
+    init();
+    let outer_poll = Poll::new().unwrap();
+    let registry = outer_poll.registry();
+
+    let mut inner_poll = Poll::new().unwrap();
+    let token = Token(0);
+    let interests = Interest::READABLE;
+    registry
+        .register(&mut inner_poll, token, interests)
+        .unwrap();
+}


### PR DESCRIPTION
Both epoll and kqueue support listening for other epoll/kqueue file descriptors.

They become readable when an event in the inner epoll/kqueue is ready.

We can expose this feature by making `Poll` an `event::Source`.

I gated this feature behind `os-ext` as this was required to use `IoSource`.

Additionally, thanks to Rust's borrow checker, there can be no cycles in the listening graph i.e. this will not compile:
```rust
let mut poll = Poll::new().unwrap();

poll.registry().register(&mut poll, Token(0), Interest::READABLE).unwrap();
```