### PR TITLE
fix: improve state transitions of Windows named pipes

### DIFF
--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -872,7 +872,6 @@ fn read_done(status: &OVERLAPPED_ENTRY, events: Option<&mut Vec<Event>>) {
     // `schedule_read` above.
     let me = unsafe { Arc::from_raw(Inner::ptr_from_read_overlapped(status.overlapped())) };
 
-    // Move from the `Pending` to `Ok` state.
     let mut io = me.io.lock().unwrap();
     let mut buf = match mem::replace(&mut io.read, State::None) {
         State::Ok(buf, pos) => {


### PR DESCRIPTION
Disclaimer: I am by no means a Windows expert. The changes presented here are built from reading through the code and trying to reason about the possible state transitions. I've tried to explain in each commit, why I think the resulting change is safe to make.

I'll apply this to our codebase and see if it fixes the crash reports that we are getting from users. In the meantime, feedback is most welcome.

Resolves: #1819