### PR TITLE
Fix race condition in NamedPipe::connect

### DIFF
--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -423,6 +423,12 @@ impl NamedPipe {
             return Err(would_block());
         }
 
+        // If `connect_overlapped` does not complete immediately then we need
+        // to pass a reference to `self.inner` to the completion handler.
+        // We need to increase the reference count here because `connect_done`
+        // could be called as soon as we call `connect_overlapped`.
+        let inner_for_completion = self.inner.clone();
+
         // Now that we've flagged ourselves in the connecting state, issue the
         // connection attempt. Afterwards interpret the return value and set
         // internal state accordingly.
@@ -448,7 +454,7 @@ impl NamedPipe {
             // `connect_done` function will "reify" this forgotten pointer to
             // drop the refcount on the other side.
             Ok(false) => {
-                mem::forget(self.inner.clone());
+                mem::forget(inner_for_completion);
                 Err(would_block())
             }
 


### PR DESCRIPTION
There is a race condition in NamePipe::connect between the asynchronous completion of `connect_overlapped` and bumping the reference count of `self.inner`. If `connect_overlapped` completes before we bump the reference count, then reference count of `self.inner` will temporarily hit zero and `self.inner` will be dropped. Note that even though `Inner` is dropped, and it's memory is returned to the allocator, the object is still used by `NamedPipe`. After `NamedPipe` is itself dropped, the reference count for `Inner` drops to zero again, resulting in `drop` being called for the second time.

The fix is to bump the reference count of `self.inner` before calling `connect_overlapped`. Then, if `connect_overlapped` does not finish immediately we forget the clone of `Arc<Inner>`.

I usually hit this issue in my module within 2 million connects. I don't hit the issue with the proposed fix. Adding a `thread::sleep` immediately before `forget` makes the issue occur almost immediately. I don't have a minimal repro that doesn't use my module. If I had to write a unit test for this I would make a wrapper of `ConnectNamedPipe` that converts synchronous completions into asynchronous ones by manually posting an event to the  IOCP.

Other operations (read / write) use a similar pattern, but unlike connect, both issuing the operation (`schedule_read` / `schedule_write`) and completions (`read_done` / `write_done`) are executed under a mutex (`self.io`).