### PR TITLE
Add Solaris event ports selector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,24 @@ jobs:
           . $HOME/.cargo/env
           cargo test --target ${{ matrix.target }} --all-features
 
+  TestSolaris:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tests
+        uses: vmactions/solaris-vm@v1
+        with:
+          release: "11.4-gcc"
+          usesh: true
+          copyback: false
+          prepare: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.sh
+            sh rustup.sh -y --profile=minimal
+          run: |
+            . $HOME/.cargo/env
+            cargo test --all-features
+
   # Single job required to merge the pr.
   Passed:
     runs-on: ubuntu-latest
@@ -267,5 +285,6 @@ jobs:
       - Rustfmt
       - CheckTargets
       - TestFreeBSD
+      - TestSolaris
     steps:
       - run: exit 0

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -9,7 +9,6 @@
         target_os = "hermit",
         target_os = "hurd",
         target_os = "nto",
-        target_os = "solaris",
         target_os = "vita",
         target_os = "cygwin",
         target_os = "horizon"
@@ -243,6 +242,7 @@ use crate::{event, sys, Events, Interest, Token};
 /// | Linux         | [epoll]   |
 /// | NetBSD        | [kqueue]  |
 /// | OpenBSD       | [kqueue]  |
+/// | Solaris       | [event ports] |
 /// | Windows       | [IOCP]    |
 /// | macOS         | [kqueue]  |
 ///
@@ -261,6 +261,7 @@ use crate::{event, sys, Events, Interest, Token};
 /// kernel.
 ///
 /// [epoll]: https://man7.org/linux/man-pages/man7/epoll.7.html
+/// [event ports]: https://docs.oracle.com/cd/E88353_01/html/E37843/port-create-3c.html
 /// [kqueue]: https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
 /// [IOCP]: https://docs.microsoft.com/en-us/windows/win32/fileio/i-o-completion-ports
 /// [`signalfd`]: https://man7.org/linux/man-pages/man2/signalfd.2.html
@@ -453,7 +454,6 @@ impl Poll {
         target_os = "hermit",
         target_os = "hurd",
         target_os = "nto",
-        target_os = "solaris",
         target_os = "vita",
         target_os = "cygwin",
         target_os = "horizon"
@@ -757,7 +757,6 @@ impl fmt::Debug for Registry {
         target_os = "hermit",
         target_os = "hurd",
         target_os = "nto",
-        target_os = "solaris",
         target_os = "vita",
         target_os = "cygwin",
         target_os = "horizon"
@@ -780,7 +779,6 @@ impl AsFd for Registry {
         target_os = "hermit",
         target_os = "hurd",
         target_os = "nto",
-        target_os = "solaris",
         target_os = "vita",
         target_os = "cygwin",
         target_os = "horizon"
@@ -802,7 +800,6 @@ cfg_os_poll! {
             target_os = "hermit",
             target_os = "hurd",
             target_os = "nto",
-            target_os = "solaris",
             target_os = "vita",
             target_os = "cygwin",
             target_os = "horizon"

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -38,6 +38,10 @@ cfg_os_poll! {
             target_os = "watchos",
         )
     ), path = "selector/kqueue.rs")]
+    #[cfg_attr(all(
+        not(mio_unsupported_force_poll_poll),
+        target_os = "solaris",
+    ), path = "selector/event_ports.rs")]
     #[cfg_attr(any(
         mio_unsupported_force_poll_poll,
         target_os = "aix",
@@ -47,7 +51,6 @@ cfg_os_poll! {
         target_os = "hermit",
         target_os = "hurd",
         target_os = "nto",
-        target_os = "solaris",
         target_os = "vita",
         target_os = "cygwin",
         target_os = "wasi",
@@ -79,6 +82,10 @@ cfg_os_poll! {
             target_os = "watchos",
         )
     ), path = "waker/kqueue.rs")]
+    #[cfg_attr(all(
+        not(mio_unsupported_force_poll_poll),
+        target_os = "solaris",
+    ), path = "waker/event_ports.rs")]
     #[cfg_attr(any(
         // NOTE: also add to the list for the `pipe` module below.
         mio_unsupported_force_waker_pipe,
@@ -102,13 +109,15 @@ cfg_os_poll! {
         target_os = "nto",
         target_os = "openbsd",
         target_os = "redox",
-        target_os = "solaris",
+        all(mio_unsupported_force_poll_poll, target_os = "solaris"),
         target_os = "vita",
         target_os = "cygwin",
         all(target_os = "wasi", target_env = "p1")
     ), path = "waker/pipe.rs")]
     #[cfg_attr(any(target_os = "horizon", all(target_os = "wasi", not(target_env = "p1"))), path = "waker/single_threaded.rs")]
     mod waker;
+    #[cfg(all(not(mio_unsupported_force_poll_poll), target_os = "solaris"))]
+    pub(crate) use self::waker::Waker;
     // NOTE: the `Waker` type is expected in the selector module as the
     // `poll(2)` implementation needs to do some special stuff.
 
@@ -153,7 +162,7 @@ cfg_os_poll! {
             target_os = "nto",
             target_os = "openbsd",
             target_os = "redox",
-            target_os = "solaris",
+            all(mio_unsupported_force_poll_poll, target_os = "solaris"),
             target_os = "vita",
             target_os = "cygwin",
         ),

--- a/src/sys/unix/selector/event_ports.rs
+++ b/src/sys/unix/selector/event_ports.rs
@@ -24,14 +24,27 @@ pub struct Selector {
     id: usize,
     port: OwnedFd,
     state: Arc<SelectorState>,
-    raw_events: EventBuffer,
+    events: EventBuffer,
 }
 
 #[derive(Debug)]
-struct EventBuffer(Vec<libc::port_event>);
+struct EventBuffer {
+    port_events: Vec<libc::port_event>,
+    poll_fds: Vec<libc::pollfd>,
+}
 
-// SAFETY: `EventBuffer` is only scratch storage for `port_getn` results and is
-// only accessed through `Selector::select`, which requires `&mut self`.
+impl EventBuffer {
+    fn new() -> EventBuffer {
+        EventBuffer {
+            port_events: Vec::new(),
+            poll_fds: Vec::new(),
+        }
+    }
+}
+
+// SAFETY: `EventBuffer` is only scratch storage for `port_getn` and `poll`
+// results and is only accessed through `Selector::select`, which requires
+// `&mut self`.
 unsafe impl Send for EventBuffer {}
 unsafe impl Sync for EventBuffer {}
 
@@ -60,7 +73,7 @@ impl Selector {
             #[cfg(debug_assertions)]
             id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
             port,
-            raw_events: EventBuffer(Vec::new()),
+            events: EventBuffer::new(),
             state: Arc::new(SelectorState {
                 fds: Mutex::new(HashMap::new()),
             }),
@@ -73,14 +86,14 @@ impl Selector {
             #[cfg(debug_assertions)]
             id: self.id,
             port,
-            raw_events: EventBuffer(Vec::new()),
+            events: EventBuffer::new(),
             state: Arc::clone(&self.state),
         })
     }
 
     pub fn select(&mut self, events: &mut Events, timeout: Option<Duration>) -> io::Result<()> {
         self.state
-            .select(self.port.as_raw_fd(), events, timeout, &mut self.raw_events)
+            .select(self.port.as_raw_fd(), events, timeout, &mut self.events)
     }
 
     cfg_io_source! {
@@ -130,7 +143,7 @@ impl SelectorState {
         port: RawFd,
         events: &mut Events,
         timeout: Option<Duration>,
-        raw_events: &mut EventBuffer,
+        event_buffer: &mut EventBuffer,
     ) -> io::Result<()> {
         events.clear();
 
@@ -138,11 +151,11 @@ impl SelectorState {
             return Ok(());
         }
 
-        raw_events.0.clear();
-        if raw_events.0.capacity() < events.capacity() {
-            raw_events
-                .0
-                .reserve(events.capacity() - raw_events.0.capacity());
+        event_buffer.port_events.clear();
+        if event_buffer.port_events.capacity() < events.capacity() {
+            event_buffer
+                .port_events
+                .reserve(events.capacity() - event_buffer.port_events.capacity());
         }
 
         let start = Instant::now();
@@ -174,13 +187,13 @@ impl SelectorState {
                 .map(|timeout| timeout as *mut _)
                 .unwrap_or(std::ptr::null_mut());
             let mut nget = 1;
-            raw_events.0.clear();
+            event_buffer.port_events.clear();
 
             trace!("waiting for Solaris event port events");
             let res = syscall!(port_getn(
                 port,
-                raw_events.0.as_mut_ptr(),
-                raw_events.0.capacity() as libc::c_uint,
+                event_buffer.port_events.as_mut_ptr(),
+                event_buffer.port_events.capacity() as libc::c_uint,
                 &mut nget,
                 timeout,
             ));
@@ -200,8 +213,8 @@ impl SelectorState {
 
             trace!("Solaris event port returned {nget} events");
             // SAFETY: `port_getn` initialized exactly the first `nget` entries.
-            unsafe { raw_events.0.set_len(nget as usize) };
-            self.process_events(port, raw_events.0.as_slice(), events)?;
+            unsafe { event_buffer.port_events.set_len(nget as usize) };
+            self.process_events(port, event_buffer, events)?;
             if !events.is_empty() {
                 return Ok(());
             }
@@ -211,12 +224,41 @@ impl SelectorState {
     fn process_events(
         &self,
         port: RawFd,
-        raw_events: &[libc::port_event],
+        event_buffer: &mut EventBuffer,
         events: &mut Events,
     ) -> io::Result<()> {
         let mut fds = self.fds.lock().unwrap();
+        let raw_events = event_buffer.port_events.as_slice();
+        let poll_fds = &mut event_buffer.poll_fds;
 
         events.reserve(raw_events.len());
+        poll_fds.clear();
+        poll_fds.reserve(raw_events.len());
+        for event in raw_events {
+            if event.portev_source != libc::PORT_SOURCE_FD as libc::c_ushort {
+                continue;
+            }
+
+            let fd = event.portev_object as RawFd;
+            let Some(data) = fds.get(&fd) else {
+                continue;
+            };
+            poll_fds.push(libc::pollfd {
+                fd,
+                events: interests_to_port(data.interests) as libc::c_short,
+                revents: 0,
+            });
+        }
+
+        if !poll_fds.is_empty() {
+            syscall!(poll(
+                poll_fds.as_mut_ptr(),
+                poll_fds.len() as libc::nfds_t,
+                0
+            ))?;
+        }
+
+        let mut poll_fds = poll_fds.iter();
         for event in raw_events {
             if event.portev_source == libc::PORT_SOURCE_USER as libc::c_ushort {
                 push_event(
@@ -234,7 +276,15 @@ impl SelectorState {
                     continue;
                 };
                 let current_interest_events = interests_to_port(data.interests);
-                let Some(poll_events) = poll_fd_readiness(fd, data.interests)? else {
+                let poll_events = poll_fds.next().and_then(|poll_fd| {
+                    debug_assert_eq!(poll_fd.fd, fd);
+                    if poll_fd.revents == 0 {
+                        None
+                    } else {
+                        Some(EventMask::from(poll_fd.revents))
+                    }
+                });
+                let Some(poll_events) = poll_events else {
                     if event.portev_events & ERROR_EVENTS == 0 {
                         let generation = data.generation.wrapping_add(1).max(1);
                         associate(port, fd, data.interests, generation)?;
@@ -479,20 +529,6 @@ fn push_event(
             portev_object: object,
             portev_user: usize::from(token) as *mut libc::c_void,
         }));
-    }
-}
-
-fn poll_fd_readiness(fd: RawFd, interests: Interest) -> io::Result<Option<EventMask>> {
-    let mut poll_fd = libc::pollfd {
-        fd,
-        events: interests_to_port(interests) as libc::c_short,
-        revents: 0,
-    };
-
-    if syscall!(poll(&mut poll_fd, 1, 0))? == 0 {
-        Ok(None)
-    } else {
-        Ok(Some(EventMask::from(poll_fd.revents)))
     }
 }
 

--- a/src/sys/unix/selector/event_ports.rs
+++ b/src/sys/unix/selector/event_ports.rs
@@ -14,10 +14,8 @@ static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
 
 type EventMask = libc::c_int;
 
-const POLLRDHUP: EventMask = 0;
 const READ_EVENTS: EventMask = libc::POLLIN as EventMask;
 const WRITE_EVENTS: EventMask = libc::POLLOUT as EventMask;
-const PRIORITY_EVENTS: EventMask = libc::POLLPRI as EventMask;
 const ERROR_EVENTS: EventMask = libc::POLLERR as EventMask | libc::POLLHUP as EventMask;
 
 #[derive(Debug)]
@@ -541,10 +539,6 @@ fn interests_to_port(interests: Interest) -> EventMask {
         events |= WRITE_EVENTS;
     }
 
-    if interests.is_priority() {
-        events |= PRIORITY_EVENTS;
-    }
-
     events
 }
 
@@ -621,7 +615,7 @@ pub mod event {
     use crate::sys::Event;
     use crate::Token;
 
-    use super::{EventMask, POLLRDHUP};
+    use super::EventMask;
 
     pub fn token(event: &Event) -> Token {
         Token(event.0.portev_user as usize)
@@ -642,7 +636,6 @@ pub mod event {
 
     pub fn is_read_closed(event: &Event) -> bool {
         (event.0.portev_events & libc::POLLHUP as EventMask) != 0
-            || (event.0.portev_events & POLLRDHUP) != 0
     }
 
     pub fn is_write_closed(event: &Event) -> bool {

--- a/src/sys/unix/selector/event_ports.rs
+++ b/src/sys/unix/selector/event_ports.rs
@@ -1,0 +1,829 @@
+use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use std::{cmp, io};
+
+use crate::{Interest, Token};
+
+/// Unique id for use as `SelectorId`.
+#[cfg(debug_assertions)]
+static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
+
+type EventMask = libc::c_int;
+
+const POLLRDHUP: EventMask = 0;
+const READ_EVENTS: EventMask = libc::POLLIN as EventMask;
+const WRITE_EVENTS: EventMask = libc::POLLOUT as EventMask;
+const PRIORITY_EVENTS: EventMask = libc::POLLPRI as EventMask;
+const ERROR_EVENTS: EventMask = libc::POLLERR as EventMask | libc::POLLHUP as EventMask;
+
+#[derive(Debug)]
+pub struct Selector {
+    #[cfg(debug_assertions)]
+    id: usize,
+    port: OwnedFd,
+    state: Arc<SelectorState>,
+    raw_events: EventBuffer,
+}
+
+#[derive(Debug)]
+struct EventBuffer(Vec<libc::port_event>);
+
+// SAFETY: `EventBuffer` is only scratch storage for `port_getn` results and is
+// only accessed through `Selector::select`, which requires `&mut self`.
+unsafe impl Send for EventBuffer {}
+unsafe impl Sync for EventBuffer {}
+
+#[derive(Debug)]
+struct SelectorState {
+    fds: Mutex<HashMap<RawFd, FdData>>,
+}
+
+#[derive(Debug)]
+struct FdData {
+    token: Token,
+    interests: Interest,
+    generation: usize,
+    associated: bool,
+    needs_fallback: bool,
+    fallback_writable: bool,
+}
+
+impl Selector {
+    pub fn new() -> io::Result<Selector> {
+        // SAFETY: `port_create(3C)` returns a valid fd on success.
+        let port = unsafe { OwnedFd::from_raw_fd(syscall!(port_create())?) };
+        syscall!(fcntl(port.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC))?;
+
+        Ok(Selector {
+            #[cfg(debug_assertions)]
+            id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+            port,
+            raw_events: EventBuffer(Vec::new()),
+            state: Arc::new(SelectorState {
+                fds: Mutex::new(HashMap::new()),
+            }),
+        })
+    }
+
+    pub fn try_clone(&self) -> io::Result<Selector> {
+        self.port.try_clone().map(|port| Selector {
+            // It's the same selector, so we use the same id.
+            #[cfg(debug_assertions)]
+            id: self.id,
+            port,
+            raw_events: EventBuffer(Vec::new()),
+            state: Arc::clone(&self.state),
+        })
+    }
+
+    pub fn select(&mut self, events: &mut Events, timeout: Option<Duration>) -> io::Result<()> {
+        self.state
+            .select(self.port.as_raw_fd(), events, timeout, &mut self.raw_events)
+    }
+
+    cfg_io_source! {
+    #[allow(dead_code)]
+    pub fn register(&self, fd: RawFd, token: Token, interests: Interest) -> io::Result<()> {
+        self.register_internal(fd, token, interests).map(|_| ())
+    }
+
+    pub(crate) fn register_internal(
+        &self,
+        fd: RawFd,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<Arc<RegistrationRecord>> {
+        self.state
+            .register(self.port.as_raw_fd(), fd, token, interests)
+    }
+    }
+
+    cfg_any_os_ext! {
+    pub fn reregister(&self, fd: RawFd, token: Token, interests: Interest) -> io::Result<()> {
+        self.state.reregister(self.port.as_raw_fd(), fd, token, interests)
+    }
+
+    pub fn deregister(&self, fd: RawFd) -> io::Result<()> {
+        self.state.deregister(self.port.as_raw_fd(), fd)
+    }
+    }
+
+    pub fn wake(&self, token: Token) -> io::Result<()> {
+        self.state.wake(self.port.as_raw_fd(), token)
+    }
+}
+
+cfg_io_source! {
+    impl Selector {
+        #[cfg(debug_assertions)]
+        pub fn id(&self) -> usize {
+            self.id
+        }
+    }
+}
+
+impl SelectorState {
+    fn select(
+        &self,
+        port: RawFd,
+        events: &mut Events,
+        timeout: Option<Duration>,
+        raw_events: &mut EventBuffer,
+    ) -> io::Result<()> {
+        events.clear();
+
+        if events.capacity() == 0 {
+            return Ok(());
+        }
+
+        raw_events.0.clear();
+        if raw_events.0.capacity() < events.capacity() {
+            raw_events
+                .0
+                .reserve(events.capacity() - raw_events.0.capacity());
+        }
+
+        let start = Instant::now();
+        let mut attempted = false;
+
+        loop {
+            let current_timeout = if attempted {
+                match timeout {
+                    Some(timeout) => match timeout.checked_sub(start.elapsed()) {
+                        Some(timeout) => Some(timeout),
+                        None => return Ok(()),
+                    },
+                    None => None,
+                }
+            } else {
+                timeout
+            };
+            let poll_fallback_on_timeout = current_timeout.is_none() && self.has_fallback_fds();
+            let current_timeout = current_timeout.or_else(|| {
+                if poll_fallback_on_timeout {
+                    Some(Duration::ZERO)
+                } else {
+                    None
+                }
+            });
+            let mut timeout = timeout_to_timespec(current_timeout);
+            let timeout = timeout
+                .as_mut()
+                .map(|timeout| timeout as *mut _)
+                .unwrap_or(std::ptr::null_mut());
+            let mut nget = 1;
+            raw_events.0.clear();
+
+            trace!("waiting for Solaris event port events");
+            let res = syscall!(port_getn(
+                port,
+                raw_events.0.as_mut_ptr(),
+                raw_events.0.capacity() as libc::c_uint,
+                &mut nget,
+                timeout,
+            ));
+            attempted = true;
+
+            if let Err(err) = res {
+                match err.raw_os_error() {
+                    Some(libc::ETIME) => nget = 0,
+                    _ => return Err(err),
+                }
+            }
+
+            if nget == 0 {
+                self.poll_registered_fds(events, poll_fallback_on_timeout)?;
+                return Ok(());
+            }
+
+            trace!("Solaris event port returned {nget} events");
+            // SAFETY: `port_getn` initialized exactly the first `nget` entries.
+            unsafe { raw_events.0.set_len(nget as usize) };
+            self.process_events(port, raw_events.0.as_slice(), events)?;
+            if !events.is_empty() {
+                return Ok(());
+            }
+        }
+    }
+
+    fn process_events(
+        &self,
+        port: RawFd,
+        raw_events: &[libc::port_event],
+        events: &mut Events,
+    ) -> io::Result<()> {
+        let mut fds = self.fds.lock().unwrap();
+
+        events.reserve(raw_events.len());
+        for event in raw_events {
+            if event.portev_source == libc::PORT_SOURCE_USER as libc::c_ushort {
+                push_event(
+                    events,
+                    libc::PORT_SOURCE_USER as libc::c_ushort,
+                    0,
+                    Token(event.portev_user as usize),
+                    event.portev_events,
+                );
+            } else if event.portev_source == libc::PORT_SOURCE_FD as libc::c_ushort {
+                let fd = event.portev_object as RawFd;
+                let generation = event.portev_user as usize;
+
+                let Some(data) = fds.get_mut(&fd) else {
+                    continue;
+                };
+                let current_interest_events = interests_to_port(data.interests);
+                let Some(poll_events) = poll_fd_readiness(fd, data.interests)? else {
+                    if event.portev_events & ERROR_EVENTS == 0 {
+                        let generation = data.generation.wrapping_add(1).max(1);
+                        associate(port, fd, data.interests, generation)?;
+                        data.generation = generation;
+                        data.associated = true;
+                        data.needs_fallback = false;
+                        data.fallback_writable = false;
+                        continue;
+                    }
+
+                    let poll_events = event.portev_events;
+                    if data.generation != generation && poll_events & current_interest_events == 0 {
+                        let generation = data.generation.wrapping_add(1).max(1);
+                        associate(port, fd, data.interests, generation)?;
+                        data.generation = generation;
+                        data.associated = true;
+                        data.needs_fallback = false;
+                        data.fallback_writable = false;
+                        continue;
+                    }
+
+                    let generation = data.generation.wrapping_add(1).max(1);
+                    associate(port, fd, data.interests, generation)?;
+                    data.generation = generation;
+                    data.associated = true;
+                    data.needs_fallback = false;
+                    data.fallback_writable = false;
+                    push_event(
+                        events,
+                        libc::PORT_SOURCE_FD as libc::c_ushort,
+                        fd as libc::uintptr_t,
+                        data.token,
+                        poll_events,
+                    );
+                    continue;
+                };
+                if data.generation != generation && poll_events & current_interest_events == 0 {
+                    let generation = data.generation.wrapping_add(1).max(1);
+                    associate(port, fd, data.interests, generation)?;
+                    data.generation = generation;
+                    data.associated = true;
+                    data.needs_fallback = false;
+                    data.fallback_writable = false;
+                    continue;
+                }
+
+                // Event ports disassociate an fd after delivery. Re-associate
+                // only interests that were not delivered, and use fallback
+                // polling for delivered interests so sources that clear
+                // readiness without reregistering can observe future events.
+                let generation = data.generation.wrapping_add(1).max(1);
+                let remaining_interests = data
+                    .interests
+                    .remove(interests_from_event(poll_events).unwrap_or(data.interests));
+                if let Some(remaining_interests) = remaining_interests {
+                    associate(port, fd, remaining_interests, generation)?;
+                    data.associated = true;
+                } else {
+                    data.associated = false;
+                }
+                data.generation = generation;
+                data.needs_fallback = true;
+                data.fallback_writable = false;
+
+                push_event(
+                    events,
+                    libc::PORT_SOURCE_FD as libc::c_ushort,
+                    fd as libc::uintptr_t,
+                    data.token,
+                    poll_events,
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn poll_registered_fds(
+        &self,
+        events: &mut Events,
+        include_writable_only: bool,
+    ) -> io::Result<()> {
+        let mut fds = self.fds.lock().unwrap();
+        if fds.is_empty() {
+            return Ok(());
+        }
+
+        let mut poll_fds = Vec::new();
+        let mut tokens = Vec::new();
+        let mut fallback_writable = Vec::new();
+        for (&fd, data) in fds.iter() {
+            if !data.needs_fallback {
+                continue;
+            }
+
+            poll_fds.push(libc::pollfd {
+                fd,
+                events: interests_to_port(data.interests) as libc::c_short,
+                revents: 0,
+            });
+            tokens.push(data.token);
+            fallback_writable.push(data.fallback_writable);
+        }
+
+        if poll_fds.is_empty() {
+            return Ok(());
+        }
+
+        syscall!(poll(
+            poll_fds.as_mut_ptr(),
+            poll_fds.len() as libc::nfds_t,
+            0
+        ))?;
+
+        events.reserve(poll_fds.len());
+        for ((poll_fd, token), fallback_writable) in
+            poll_fds.iter().zip(tokens).zip(fallback_writable)
+        {
+            if poll_fd.revents != 0 {
+                let revents = EventMask::from(poll_fd.revents);
+                let writable_only = revents & !WRITE_EVENTS == 0;
+                if include_writable_only || fallback_writable || !writable_only {
+                    push_event(
+                        events,
+                        libc::PORT_SOURCE_FD as libc::c_ushort,
+                        poll_fd.fd as libc::uintptr_t,
+                        token,
+                        revents,
+                    );
+                    if writable_only {
+                        if let Some(data) = fds.get_mut(&poll_fd.fd) {
+                            data.fallback_writable = false;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn has_fallback_fds(&self) -> bool {
+        self.fds
+            .lock()
+            .unwrap()
+            .values()
+            .any(|data| data.needs_fallback)
+    }
+
+    cfg_io_source! {
+    fn register(
+        &self,
+        port: RawFd,
+        fd: RawFd,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<Arc<RegistrationRecord>> {
+        let mut fds = self.fds.lock().unwrap();
+        let record = Arc::new(RegistrationRecord::new());
+
+        associate(port, fd, interests, 1)?;
+
+        fds.insert(
+            fd,
+            FdData {
+                token,
+                interests,
+                generation: 1,
+                associated: true,
+                needs_fallback: true,
+                fallback_writable: true,
+            },
+        );
+        Ok(record)
+    }
+    }
+
+    cfg_any_os_ext! {
+    fn reregister(
+        &self,
+        port: RawFd,
+        fd: RawFd,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        let mut fds = self.fds.lock().unwrap();
+        let data = fds.get_mut(&fd).ok_or(io::ErrorKind::NotFound)?;
+        let generation = data.generation.wrapping_add(1).max(1);
+
+        associate(port, fd, interests, generation)?;
+
+        data.token = token;
+        data.interests = interests;
+        data.generation = generation;
+        data.associated = true;
+        data.needs_fallback = true;
+        data.fallback_writable = true;
+        Ok(())
+    }
+
+    fn deregister(&self, port: RawFd, fd: RawFd) -> io::Result<()> {
+        let mut fds = self.fds.lock().unwrap();
+        let data = fds.remove(&fd).ok_or(io::ErrorKind::NotFound)?;
+
+        if data.associated {
+            dissociate(port, fd)?;
+        }
+        Ok(())
+    }
+    }
+
+    fn wake(&self, port: RawFd, token: Token) -> io::Result<()> {
+        // `events` is controlled by Mio for user events. Solaris returns it
+        // as `portev_events`, so use `POLLIN` to make waker events readable
+        // like the other selector implementations.
+        syscall!(port_send(
+            port,
+            libc::POLLIN as libc::c_int,
+            usize::from(token) as *mut libc::c_void,
+        ))
+        .map(|_| ())
+    }
+}
+
+fn push_event(
+    events: &mut Events,
+    source: libc::c_ushort,
+    object: libc::uintptr_t,
+    token: Token,
+    event_mask: EventMask,
+) {
+    if let Some(event) = events
+        .iter_mut()
+        .find(|event| event.0.portev_user as usize == usize::from(token))
+    {
+        event.0.portev_events |= event_mask;
+    } else {
+        events.push(Event(libc::port_event {
+            portev_events: event_mask,
+            portev_source: source,
+            portev_pad: 0,
+            portev_object: object,
+            portev_user: usize::from(token) as *mut libc::c_void,
+        }));
+    }
+}
+
+fn poll_fd_readiness(fd: RawFd, interests: Interest) -> io::Result<Option<EventMask>> {
+    let mut poll_fd = libc::pollfd {
+        fd,
+        events: interests_to_port(interests) as libc::c_short,
+        revents: 0,
+    };
+
+    if syscall!(poll(&mut poll_fd, 1, 0))? == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(EventMask::from(poll_fd.revents)))
+    }
+}
+
+fn associate(port: RawFd, fd: RawFd, interests: Interest, generation: usize) -> io::Result<()> {
+    syscall!(port_associate(
+        port,
+        libc::PORT_SOURCE_FD,
+        fd as libc::uintptr_t,
+        interests_to_port(interests),
+        generation as *mut libc::c_void,
+    ))
+    .map(|_| ())
+}
+
+cfg_any_os_ext! {
+fn dissociate(port: RawFd, fd: RawFd) -> io::Result<()> {
+    syscall!(port_dissociate(port, libc::PORT_SOURCE_FD, fd as libc::uintptr_t))
+        .map(|_| ())
+        .or_else(|err| {
+            if err.raw_os_error() == Some(libc::ENOENT) {
+                Ok(())
+            } else {
+                Err(err)
+            }
+        })
+}
+}
+
+fn timeout_to_timespec(timeout: Option<Duration>) -> Option<libc::timespec> {
+    timeout.map(|timeout| libc::timespec {
+        tv_sec: cmp::min(timeout.as_secs(), libc::time_t::MAX as u64) as libc::time_t,
+        tv_nsec: libc::c_long::from(timeout.subsec_nanos() as i32),
+    })
+}
+
+fn interests_to_port(interests: Interest) -> EventMask {
+    let mut events = 0;
+
+    if interests.is_readable() {
+        events |= READ_EVENTS;
+    }
+
+    if interests.is_writable() {
+        events |= WRITE_EVENTS;
+    }
+
+    if interests.is_priority() {
+        events |= PRIORITY_EVENTS;
+    }
+
+    events
+}
+
+fn interests_from_event(events: EventMask) -> Option<Interest> {
+    let mut interests = None;
+
+    if (events & READ_EVENTS) != 0 {
+        interests = Some(Interest::READABLE);
+    }
+
+    if (events & WRITE_EVENTS) != 0 {
+        interests = Some(match interests {
+            Some(interests) => interests.add(Interest::WRITABLE),
+            None => Interest::WRITABLE,
+        });
+    }
+
+    interests
+}
+
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct Event(libc::port_event);
+
+unsafe impl Send for Event {}
+unsafe impl Sync for Event {}
+
+impl Deref for Event {
+    type Target = libc::port_event;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Event {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+pub struct Events(Vec<Event>);
+
+impl Deref for Events {
+    type Target = Vec<Event>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Events {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Events {
+    pub fn with_capacity(capacity: usize) -> Events {
+        Events(Vec::with_capacity(capacity))
+    }
+}
+
+// `Events` cannot derive `Send` or `Sync` because of the
+// `portev_user: *mut c_void` field in `libc::port_event`. Mio stores tokens in
+// `portev_user`, and its event API only exposes those tokens and readiness
+// flags without allowing shared mutation of the raw pointer field.
+unsafe impl Send for Events {}
+unsafe impl Sync for Events {}
+
+pub mod event {
+    use std::fmt;
+
+    use crate::sys::Event;
+    use crate::Token;
+
+    use super::{EventMask, POLLRDHUP};
+
+    pub fn token(event: &Event) -> Token {
+        Token(event.0.portev_user as usize)
+    }
+
+    pub fn is_readable(event: &Event) -> bool {
+        (event.0.portev_events & libc::POLLIN as EventMask) != 0
+            || (event.0.portev_events & libc::POLLPRI as EventMask) != 0
+    }
+
+    pub fn is_writable(event: &Event) -> bool {
+        (event.0.portev_events & libc::POLLOUT as EventMask) != 0
+    }
+
+    pub fn is_error(event: &Event) -> bool {
+        (event.0.portev_events & libc::POLLERR as EventMask) != 0
+    }
+
+    pub fn is_read_closed(event: &Event) -> bool {
+        (event.0.portev_events & libc::POLLHUP as EventMask) != 0
+            || (event.0.portev_events & POLLRDHUP) != 0
+    }
+
+    pub fn is_write_closed(event: &Event) -> bool {
+        (event.0.portev_events & libc::POLLHUP as EventMask) != 0
+            || ((event.0.portev_events & libc::POLLOUT as EventMask) != 0
+                && (event.0.portev_events & libc::POLLERR as EventMask) != 0)
+            || event.0.portev_events == libc::POLLERR as EventMask
+    }
+
+    pub fn is_priority(event: &Event) -> bool {
+        (event.0.portev_events & libc::POLLPRI as EventMask) != 0
+    }
+
+    pub fn is_aio(_: &Event) -> bool {
+        false
+    }
+
+    pub fn is_lio(_: &Event) -> bool {
+        false
+    }
+
+    pub fn debug_details(f: &mut fmt::Formatter<'_>, event: &Event) -> fmt::Result {
+        #[allow(clippy::trivially_copy_pass_by_ref)]
+        fn check_events(got: &EventMask, want: &libc::c_short) -> bool {
+            (*got & EventMask::from(*want)) != 0
+        }
+        debug_detail!(
+            EventsDetails(EventMask),
+            check_events,
+            libc::POLLIN,
+            libc::POLLPRI,
+            libc::POLLOUT,
+            libc::POLLRDNORM,
+            libc::POLLRDBAND,
+            libc::POLLWRNORM,
+            libc::POLLWRBAND,
+            libc::POLLERR,
+            libc::POLLHUP,
+        );
+
+        f.debug_struct("port_event")
+            .field("events", &EventsDetails(event.0.portev_events))
+            .field("source", &event.0.portev_source)
+            .field("object", &event.0.portev_object)
+            .field("user", &event.0.portev_user)
+            .finish()
+    }
+}
+
+cfg_io_source! {
+    use crate::Registry;
+
+    struct InternalState {
+        selector: Selector,
+        token: Token,
+        interests: Interest,
+        fd: RawFd,
+        shared_record: Arc<RegistrationRecord>,
+    }
+
+    impl Drop for InternalState {
+        fn drop(&mut self) {
+            if self.shared_record.is_registered() {
+                let _ = self.selector.deregister(self.fd);
+            }
+        }
+    }
+
+    pub(crate) struct IoSourceState {
+        inner: Option<Box<InternalState>>,
+    }
+
+    impl IoSourceState {
+        pub fn new() -> IoSourceState {
+            IoSourceState { inner: None }
+        }
+
+        pub fn do_io<T, F, R>(&self, f: F, io: &T) -> io::Result<R>
+        where
+            F: FnOnce(&T) -> io::Result<R>,
+        {
+            let result = f(io);
+
+            if let Err(err) = &result {
+                if err.kind() == io::ErrorKind::WouldBlock {
+                    self.inner.as_ref().map_or(Ok(()), |state| {
+                        state
+                            .selector
+                            .reregister(state.fd, state.token, state.interests)
+                    })?;
+                }
+            }
+
+            result
+        }
+
+        pub fn register(
+            &mut self,
+            registry: &Registry,
+            token: Token,
+            interests: Interest,
+            fd: RawFd,
+        ) -> io::Result<()> {
+            if self.inner.is_some() {
+                Err(io::ErrorKind::AlreadyExists.into())
+            } else {
+                let selector = registry.selector().try_clone()?;
+
+                selector.register_internal(fd, token, interests).map(move |shared_record| {
+                    let state = InternalState {
+                        selector,
+                        token,
+                        interests,
+                        fd,
+                        shared_record,
+                    };
+
+                    self.inner = Some(Box::new(state));
+                })
+            }
+        }
+
+        pub fn reregister(
+            &mut self,
+            registry: &Registry,
+            token: Token,
+            interests: Interest,
+            fd: RawFd,
+        ) -> io::Result<()> {
+            match self.inner.as_mut() {
+                Some(state) => registry.selector().reregister(fd, token, interests).map(|()| {
+                    state.token = token;
+                    state.interests = interests;
+                }),
+                None => Err(io::ErrorKind::NotFound.into()),
+            }
+        }
+
+        pub fn deregister(&mut self, registry: &Registry, fd: RawFd) -> io::Result<()> {
+            if let Some(state) = self.inner.take() {
+                state.shared_record.mark_unregistered();
+            }
+
+            registry.selector().deregister(fd)
+        }
+    }
+}
+
+cfg_io_source! {
+use std::sync::atomic::AtomicBool;
+
+#[derive(Debug)]
+pub(crate) struct RegistrationRecord {
+    is_unregistered: AtomicBool,
+}
+
+impl RegistrationRecord {
+    pub fn new() -> Self {
+        Self {
+            is_unregistered: AtomicBool::new(false),
+        }
+    }
+
+    pub fn mark_unregistered(&self) {
+        self.is_unregistered.store(true, Ordering::Relaxed);
+    }
+
+    pub fn is_registered(&self) -> bool {
+        !self.is_unregistered.load(Ordering::Relaxed)
+    }
+}
+}
+
+impl AsFd for Selector {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.port.as_fd()
+    }
+}
+
+impl AsRawFd for Selector {
+    fn as_raw_fd(&self) -> RawFd {
+        self.port.as_raw_fd()
+    }
+}

--- a/src/sys/unix/waker/event_ports.rs
+++ b/src/sys/unix/waker/event_ports.rs
@@ -1,0 +1,24 @@
+use std::io;
+
+use crate::sys::Selector;
+use crate::Token;
+
+/// Waker backed by Solaris event ports user events.
+#[derive(Debug)]
+pub(crate) struct Waker {
+    selector: Selector,
+    token: Token,
+}
+
+impl Waker {
+    pub(crate) fn new(selector: &Selector, token: Token) -> io::Result<Waker> {
+        Ok(Waker {
+            selector: selector.try_clone()?,
+            token,
+        })
+    }
+
+    pub(crate) fn wake(&self) -> io::Result<()> {
+        self.selector.wake(self.token)
+    }
+}

--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -1,5 +1,6 @@
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
+use std::io::{Read, Write};
 use std::net;
 use std::sync::{Arc, Barrier};
 use std::thread::{self, sleep};
@@ -12,7 +13,8 @@ use mio::{event, Events, Interest, Poll, Registry, Token};
 
 mod util;
 use util::{
-    any_local_address, assert_send, assert_sync, expect_events, init, init_with_poll, ExpectEvent,
+    any_local_address, assert_send, assert_sync, expect_events, expect_no_events, init,
+    init_with_poll, ExpectEvent,
 };
 
 const ID1: Token = Token(1);
@@ -108,6 +110,48 @@ fn poll_closes_fd() {
 
         drop(poll);
     }
+}
+
+#[test]
+fn readiness_is_reregistered_after_would_block() {
+    // Solaris event ports disassociate an fd after delivering an event. Ensure
+    // readiness is observed again after the source is drained to WouldBlock.
+    init();
+
+    let listener = net::TcpListener::bind(any_local_address()).unwrap();
+    let addr = listener.local_addr().unwrap();
+    let client = net::TcpStream::connect(addr).unwrap();
+    let (mut server, _) = listener.accept().unwrap();
+    client.set_nonblocking(true).unwrap();
+    server.set_nonblocking(true).unwrap();
+
+    let mut client = TcpStream::from_std(client);
+    let mut poll = Poll::new().unwrap();
+    let mut events = Events::with_capacity(8);
+
+    poll.registry()
+        .register(&mut client, ID1, Interest::READABLE)
+        .unwrap();
+
+    server.write_all(b"hello").unwrap();
+    expect_events(
+        &mut poll,
+        &mut events,
+        vec![ExpectEvent::new(ID1, Interest::READABLE)],
+    );
+
+    let mut buf = [0; 16];
+    assert_eq!(client.read(&mut buf).unwrap(), 5);
+    util::assert_would_block(client.read(&mut buf));
+
+    expect_no_events(&mut poll, &mut events);
+
+    server.write_all(b"again").unwrap();
+    expect_events(
+        &mut poll,
+        &mut events,
+        vec![ExpectEvent::new(ID1, Interest::READABLE)],
+    );
 }
 
 #[cfg_attr(


### PR DESCRIPTION
Use Solaris event ports as the native os-poll backend instead of the poll(2)-based fallback. Keep the existing poll backend available behind mio_unsupported_force_poll_poll for comparison and unsupported builds.

Add a regression test for readiness after WouldBlock and add Solaris VM coverage to CI.