### PR TITLE
windows/named_pipe: cancel pending writes on drop to prevent UAF

### DIFF
--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -692,8 +692,8 @@ impl fmt::Debug for NamedPipe {
 
 impl Drop for NamedPipe {
     fn drop(&mut self) {
-        // Cancel pending reads/connects, but don't cancel writes to ensure that
-        // everything is flushed out.
+        // Cancel pending reads/connects and writes to ensure that all overlapped
+        // operations are aborted before the OVERLAPPED memory is freed.
         unsafe {
             if self.inner.connecting.load(SeqCst) {
                 drop(cancel(&self.inner.handle, &self.inner.connect));
@@ -702,6 +702,9 @@ impl Drop for NamedPipe {
             let io = self.inner.io.lock().unwrap();
             if let State::Pending(..) = io.read {
                 drop(cancel(&self.inner.handle, &self.inner.read));
+            }
+            if let State::Pending(..) = io.write {
+                drop(cancel(&self.inner.handle, &self.inner.write));
             }
         }
     }

--- a/tests/win_named_pipe.rs
+++ b/tests/win_named_pipe.rs
@@ -448,3 +448,25 @@ fn read_with_small_buffer_provided() {
 
     assert_eq!(actual_msg, expected_msg);
 }
+
+#[test]
+fn write_then_drop_stress_test() {
+    for _ in 0..1000 {
+        let (mut server, mut client) = pipe();
+        let expected_msg = vec![0x5u8; 65536];
+        
+        // This initiates an overlapped write. Since we haven't read anything on the server,
+        // it stays pending in the Windows kernel.
+        let _ = client.write(&expected_msg);
+
+        // Drop the client while the write is pending.
+        // Without CancelIoEx, the OVERLAPPED struct is freed while the kernel still holds it.
+        drop(client);
+
+        // Read from the server to allow the pending write to finish in the kernel.
+        // If the UAF occurs, the kernel writes the completion status into freed memory,
+        // which will reliably cause an access violation (crash) over 1000 iterations.
+        let mut buf = [0u8; 65536];
+        let _ = server.read(&mut buf);
+    }
+}


### PR DESCRIPTION
Previously, the Drop implementation for NamedPipe only cancelled pending reads and connects, intentionally skipping writes to let them flush. However, if the NamedPipe struct is dropped, the inner memory managing the OVERLAPPED write structure is also freed. If the Windows kernel completes the pending write, it writes the completion status to the freed OVERLAPPED pointer, leading to memory corruption (Use-After-Free).

This safely cancels pending writes during drop before the struct is deallocated.