### PR TITLE
Don't run doc tests with sanitizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,14 @@ test_all: check_all_targets
 # NOTE: Requires a nightly compiler.
 # NOTE: Keep `RUSTFLAGS` and `RUSTDOCFLAGS` in sync to ensure the doc tests
 # compile correctly.
+# TODO: remove `--all-targets` once
+# <https://github.com/rust-lang/rust/issues/147394> and/or
+# <https://github.com/rust-lang/rust/issues/146465> are fixed.
 test_sanitizer:
 	@if [ -z $${SAN+x} ]; then echo "Required '\$$SAN' variable is not set" 1>&2; exit 1; fi
 	RUSTFLAGS="-Z sanitizer=$$SAN -Z sanitizer-memory-track-origins" \
 	RUSTDOCFLAGS="-Z sanitizer=$$SAN -Z sanitizer-memory-track-origins" \
-	cargo test -Z build-std --all-features --target $(RUSTUP_TARGET)
+	cargo test --all-targets -Z build-std --all-features --target $(RUSTUP_TARGET)
 
 # Check all targets using all features.
 check_all_targets: $(TARGETS)


### PR DESCRIPTION
Currently runs into the following error.
> mixing `-Zsanitizer` will cause an ABI mismatch in crate `mio`

Tracked in https://github.com/rust-lang/rust/issues/147394 and https://github.com/rust-lang/rust/issues/146465.