### PR TITLE
Clamp epoll timeout to c_int::MAX to prevent truncation

### DIFF
--- a/src/sys/unix/selector/epoll.rs
+++ b/src/sys/unix/selector/epoll.rs
@@ -50,9 +50,12 @@ impl Selector {
                 // turning sub-millisecond timeouts into a zero timeout, unless
                 // the caller explicitly requests that by specifying a zero
                 // timeout.
-                to.checked_add(Duration::from_nanos(999_999))
-                    .unwrap_or(to)
-                    .as_millis() as libc::c_int
+                libc::c_int::try_from(
+                    to.checked_add(Duration::from_nanos(999_999))
+                        .unwrap_or(to)
+                        .as_millis(),
+                )
+                .unwrap_or(libc::c_int::MAX)
             })
             .unwrap_or(-1);
 


### PR DESCRIPTION
`Duration::as_millis()` returns u128, which was cast directly to `libc::c_int` (i32). Timeouts exceeding ~24.8 days would silently truncate to a negative value, causing epoll_wait to block indefinitely. The kqueue, poll(2), and IOCP backends already clamp correctly; this brings epoll in line.

This issue has been introduced by #1741, which missed the fact that `c_int` is smaller than u128.