### PR TITLE
Fix NetBSD build error due to UData type mismatched

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,10 +47,10 @@ net = []
 log = { version = "0.4.8", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.159"
+libc = "0.2.178"
 
 [target.'cfg(target_os = "hermit")'.dependencies]
-libc = "0.2.159"
+libc = "0.2.178"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.61"
@@ -68,7 +68,7 @@ features = [
 
 [target.'cfg(target_os = "wasi")'.dependencies]
 wasi = "0.11.0"
-libc = "0.2.159"
+libc = "0.2.178"
 
 [dev-dependencies]
 env_logger = { version = "0.11", default-features = false }

--- a/src/sys/unix/selector/kqueue.rs
+++ b/src/sys/unix/selector/kqueue.rs
@@ -50,10 +50,7 @@ type Flags = u16;
 type Flags = u32;
 
 // Type of the `udata` field in the `kevent` structure.
-#[cfg(not(target_os = "netbsd"))]
 type UData = *mut libc::c_void;
-#[cfg(target_os = "netbsd")]
-type UData = libc::intptr_t;
 
 macro_rules! kevent {
     ($id: expr, $filter: expr, $flags: expr, $data: expr) => {


### PR DESCRIPTION
libc [0.2.178](https://github.com/rust-lang/libc/releases/tag/0.2.178) changed the type of `kevent.udata` to brings it in line with other BSDs.

Without this pull request, netbsd build failed with the following error.
```
error[E0308]: mismatched types
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mio-1.1.0/src/sys/unix/selector/kqueue.rs:64:20
    |
 64 |             udata: $data as UData,
    |                    ^^^^^^^^^^^^^^ expected `*mut c_void`, found `isize`
...
137 |             let kevent = kevent!(fd, libc::EVFILT_WRITE, flags, token.0);
    |                          ----------------------------------------------- in this macro invocation
    |
    = note: expected raw pointer `*mut c_void`
                      found type `isize`
    = note: this error originates in the macro `kevent` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Reference:
https://github.com/rust-lang/libc/pull/4782/commits/63f40376430e3f86b895d2b73621c2e25e802858
https://github.com/shadowsocks/shadowsocks-rust/actions/runs/19874531148/job/56958491608