### PR TITLE
Update windows-sys to 0.60

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ libc = "0.2.159"
 libc = "0.2.159"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.59"
+version = "0.60"
 features = [
   "Wdk_Foundation",                   # Required for AFD.
   "Wdk_Storage_FileSystem",           # Required for AFD.
@@ -61,6 +61,7 @@ features = [
   "Win32_Foundation",                 # Basic types eg HANDLE
   "Win32_Networking_WinSock",         # winsock2 types/functions
   "Win32_Storage_FileSystem",         # Enables NtCreateFile
+  "Win32_Security",                   # Enables NtCreateFile
   "Win32_System_IO",                  # IO types like OVERLAPPED etc
   "Win32_System_WindowsProgramming",  # General future used for various types/funcs
 ]


### PR DESCRIPTION
The affected notable change is that NtCreateFile-related things are now also gated by Win32_Security feature, not only Wdk_Foundation feature: https://github.com/microsoft/windows-rs/pull/3342

```
error[E0432]: unresolved import `windows_sys::Wdk::Foundation::OBJECT_ATTRIBUTES`
    --> src/sys/windows/afd.rs:122:9
     |
122  |     use windows_sys::Wdk::Foundation::OBJECT_ATTRIBUTES;
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `OBJECT_ATTRIBUTES` in `Wdk::Foundation`
     |
note: found an item that was configured out
    --> /Users/taiki/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/windows-sys-0.60.2/src/Windows/Wdk/Foundation/mod.rs:1608:12
     |
1608 | pub struct OBJECT_ATTRIBUTES {
     |            ^^^^^^^^^^^^^^^^^
note: the item is gated behind the `Win32_Security` feature
    --> /Users/taiki/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/windows-sys-0.60.2/src/Windows/Wdk/Foundation/mod.rs:1606:7
     |
1606 | #[cfg(feature = "Win32_Security")]
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0432]: unresolved import `windows_sys::Wdk::Storage::FileSystem::NtCreateFile`
   --> src/sys/windows/afd.rs:123:49
    |
123 |     use windows_sys::Wdk::Storage::FileSystem::{NtCreateFile, FILE_OPEN};
    |                                                 ^^^^^^^^^^^^
    |                                                 |
    |                                                 no `NtCreateFile` in `Wdk::Storage::FileSystem`
    |                                                 help: a similar name exists in the module: `NtWriteFile`
```