### PR TITLE
Enable aarch64-unknown-openbsd CI target in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,9 +143,7 @@ jobs:
           - aarch64-unknown-linux-musl
           - aarch64-unknown-netbsd
           - aarch64-unknown-nto-qnx710
-          # Standard library doesn't build anymore:
-          # <https://github.com/rust-lang/rust/issues/148898>
-          # - aarch64-unknown-openbsd
+          - aarch64-unknown-openbsd
           - aarch64-unknown-redox
           - arm-linux-androideabi
           - arm64_32-apple-watchos


### PR DESCRIPTION
Now that the standard library builds again.