### PR TITLE
Fix readme typo and assert for windows in unix target tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To use `mio`, first add this to your `Cargo.toml`:
 mio = "1"
 ```
 
-Next we can start using Mio. The following is quick introduction using
+Next we can start using Mio. The following is a quick introduction using
 `TcpListener` and `TcpStream`. Note that `features = ["os-poll", "net"]` must be
 specified for this example.
 

--- a/tests/unix_stream.rs
+++ b/tests/unix_stream.rs
@@ -404,8 +404,6 @@ fn unix_stream_shutdown_both() {
     let err = stream.write(DATA2).unwrap_err();
     #[cfg(unix)]
     assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
-    #[cfg(windows)]
-    assert_eq!(err.kind(), io::ErrorKind::ConnectionAbroted);
 
     // Close the connection to allow the remote to shutdown
     drop(stream);


### PR DESCRIPTION
Fixes a missing `a` in  the README and removes an assert in `UnixStream` test checking for a Windows target (which also had a typo).