### PR TITLE
clippy:fix needless_lifetime warnings

### DIFF
--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -284,7 +284,7 @@ impl Read for TcpStream {
     }
 }
 
-impl<'a> Read for &'a TcpStream {
+impl Read for &'_ TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.do_io(|mut inner| inner.read(buf))
     }
@@ -308,7 +308,7 @@ impl Write for TcpStream {
     }
 }
 
-impl<'a> Write for &'a TcpStream {
+impl Write for &'_ TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.inner.do_io(|mut inner| inner.write(buf))
     }

--- a/src/net/uds/stream.rs
+++ b/src/net/uds/stream.rs
@@ -161,7 +161,7 @@ impl Read for UnixStream {
     }
 }
 
-impl<'a> Read for &'a UnixStream {
+impl Read for &'_ UnixStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.do_io(|mut inner| inner.read(buf))
     }
@@ -185,7 +185,7 @@ impl Write for UnixStream {
     }
 }
 
-impl<'a> Write for &'a UnixStream {
+impl Write for &'_ UnixStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.inner.do_io(|mut inner| inner.write(buf))
     }


### PR DESCRIPTION
Running clippy with the enabled `net` feature reported several `needless_lifetime` warnings. This commit fixes them by switching to anonymous lifetimes.

**Tools:**
  - rustc 1.89.0 (29483883e 2025-08-04)
  - clippy 0.1.89 (29483883ee 2025-08-04)
  - cargo 1.89.0 (c24e10642 2025-06-23)


**Before:**
```
cargo clippy --features net
...
warning: the following explicit lifetimes could be elided: 'a
   --> src/net/tcp/stream.rs:287:6
    |
287 | impl<'a> Read for &'a TcpStream {
    |      ^^            ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
    |
287 - impl<'a> Read for &'a TcpStream {
287 + impl Read for &TcpStream {
...
```

**After:**
```
 cargo clippy --features net
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.01s
```