### PR TITLE
windows: implement vectored I/O for NamedPipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Fixed a casting issue when polling with a timeout larger than ~24.8 days on Linux
   (https://github.com/tokio-rs/mio/pull/1948).
 * Implemented vectored I/O (`write_vectored`/`read_vectored`) for Windows `NamedPipe`
-  (https://github.com/tokio-rs/tokio/issues/6970).
+  (https://github.com/tokio-rs/mio/pull/1959).
 
 # 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   (https://github.com/tokio-rs/mio/pull/1954).
 * Fixed a casting issue when polling with a timeout larger than ~24.8 days on Linux
   (https://github.com/tokio-rs/mio/pull/1948).
+* Implemented vectored I/O (`write_vectored`/`read_vectored`) for Windows `NamedPipe`
+  (https://github.com/tokio-rs/tokio/issues/6970).
 
 # 1.2.0
 

--- a/src/sys/windows/iocp.rs
+++ b/src/sys/windows/iocp.rs
@@ -215,7 +215,7 @@ impl CompletionStatus {
     /// A completion key is a per-handle key that is specified when it is added
     /// to an I/O completion port via `add_handle` or `add_socket`.
     pub fn token(&self) -> usize {
-        self.0.lpCompletionKey
+        self.0.lpCompletionKey as usize
     }
 
     /// Returns a pointer to the `Overlapped` structure that was specified when

--- a/src/sys/windows/iocp.rs
+++ b/src/sys/windows/iocp.rs
@@ -215,7 +215,7 @@ impl CompletionStatus {
     /// A completion key is a per-handle key that is specified when it is added
     /// to an I/O completion port via `add_handle` or `add_socket`.
     pub fn token(&self) -> usize {
-        self.0.lpCompletionKey as usize
+        self.0.lpCompletionKey
     }
 
     /// Returns a pointer to the `Overlapped` structure that was specified when

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -1,5 +1,5 @@
 use std::ffi::OsStr;
-use std::io::{self, Read, Write};
+use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle};
 use std::sync::atomic::Ordering::{Relaxed, SeqCst};
 use std::sync::atomic::{AtomicBool, AtomicUsize};
@@ -517,11 +517,19 @@ impl Read for NamedPipe {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         <&NamedPipe as Read>::read(&mut &*self, buf)
     }
+
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        <&NamedPipe as Read>::read_vectored(&mut &*self, bufs)
+    }
 }
 
 impl Write for NamedPipe {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         <&NamedPipe as Write>::write(&mut &*self, buf)
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        <&NamedPipe as Write>::write_vectored(&mut &*self, bufs)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -578,6 +586,55 @@ impl<'a> Read for &'a NamedPipe {
             }
         }
     }
+
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        let mut state = self.inner.io.lock().unwrap();
+
+        if state.token.is_none() {
+            return Err(would_block());
+        }
+
+        match mem::replace(&mut state.read, State::None) {
+            // In theory not possible with `token` checked above,
+            // but return would block for now.
+            State::None => Err(would_block()),
+
+            // A read is in flight, still waiting for it to finish
+            State::Pending(buf, amt) => {
+                state.read = State::Pending(buf, amt);
+                Err(would_block())
+            }
+
+            // We previously read something into `data`, try to scatter out some
+            // data. If we copy out all the data schedule a new read and
+            // otherwise store the buffer to get read later.
+            State::Ok(data, cur) => {
+                let n = {
+                    let mut remaining = &data[cur..];
+                    Read::read_vectored(&mut remaining, bufs)?
+                };
+                let next = cur + n;
+                if next != data.len() {
+                    state.read = State::Ok(data, next);
+                } else {
+                    self.inner.put_buffer(data);
+                    Inner::schedule_read(&self.inner, &mut state, None);
+                }
+                Ok(n)
+            }
+
+            // Looks like an in-flight read hit an error, return that here while
+            // we schedule a new one.
+            State::Err(e) => {
+                Inner::schedule_read(&self.inner, &mut state, None);
+                if e.raw_os_error() == Some(ERROR_BROKEN_PIPE as i32) {
+                    Ok(0)
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
 }
 
 impl<'a> Write for &'a NamedPipe {
@@ -610,6 +667,41 @@ impl<'a> Write for &'a NamedPipe {
             Some(n) => Ok(n),
             // Write operation is enqueued for whole buffer
             None => Ok(buf.len()),
+        }
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        // Make sure there's no writes pending
+        let mut io = self.inner.io.lock().unwrap();
+
+        if io.token.is_none() {
+            return Err(would_block());
+        }
+
+        match io.write {
+            State::None => {}
+            State::Err(_) => match mem::replace(&mut io.write, State::None) {
+                State::Err(e) => return Err(e),
+                // `io` is locked, so this branch is unreachable
+                _ => unreachable!(),
+            },
+            // any other state should be handled in `write_done`
+            _ => {
+                return Err(would_block());
+            }
+        }
+
+        // Move all buffers onto the heap and fire off a single write
+        let mut owned_buf = self.inner.get_buffer();
+        for buf in bufs {
+            owned_buf.extend_from_slice(buf);
+        }
+        let total_len = owned_buf.len();
+        match Inner::maybe_schedule_write(&self.inner, owned_buf, 0, &mut io)? {
+            // Some bytes are written immediately
+            Some(n) => Ok(n),
+            // Write operation is enqueued for whole buffer
+            None => Ok(total_len),
         }
     }
 

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -537,7 +537,7 @@ impl Write for NamedPipe {
     }
 }
 
-impl Read for &NamedPipe {
+impl<'a> Read for &'a NamedPipe {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut state = self.inner.io.lock().unwrap();
 
@@ -637,7 +637,7 @@ impl Read for &NamedPipe {
     }
 }
 
-impl Write for &NamedPipe {
+impl<'a> Write for &'a NamedPipe {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         // Make sure there's no writes pending
         let mut io = self.inner.io.lock().unwrap();
@@ -1098,7 +1098,7 @@ fn event_done(status: &OVERLAPPED_ENTRY, events: Option<&mut Vec<Event>>) {
         // cleanup. In this case, `events` is `None` and we don't need to track
         // the event.
         if let Some(events) = events {
-            let mut ev = Event::from_completion_status(status);
+            let mut ev = Event::from_completion_status(&status);
             // Reverse the `.data` alteration done in `schedule_event`. This
             // alteration was done so the selector recognized the event as one from
             // a named pipe.

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -537,7 +537,7 @@ impl Write for NamedPipe {
     }
 }
 
-impl<'a> Read for &'a NamedPipe {
+impl Read for &NamedPipe {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut state = self.inner.io.lock().unwrap();
 
@@ -637,7 +637,7 @@ impl<'a> Read for &'a NamedPipe {
     }
 }
 
-impl<'a> Write for &'a NamedPipe {
+impl Write for &NamedPipe {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         // Make sure there's no writes pending
         let mut io = self.inner.io.lock().unwrap();
@@ -1098,7 +1098,7 @@ fn event_done(status: &OVERLAPPED_ENTRY, events: Option<&mut Vec<Event>>) {
         // cleanup. In this case, `events` is `None` and we don't need to track
         // the event.
         if let Some(events) = events {
-            let mut ev = Event::from_completion_status(&status);
+            let mut ev = Event::from_completion_status(status);
             // Reverse the `.data` alteration done in `schedule_event`. This
             // alteration was done so the selector recognized the event as one from
             // a named pipe.

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -1,7 +1,7 @@
 #![cfg(all(windows, feature = "os-poll", feature = "os-ext"))]
 
 use std::fs::OpenOptions;
-use std::io::{self, Read, Write};
+use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::os::windows::fs::OpenOptionsExt;
 use std::os::windows::io::{FromRawHandle, IntoRawHandle};
 use std::time::Duration;
@@ -447,4 +447,56 @@ fn read_with_small_buffer_provided() {
     }
 
     assert_eq!(actual_msg, expected_msg);
+}
+
+#[test]
+fn write_vectored_then_read_vectored() {
+    let (mut server, mut client) = pipe();
+    let mut poll = t!(Poll::new());
+    t!(poll.registry().register(
+        &mut server,
+        Token(0),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
+    t!(poll.registry().register(
+        &mut client,
+        Token(1),
+        Interest::READABLE | Interest::WRITABLE,
+    ));
+
+    let mut events = Events::with_capacity(128);
+    t!(poll.poll(&mut events, None));
+
+    // Write three slices as a single vectored write
+    let bufs = [
+        IoSlice::new(b"foo"),
+        IoSlice::new(b"bar"),
+        IoSlice::new(b"baz"),
+    ];
+    assert_eq!(t!(client.write_vectored(&bufs)), 9);
+
+    // Spin until server is readable
+    loop {
+        t!(poll.poll(&mut events, None));
+        let events = events.iter().collect::<Vec<_>>();
+        if let Some(event) = events.iter().find(|e| e.token() == Token(0)) {
+            if event.is_readable() {
+                break;
+            }
+        }
+    }
+
+    // Scatter-read into three separate buffers
+    let mut b0 = [0u8; 3];
+    let mut b1 = [0u8; 3];
+    let mut b2 = [0u8; 3];
+    let mut scatter = [
+        IoSliceMut::new(&mut b0),
+        IoSliceMut::new(&mut b1),
+        IoSliceMut::new(&mut b2),
+    ];
+    assert_eq!(t!(server.read_vectored(&mut scatter)), 9);
+    assert_eq!(&b0, b"foo");
+    assert_eq!(&b1, b"bar");
+    assert_eq!(&b2, b"baz");
 }


### PR DESCRIPTION
`NamedPipe` didn't override `write_vectored`/`read_vectored`, so std's defaults only processed the **first** buffer. Root cause of tokio-rs/tokio#6970 (redirected here by @Darksonn).

- `write_vectored` (`&NamedPipe`): gathers all `IoSlice`s into the internal `owned_buf` and fires one overlapped write — same lock/state logic as `write`, no extra copy.
- `read_vectored` (`&NamedPipe`): scatters the internal read buffer across the `IoSliceMut`s.
- Delegating overrides on the owned `NamedPipe` impls; adds a test + CHANGELOG entry.

`is_write_vectored` is omitted — unstable (`can_vector`, rust-lang/rust#69941) on mio's MSRV 1.71, and not needed here since callers invoke `write_vectored` directly.

`#[cfg(windows)]` code: locally `cargo check`'d for the Windows target; runtime tests run on CI's Windows job.