### PR TITLE
declare version of `windows-sys` by range set to fix compile under win7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ libc = "0.2.159"
 libc = "0.2.159"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.61"
+version = ">=0.59, <=0.61"
 features = [
   "Wdk_Foundation",                   # Required for AFD.
   "Wdk_Storage_FileSystem",           # Required for AFD.


### PR DESCRIPTION
Declaration with range is a [recommended way](https://crates.io/crates/windows-sys/0.61.2) to add `windows-sys` crate as dependency:

> Using a range instead of the default Caret requirements helps avoid duplicate versions in downstream graphs and improves resolver flexibility.

**Additionally**, `windows-sys@0.61+` has a _bug_ that causes compilation errors under `*-win7-windows-*` targets, so this change will allow your users to choose & lock in theirs `Cargo.lock` older version of `windows-sys` to continue support Windows 7.

