### PR TITLE
Release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.2.2
+
+* Add support for Solaris using event ports
+  (https://github.com/tokio-rs/mio/pull/1962).
+* Add experiment support for NuttX using `poll(2)`
+  (https://github.com/tokio-rs/mio/pull/1966).
+
 # 1.2.1
 
 * Add support for horizonOS/n3ds

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "mio"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create git tag
-version       = "1.2.1"
+version       = "1.2.2"
 license       = "MIT"
 authors       = [
   "Carl Lerche <me@carllerche.com>",

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Currently supported platforms:
 * Windows
 * iOS
 * macOS
+* Solaris
 
 Mio can handle interfacing with each of the event systems of the aforementioned
 platforms. The details of their implementation are further discussed in the


### PR DESCRIPTION
Note this add NuttX to the supported list of OS in the readme as it still need (released) changes in other crates (libc, etc.). We ideally also want it to use the epoll based implementation rather than poll.