### PR TITLE
fix: Handle State::None in named pipe read_done and write_done

### DIFF
--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -906,7 +906,16 @@ fn read_done(status: &OVERLAPPED_ENTRY, events: Option<&mut Vec<Event>>) {
             io.notify_readable(&me, events);
             return;
         }
-        State::None => unreachable!(),
+        // IOCP completion arrived after the state was already consumed
+        // (e.g. pipe deregistered or closed). The Arc refcount is
+        // reclaimed by `Arc::from_raw` above; recover silently in
+        // release, panic in debug to surface unexpected occurrences.
+        State::None => {
+            if cfg!(debug_assertions) {
+                unreachable!("read_done: unexpected State::None");
+            }
+            return;
+        }
     };
     unsafe {
         match me.result(status.overlapped()) {
@@ -960,7 +969,16 @@ fn write_done(status: &OVERLAPPED_ENTRY, events: Option<&mut Vec<Event>>) {
             io.notify_writable(&me, events);
             return;
         }
-        State::None => unreachable!(),
+        // IOCP completion arrived after the state was already consumed
+        // (e.g. pipe deregistered or closed). The Arc refcount is
+        // reclaimed by `Arc::from_raw` above; recover silently in
+        // release, panic in debug to surface unexpected occurrences.
+        State::None => {
+            if cfg!(debug_assertions) {
+                unreachable!("write_done: unexpected State::None");
+            }
+            return;
+        }
     };
 
     unsafe {


### PR DESCRIPTION
_Disclaimer - this is a pure AI slop. I'm mostly interested in not crashing production code that hits this edge case._

Fixes a panic observed in production (reported upstream in tokio-rs/mio#1819 as `State::None` variant).

Replace `unreachable!()` with a graceful return (but still panic in debug builds) when IOCP delivers a completion event for a named pipe whose I/O state has already been consumed (e.g. after deregistration or an unexpected pipe closure race).

The `Arc` refcount leaked by `mem::forget` during `schedule_read` / `schedule_write` is properly reclaimed by `Arc::from_raw` at the top of each callback, so returning early is safe.