### PR TITLE
added 'Event.as_vec()' & 'Events.as_vec_mut()'

### DIFF
--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -182,15 +182,6 @@ impl Event {
     pub fn is_lio(&self) -> bool {
         sys::event::is_lio(&self.inner)
     }
-
-    /// Create a reference to an `Event` from a platform specific event.
-    pub(crate) fn from_sys_event_ref(sys_event: &sys::Event) -> &Event {
-        unsafe {
-            // This is safe because the memory layout of `Event` is
-            // the same as `sys::Event` due to the `repr(transparent)` attribute.
-            &*(sys_event as *const sys::Event as *const Event)
-        }
-    }
 }
 
 /// When the [alternate] flag is enabled this will print platform specific

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -185,8 +185,7 @@ impl Events {
     /// # }
     /// ```
     pub fn clear(&mut self) {
-        let vec: &mut Vec<Event> = self.into();
-        vec.clear();
+        self.inner.clear();
     }
 
     /// Returns a shared reference to the underlying Vec

--- a/src/sys/shell/selector.rs
+++ b/src/sys/shell/selector.rs
@@ -5,7 +5,26 @@ use std::time::Duration;
 
 pub type Event = usize;
 
-pub type Events = Vec<Event>;
+#[derive(Debug)]
+pub struct Events(Vec<Event>);
+
+impl Events {
+    pub fn with_capacity(cap: usize) -> Self {
+        Self(Vec::with_capacity(cap))
+    }
+}
+
+impl<'a> From<&'a Events> for &'a Vec<Event> {
+    fn from(value: &'a Events) -> Self {
+        &value.0
+    }
+}
+
+impl<'a> From<&'a mut Events> for &'a mut Vec<Event> {
+    fn from(value: &'a mut Events) -> Self {
+        &mut value.0
+    }
+}
 
 #[derive(Debug)]
 pub struct Selector {}

--- a/src/sys/shell/selector.rs
+++ b/src/sys/shell/selector.rs
@@ -12,6 +12,10 @@ impl Events {
     pub fn with_capacity(cap: usize) -> Self {
         Self(Vec::with_capacity(cap))
     }
+
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
 }
 
 impl<'a> From<&'a Events> for &'a Vec<Event> {

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -332,6 +332,18 @@ impl Events {
     }
 }
 
+impl<'a> From<&'a Events> for &'a Vec<Event> {
+    fn from(value: &'a Events) -> Self {
+        &value.0
+    }
+}
+
+impl<'a> From<&'a mut Events> for &'a mut Vec<Event> {
+    fn from(value: &'a mut Events) -> Self {
+        &mut value.0
+    }
+}
+
 impl Deref for Events {
     type Target = Vec<libc::kevent>;
 

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -5,7 +5,7 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 #[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
-use std::{cmp, io, ptr, slice};
+use std::{cmp, io, ptr, slice, fmt};
 
 /// Unique id for use as `SelectorId`.
 #[cfg(debug_assertions)]
@@ -324,7 +324,6 @@ impl AsRawFd for Selector {
 }
 
 pub type Event = libc::kevent;
-#[derive(Debug)]
 pub struct Events(Vec<libc::kevent>);
 
 impl Events {
@@ -360,6 +359,12 @@ impl Deref for Events {
 impl DerefMut for Events {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+impl fmt::Debug for Events {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Events: TODO: actually print them")
     }
 }
 

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -324,11 +324,16 @@ impl AsRawFd for Selector {
 }
 
 pub type Event = libc::kevent;
+#[derive(Debug)]
 pub struct Events(Vec<libc::kevent>);
 
 impl Events {
     pub fn with_capacity(capacity: usize) -> Events {
         Events(Vec::with_capacity(capacity))
+    }
+
+    pub fn clear(&mut self) {
+        self.0.clear();
     }
 }
 

--- a/src/sys/windows/event.rs
+++ b/src/sys/windows/event.rs
@@ -167,3 +167,15 @@ impl Events {
         }
     }
 }
+
+impl<'a> From<&'a Events> for &'a Vec<Event> {
+    fn from(value: &'a Events) -> Self {
+        &value.events
+    }
+}
+
+impl<'a> From<&'a mut Events> for &'a mut Vec<Event> {
+    fn from(value: &'a mut Events) -> Self {
+        &mut value.events
+    }
+}


### PR DESCRIPTION
these provide a useful "escape hatch" for any methods of `Vec` that we've yet to create wrapper methods for, i also implemented `From<&sys::Events>` & `From<&mut sys::Events>` for `&Vec<sys::Events>` & `&mut Vec<sys::Events>` respectively, so whereas before we had to implement methods of `Vec` both on `Events` & `sys::events` now we can just implement them on `Events`, i plan to eventually implement all the methods of `Vec` for `Events`