### PR TITLE
Socket Inheritance on Windows with TcpListener #1892

### DIFF
--- a/src/sys/windows/net.rs
+++ b/src/sys/windows/net.rs
@@ -4,9 +4,8 @@ use std::net::SocketAddr;
 use std::sync::Once;
 
 use windows_sys::Win32::Networking::WinSock::{
-    closesocket, ioctlsocket, AF_INET, AF_INET6, FIONBIO, IN6_ADDR, IN6_ADDR_0,
     closesocket, ioctlsocket, WSASocketW, AF_INET, AF_INET6, FIONBIO, IN6_ADDR, IN6_ADDR_0,
-     INVALID_SOCKET, IN_ADDR, IN_ADDR_0, SOCKADDR, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_IN6_0,
+    INVALID_SOCKET, IN_ADDR, IN_ADDR_0, SOCKADDR, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_IN6_0,
     SOCKET, WSA_FLAG_NO_HANDLE_INHERIT, WSA_FLAG_OVERLAPPED,
 };
 

--- a/src/sys/windows/net.rs
+++ b/src/sys/windows/net.rs
@@ -5,9 +5,9 @@ use std::sync::Once;
 
 use windows_sys::Win32::Networking::WinSock::{
     closesocket, ioctlsocket, AF_INET, AF_INET6, FIONBIO, IN6_ADDR, IN6_ADDR_0,
-    INVALID_SOCKET, IN_ADDR, IN_ADDR_0, SOCKADDR, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_IN6_0,
-    SOCKET,
-    WSA_FLAG_OVERLAPPED, WSA_FLAG_NO_HANDLE_INHERIT, WSASocketW,
+    closesocket, ioctlsocket, WSASocketW, AF_INET, AF_INET6, FIONBIO, IN6_ADDR, IN6_ADDR_0,
+     INVALID_SOCKET, IN_ADDR, IN_ADDR_0, SOCKADDR, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_IN6_0,
+    SOCKET, WSA_FLAG_NO_HANDLE_INHERIT, WSA_FLAG_OVERLAPPED,
 };
 
 /// Initialise the network stack for Windows.

--- a/src/sys/windows/net.rs
+++ b/src/sys/windows/net.rs
@@ -35,7 +35,6 @@ pub(crate) fn new_socket(domain: u32, socket_type: i32) -> io::Result<SOCKET> {
     init();
 
     let flags = WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT;
-
     let socket = syscall!(
         WSASocketW(domain as i32, socket_type, 0, std::ptr::null(), 0, flags),
         PartialEq::eq,

--- a/src/sys/windows/net.rs
+++ b/src/sys/windows/net.rs
@@ -4,9 +4,10 @@ use std::net::SocketAddr;
 use std::sync::Once;
 
 use windows_sys::Win32::Networking::WinSock::{
-    closesocket, ioctlsocket, socket, AF_INET, AF_INET6, FIONBIO, IN6_ADDR, IN6_ADDR_0,
+    closesocket, ioctlsocket, AF_INET, AF_INET6, FIONBIO, IN6_ADDR, IN6_ADDR_0,
     INVALID_SOCKET, IN_ADDR, IN_ADDR_0, SOCKADDR, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_IN6_0,
     SOCKET,
+    WSA_FLAG_OVERLAPPED, WSA_FLAG_NO_HANDLE_INHERIT, WSASocketW,
 };
 
 /// Initialise the network stack for Windows.
@@ -33,8 +34,10 @@ pub(crate) fn new_ip_socket(addr: SocketAddr, socket_type: i32) -> io::Result<SO
 pub(crate) fn new_socket(domain: u32, socket_type: i32) -> io::Result<SOCKET> {
     init();
 
+    let flags = WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT;
+
     let socket = syscall!(
-        socket(domain as i32, socket_type, 0),
+        WSASocketW(domain as i32, socket_type, 0, std::ptr::null(), 0, flags),
         PartialEq::eq,
         INVALID_SOCKET
     )?;


### PR DESCRIPTION
I have changed the new_socket function from using socket to using WSASocketW as the issue suggests.

I have tried to spawn a child process to see if it contains a handle to the TcpListener and I think it works correctly

The process explorer before:
<img width="1918" height="1016" alt="before my fix" src="https://github.com/user-attachments/assets/99d36bff-6426-46a1-8fa3-1e89fa56b507" />
it contains a handle to an AFD

The process explorer after:
<img width="1918" height="1017" alt="after my fix" src="https://github.com/user-attachments/assets/91d6ad91-1059-4b9f-8ee8-3cac353ccbab" />
It disappeared