### PR TITLE
Support Nuttx target os

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -4,6 +4,7 @@
     not(any(
         target_os = "aix",
         target_os = "espidf",
+        target_os = "nuttx",
         target_os = "fuchsia",
         target_os = "haiku",
         target_os = "hermit",
@@ -448,6 +449,7 @@ impl Poll {
     not(any(
         target_os = "aix",
         target_os = "espidf",
+        target_os = "nuttx",
         target_os = "fuchsia",
         target_os = "haiku",
         target_os = "hermit",
@@ -752,6 +754,7 @@ impl fmt::Debug for Registry {
     not(any(
         target_os = "aix",
         target_os = "espidf",
+        target_os = "nuttx",
         target_os = "haiku",
         target_os = "fuchsia",
         target_os = "hermit",
@@ -775,6 +778,7 @@ impl AsFd for Registry {
     not(any(
         target_os = "aix",
         target_os = "espidf",
+        target_os = "nuttx",
         target_os = "haiku",
         target_os = "fuchsia",
         target_os = "hermit",
@@ -799,6 +803,7 @@ cfg_os_poll! {
         not(any(
             target_os = "aix",
             target_os = "espidf",
+            target_os = "nuttx",
             target_os = "hermit",
             target_os = "hurd",
             target_os = "nto",

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -42,6 +42,7 @@ cfg_os_poll! {
         mio_unsupported_force_poll_poll,
         target_os = "aix",
         target_os = "espidf",
+        target_os = "nuttx",
         target_os = "fuchsia",
         target_os = "haiku",
         target_os = "hermit",
@@ -61,6 +62,7 @@ cfg_os_poll! {
         any(
             target_os = "android",
             target_os = "espidf",
+            target_os = "nuttx",
             target_os = "fuchsia",
             target_os = "hermit",
             target_os = "illumos",

--- a/src/sys/unix/pipe.rs
+++ b/src/sys/unix/pipe.rs
@@ -22,6 +22,7 @@ pub(crate) fn new_raw() -> io::Result<[RawFd; 2]> {
         target_os = "solaris",
         target_os = "vita",
         target_os = "cygwin",
+        target_os = "nuttx",
     ))]
     unsafe {
         if libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC | libc::O_NONBLOCK) != 0 {

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -74,6 +74,7 @@ pub(crate) fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream,
         target_os = "openbsd",
         target_os = "solaris",
         target_os = "cygwin",
+        target_os = "nuttx",
     ))]
     let stream = {
         syscall!(accept4(


### PR DESCRIPTION
Enable pipe2/accept4/eventfd/poll capabilities.

Use `poll` as the selector instead of `epoll`, because the `epoll_event` structure is defined differently from the linux_like. Therefore, additional support may be needed; for now, let's get tokio working.