### PR TITLE
Fix operator precedence in epoll is_read_closed and is_write_closed

### DIFF
--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -171,16 +171,16 @@ pub mod event {
         // Both halves of the socket have closed
         event.events as libc::c_int & libc::EPOLLHUP != 0
             // Socket has received FIN or called shutdown(SHUT_RD)
-            || (event.events as libc::c_int & libc::EPOLLIN != 0
-                && event.events as libc::c_int & libc::EPOLLRDHUP != 0)
+            || ((event.events as libc::c_int & libc::EPOLLIN) != 0
+                && (event.events as libc::c_int & libc::EPOLLRDHUP) != 0)
     }
 
     pub fn is_write_closed(event: &Event) -> bool {
         // Both halves of the socket have closed
         event.events as libc::c_int & libc::EPOLLHUP != 0
             // Unix pipe write end has closed
-            || (event.events as libc::c_int & libc::EPOLLOUT != 0
-                && event.events as libc::c_int & libc::EPOLLERR != 0)
+            || ((event.events as libc::c_int & libc::EPOLLOUT) != 0
+                && (event.events as libc::c_int & libc::EPOLLERR) != 0)
             // The other side (read end) of a Unix pipe has closed.
             || event.events as libc::c_int == libc::EPOLLERR
     }


### PR DESCRIPTION
**Issue:** In src/sys/unix/selector/epoll.rs, the is_read_closed and is_write_closed functions had an operator precedence bug. Without parentheses, bitwise AND (&) has lower precedence than !=, so expressions like events & EPOLLIN != 0 were parsed as events & (EPOLLIN != 0) instead of (events & EPOLLIN) != 0.

**Fix:** Added explicit parentheses around each bitwise AND in the condition chains for both functions.

- Changed events & EPOLLIN != 0 && events & EPOLLRDHUP != 0 to (events & EPOLLIN) != 0 && (events & EPOLLRDHUP) != 0 in is_read_closed
- Changed events & EPOLLOUT != 0 && events & EPOLLERR != 0 to (events & EPOLLOUT) != 0 && (events & EPOLLERR) != 0 in is_write_closed

**Testing:** Code compiles with cargo build --all-features.