### PR TITLE
Fix semicolon_in_expressions_from_macros warning

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -90,7 +90,7 @@ macro_rules! error {
 macro_rules! log {
     ($level: ident, $($t:tt)*) => {
         #[cfg(feature = "log")]
-        { log::$level!($($t)*) }
+        { log::$level!($($t)*); }
         // Silence unused variables warnings.
         #[cfg(not(feature = "log"))]
         { if false { let _ = ( $($t)* ); } }


### PR DESCRIPTION
Latest nightly emits a warning about "trailing semicolon in macro used in expression position", with the following output

    error: trailing semicolon in macro used in expression position
       --> src/macros.rs:93:11
        |
     93 |           { log::$level!($($t)*) }
        |             ^^^^^^^^^^^^^^^^^^^^
        |
       ::: src/poll.rs:580:9
        |
    580 | /         trace!(
    581 | |             "registering event source with poller: token={:?}, interests={:?}",
    582 | |             token,
    583 | |             interests
    584 | |         );
        | |_________- in this macro invocation
        |
        = note: macro invocations at the end of a block are treated as expressions
        = note: to ignore the value produced by the macro, add a semicolon after the invocation of `trace`
        = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
        = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
        = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
        = note: this error originates in the macro `log::trace` which comes from the expansion of the macro `trace` (in Nightly builds, run with -Z macro-backtrace for more info)

The linked issue and description are a little misleading because they mostly talk about having a semicolon and removing it to fix the warning. We have to do the opposite here though.