### PR TITLE
Extend documentation about implict source deregistrations

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -670,6 +670,10 @@ impl Registry {
     /// deregistered; however, it must be passed back to the **same** `Poll`
     /// instance, otherwise the behavior is unspecified.
     ///
+    /// After the last file descriptor (or file handle) for a registered event source
+    /// is closed, it will be automatically deregistered if the underlying selector
+    /// provides this behavior.
+    ///
     /// # Examples
     ///
     #[cfg_attr(all(feature = "os-poll", feature = "net"), doc = "```")]


### PR DESCRIPTION
This pull request extends the documentation of the `Registry::deregister` method to include a note about what happens when the last file descriptor (or file handle) of a registered event source is closed.
The purpose of this addition is to tell "mio is fine with not deregistering a source as long as it doesn't break the underlying selector". I've intentionally didn't add a list of selectors for which this behavior applies as it might not be exhaustive.

Closes #1972