### PR TITLE
Merge defining libc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,7 @@ net = []
 [dependencies]
 log = { version = "0.4.8", optional = true }
 
-[target.'cfg(unix)'.dependencies]
-libc = "0.2.183"
-
-[target.'cfg(target_os = "hermit")'.dependencies]
+[target.'cfg(any(unix, target_os = "hermit", target_os = "wasi"))'.dependencies]
 libc = "0.2.183"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
@@ -68,7 +65,6 @@ features = [
 
 [target.'cfg(target_os = "wasi")'.dependencies]
 wasi = "0.11.0"
-libc = "0.2.183"
 
 [dev-dependencies]
 env_logger = { version = "0.11", default-features = false }


### PR DESCRIPTION
Instead of having three different places defining the libc dependency, merge the cfg attributes so we can define it once.