### PR TITLE
Update `windows-sys` and dev-dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       with:
         # NOTE: full version (including .0) to work around
         # <https://github.com/dtolnay/rust-toolchain/issues/112>.
-        toolchain: 1.70.0
+        toolchain: 1.71.0
     - name: Check
       # We only run check allowing us to use newer features in tests.
       run: cargo check --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.71"
 name = "mio"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
@@ -53,7 +53,7 @@ libc = "0.2.159"
 libc = "0.2.159"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.60"
+version = "0.61"
 features = [
   "Wdk_Foundation",                   # Required for AFD.
   "Wdk_Storage_FileSystem",           # Required for AFD.
@@ -71,8 +71,8 @@ wasi = "0.11.0"
 libc = "0.2.159"
 
 [dev-dependencies]
-env_logger = { version = "0.9.3", default-features = false }
-rand = "0.8"
+env_logger = { version = "0.11.8", default-features = false }
+rand = "0.9"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tests/unix_listener.rs
+++ b/tests/unix_listener.rs
@@ -144,14 +144,13 @@ fn unix_listener_deregister() {
 #[test]
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn unix_listener_abstract_namespace() {
-    use rand::Rng;
     use std::os::linux::net::SocketAddrExt;
     use std::os::unix::net::SocketAddr;
 
     let (mut poll, mut events) = init_with_poll();
     let barrier = Arc::new(Barrier::new(2));
 
-    let num: u64 = rand::thread_rng().gen();
+    let num: u64 = rand::random();
     let name = format!("mio-abstract-uds-{num}");
     let address = SocketAddr::from_abstract_name(name.as_bytes()).unwrap();
     let mut listener = UnixListener::bind_addr(&address).unwrap();

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 
 use mio::windows::NamedPipe;
 use mio::{Events, Interest, Poll, Token};
-use rand::Rng;
 use windows_sys::Win32::{Foundation::ERROR_NO_DATA, Storage::FileSystem::FILE_FLAG_OVERLAPPED};
 
 fn _assert_kinds() {
@@ -28,7 +27,7 @@ macro_rules! t {
 }
 
 fn server() -> (NamedPipe, String) {
-    let num: u64 = rand::thread_rng().gen();
+    let num: u64 = rand::random();
     let name = format!(r"\\.\pipe\my-pipe-{}", num);
     let pipe = t!(NamedPipe::new(&name));
     (pipe, name)


### PR DESCRIPTION
- `windows-sys` to 0.61 (Requires MSRV 1.71)
- dev-dependencies: `env_logger` to 0.11 and `rand` to 0.9

It would be nice to move from the old `wasi` version to the new `wasip1` crate but this requires MSRV 1.82, so I'm not sure this is acceptable.