### PR TITLE
Revert "Fix FreeBSD by working around a cargo bug"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,8 +15,6 @@ task:
   setup_script:
     - fetch https://sh.rustup.rs -o rustup.sh
     - sh rustup.sh -y --profile minimal
-    # Workaround https://github.com/rust-lang/cargo/issues/16357
-    - pkg install -y ca_root_nss
   cargo_cache:
     folder: $HOME/.cargo/registry
   build_script:


### PR DESCRIPTION
Rust 1.94.1 is available, remove Rust 1.94.0 workaround.

This reverts commit 68c315cb801f033dc72df0e25705cd1af6b73f6a.
