### PR TITLE
enable various tests for WASI and remove obsolete `cfg` guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
   CI: true
-  WASMTIME_VERSION: 41.0.3
+  WASMTIME_VERSION: 47.0.0
 
 permissions:
   contents: read #  to fetch code (actions/checkout)

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -36,8 +36,6 @@ use crate::{event, sys, Interest, Registry, Token};
 /// # use std::error::Error;
 /// #
 /// # fn main() -> Result<(), Box<dyn Error>> {
-/// # // Temporarily disabled on WASI pending https://github.com/WebAssembly/wasi-libc/pull/740:
-/// # if cfg!(target_os = "wasi") { return Ok(()) }
 /// // An Echo program:
 /// // SENDER -> sends a message.
 /// // ECHOER -> listens and prints the message received.

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -125,14 +125,9 @@ pub(crate) fn accept(listener: &net::TcpListener) -> io::Result<(net::TcpStream,
                 target_os = "vita",
                 target_os = "hermit",
                 target_os = "nto",
+                target_os = "wasi",
             ))]
             syscall!(fcntl(s.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK))?;
-
-            // Once https://github.com/WebAssembly/wasi-libc/pull/742 lands and
-            // makes it into Rust std, we can remove this and switch to using
-            // `fcntl` above.
-            #[cfg(target_os = "wasi")]
-            syscall!(ioctl(s.as_raw_fd(), libc::FIONBIO, &mut 1))?;
 
             Ok(s)
         })

--- a/tests/registering.rs
+++ b/tests/registering.rs
@@ -68,10 +68,6 @@ impl TestHandler {
     }
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/732"
-)]
 #[test]
 pub fn register_deregister() {
     init();
@@ -117,10 +113,6 @@ pub fn register_deregister() {
     assert!(events.iter().next().is_none());
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/737"
-)]
 #[test]
 pub fn reregister_different_interest_without_poll() {
     init();

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -687,10 +687,6 @@ macro_rules! wait {
     }};
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/732"
-)]
 #[test]
 fn write_shutdown() {
     init();
@@ -809,10 +805,6 @@ fn local_addr_ready() {
     }
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/732"
-)]
 #[test]
 fn write_then_drop() {
     init();
@@ -869,10 +861,6 @@ fn write_then_drop() {
     expect_read!(s.read(&mut buf), &[1, 2, 3, 4]);
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/732"
-)]
 #[test]
 fn write_then_deregister() {
     init();
@@ -932,10 +920,6 @@ const ID1: Token = Token(1);
 const ID2: Token = Token(2);
 const ID3: Token = Token(3);
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/732"
-)]
 #[test]
 fn tcp_no_events_after_deregister() {
     let (mut poll, mut events) = init_with_poll();

--- a/tests/tcp_listener.rs
+++ b/tests/tcp_listener.rs
@@ -11,14 +11,14 @@ use std::thread;
 
 mod util;
 use util::{
-    any_local_address, any_local_ipv6_address, assert_send, assert_sync, assert_would_block,
-    expect_events, expect_no_events, init, init_with_poll, ExpectEvent,
+    any_local_address, any_local_ipv6_address, assert_send, assert_socket_non_blocking,
+    assert_sync, assert_would_block, expect_events, expect_no_events, init, init_with_poll,
+    ExpectEvent,
 };
 
-// Close-on-exec doesn't apply to WASI; non-blocking does, but `wasi-libc`
-// doesn't support it yet (https://github.com/WebAssembly/wasi-libc/pull/742).
+// Close-on-exec doesn't apply to WASI
 #[cfg(not(target_os = "wasi"))]
-use util::{assert_socket_close_on_exec, assert_socket_non_blocking};
+use util::assert_socket_close_on_exec;
 
 const ID1: Token = Token(0);
 const ID2: Token = Token(1);
@@ -71,9 +71,10 @@ where
     let mut listener = make_listener(addr).unwrap();
     let address = listener.local_addr().unwrap();
 
+    assert_socket_non_blocking(&listener);
+
     #[cfg(not(target_os = "wasi"))]
     {
-        assert_socket_non_blocking(&listener);
         assert_socket_close_on_exec(&listener);
     }
 

--- a/tests/tcp_listener.rs
+++ b/tests/tcp_listener.rs
@@ -11,14 +11,10 @@ use std::thread;
 
 mod util;
 use util::{
-    any_local_address, any_local_ipv6_address, assert_send, assert_socket_non_blocking,
-    assert_sync, assert_would_block, expect_events, expect_no_events, init, init_with_poll,
-    ExpectEvent,
+    any_local_address, any_local_ipv6_address, assert_send, assert_socket_close_on_exec,
+    assert_socket_non_blocking, assert_sync, assert_would_block, expect_events, expect_no_events,
+    init, init_with_poll, ExpectEvent,
 };
-
-// Close-on-exec doesn't apply to WASI
-#[cfg(not(target_os = "wasi"))]
-use util::assert_socket_close_on_exec;
 
 const ID1: Token = Token(0);
 const ID2: Token = Token(1);
@@ -72,11 +68,7 @@ where
     let address = listener.local_addr().unwrap();
 
     assert_socket_non_blocking(&listener);
-
-    #[cfg(not(target_os = "wasi"))]
-    {
-        assert_socket_close_on_exec(&listener);
-    }
+    assert_socket_close_on_exec(&listener);
 
     poll.registry()
         .register(&mut listener, ID1, Interest::READABLE)

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -16,15 +16,15 @@ mod util;
 #[cfg(not(any(target_os = "windows", target_os = "wasi")))]
 use util::init;
 use util::{
-    any_local_address, any_local_ipv6_address, assert_send, assert_socket_non_blocking,
-    assert_sync, assert_would_block, expect_events, expect_no_events, init_with_poll, ExpectEvent,
-    Readiness,
+    any_local_address, any_local_ipv6_address, assert_send, assert_socket_close_on_exec,
+    assert_socket_non_blocking, assert_sync, assert_would_block, expect_events, expect_no_events,
+    init_with_poll, ExpectEvent, Readiness,
 };
 
-// Close-on-exec doesn't apply to WASI, and it does not yet support `SO_LINGER`
-// (see https://github.com/WebAssembly/WASI/issues/709).
+// WASI does not yet support `SO_LINGER` (see
+// https://github.com/WebAssembly/WASI/issues/709).
 #[cfg(not(target_os = "wasi"))]
-use util::{assert_socket_close_on_exec, set_linger_zero};
+use util::set_linger_zero;
 
 const DATA1: &[u8] = b"Hello world!";
 const DATA2: &[u8] = b"Hello mars!";
@@ -84,11 +84,7 @@ where
     let mut stream = make_stream(addr).unwrap();
 
     assert_socket_non_blocking(&stream);
-
-    #[cfg(not(target_os = "wasi"))]
-    {
-        assert_socket_close_on_exec(&stream);
-    }
+    assert_socket_close_on_exec(&stream);
 
     poll.registry()
         .register(&mut stream, ID1, Interest::WRITABLE.add(Interest::READABLE))

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -16,14 +16,15 @@ mod util;
 #[cfg(not(any(target_os = "windows", target_os = "wasi")))]
 use util::init;
 use util::{
-    any_local_address, any_local_ipv6_address, assert_send, assert_sync, assert_would_block,
-    expect_events, expect_no_events, init_with_poll, ExpectEvent, Readiness,
+    any_local_address, any_local_ipv6_address, assert_send, assert_socket_non_blocking,
+    assert_sync, assert_would_block, expect_events, expect_no_events, init_with_poll, ExpectEvent,
+    Readiness,
 };
 
-// Close-on-exec doesn't apply to WASI; non-blocking does, but `wasi-libc`
-// doesn't support it yet (https://github.com/WebAssembly/wasi-libc/pull/742).
+// Close-on-exec doesn't apply to WASI, and it does not yet support `SO_LINGER`
+// (see https://github.com/WebAssembly/WASI/issues/709).
 #[cfg(not(target_os = "wasi"))]
-use util::{assert_socket_close_on_exec, assert_socket_non_blocking, set_linger_zero};
+use util::{assert_socket_close_on_exec, set_linger_zero};
 
 const DATA1: &[u8] = b"Hello world!";
 const DATA2: &[u8] = b"Hello mars!";
@@ -82,9 +83,10 @@ where
     let (handle, addr) = echo_listener(addr, 1);
     let mut stream = make_stream(addr).unwrap();
 
+    assert_socket_non_blocking(&stream);
+
     #[cfg(not(target_os = "wasi"))]
     {
-        assert_socket_non_blocking(&stream);
         assert_socket_close_on_exec(&stream);
     }
 

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -15,13 +15,9 @@ use std::time::Duration;
 mod util;
 use util::{
     any_local_address, any_local_ipv6_address, assert_error, assert_send,
-    assert_socket_non_blocking, assert_sync, assert_would_block, expect_events, expect_no_events,
-    init, init_with_poll, ExpectEvent,
+    assert_socket_close_on_exec, assert_socket_non_blocking, assert_sync, assert_would_block,
+    expect_events, expect_no_events, init, init_with_poll, ExpectEvent,
 };
-
-// Close-on-exec doesn't apply to WASI
-#[cfg(not(target_os = "wasi"))]
-use util::assert_socket_close_on_exec;
 
 const DATA1: &[u8] = b"Hello world!";
 const DATA2: &[u8] = b"Hello mars!";
@@ -116,13 +112,9 @@ fn smoke_test_unconnected_udp_socket(mut socket1: UdpSocket, mut socket2: UdpSoc
     let (mut poll, mut events) = init_with_poll();
 
     assert_socket_non_blocking(&socket1);
+    assert_socket_close_on_exec(&socket1);
     assert_socket_non_blocking(&socket2);
-
-    #[cfg(not(target_os = "wasi"))]
-    {
-        assert_socket_close_on_exec(&socket1);
-        assert_socket_close_on_exec(&socket2);
-    }
+    assert_socket_close_on_exec(&socket2);
 
     let address1 = socket1.local_addr().unwrap();
     let address2 = socket2.local_addr().unwrap();
@@ -356,13 +348,9 @@ fn smoke_test_connected_udp_socket(mut socket1: UdpSocket, mut socket2: UdpSocke
     let (mut poll, mut events) = init_with_poll();
 
     assert_socket_non_blocking(&socket1);
+    assert_socket_close_on_exec(&socket1);
     assert_socket_non_blocking(&socket2);
-
-    #[cfg(not(target_os = "wasi"))]
-    {
-        assert_socket_close_on_exec(&socket1);
-        assert_socket_close_on_exec(&socket2);
-    }
+    assert_socket_close_on_exec(&socket2);
 
     poll.registry()
         .register(

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -14,14 +14,14 @@ use std::time::Duration;
 #[macro_use]
 mod util;
 use util::{
-    any_local_address, any_local_ipv6_address, assert_error, assert_send, assert_sync,
-    assert_would_block, expect_events, expect_no_events, init, init_with_poll, ExpectEvent,
+    any_local_address, any_local_ipv6_address, assert_error, assert_send,
+    assert_socket_non_blocking, assert_sync, assert_would_block, expect_events, expect_no_events,
+    init, init_with_poll, ExpectEvent,
 };
 
-// Close-on-exec doesn't apply to WASI; non-blocking does, but `wasi-libc`
-// doesn't support it yet (https://github.com/WebAssembly/wasi-libc/pull/742).
+// Close-on-exec doesn't apply to WASI
 #[cfg(not(target_os = "wasi"))]
-use util::{assert_socket_close_on_exec, assert_socket_non_blocking};
+use util::assert_socket_close_on_exec;
 
 const DATA1: &[u8] = b"Hello world!";
 const DATA2: &[u8] = b"Hello mars!";
@@ -44,10 +44,6 @@ fn assert_size() {
     assert_eq!(size_of::<UdpSocket>(), size_of::<std::net::UdpSocket>());
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/740"
-)]
 #[test]
 fn empty_datagram() {
     const EMPTY: &[u8] = b"";
@@ -87,10 +83,6 @@ fn is_send_and_sync() {
     assert_sync::<UdpSocket>();
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/740"
-)]
 #[test]
 fn unconnected_udp_socket_ipv4() {
     let socket1 = UdpSocket::bind(any_local_address()).unwrap();
@@ -98,10 +90,6 @@ fn unconnected_udp_socket_ipv4() {
     smoke_test_unconnected_udp_socket(socket1, socket2);
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/740"
-)]
 #[test]
 fn unconnected_udp_socket_ipv6() {
     let socket1 = UdpSocket::bind(any_local_ipv6_address()).unwrap();
@@ -109,10 +97,6 @@ fn unconnected_udp_socket_ipv6() {
     smoke_test_unconnected_udp_socket(socket1, socket2);
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/740"
-)]
 #[test]
 fn unconnected_udp_socket_std() {
     let socket1 = net::UdpSocket::bind(any_local_address()).unwrap();
@@ -131,11 +115,12 @@ fn unconnected_udp_socket_std() {
 fn smoke_test_unconnected_udp_socket(mut socket1: UdpSocket, mut socket2: UdpSocket) {
     let (mut poll, mut events) = init_with_poll();
 
+    assert_socket_non_blocking(&socket1);
+    assert_socket_non_blocking(&socket2);
+
     #[cfg(not(target_os = "wasi"))]
     {
-        assert_socket_non_blocking(&socket1);
         assert_socket_close_on_exec(&socket1);
-        assert_socket_non_blocking(&socket2);
         assert_socket_close_on_exec(&socket2);
     }
 
@@ -196,10 +181,6 @@ fn smoke_test_unconnected_udp_socket(mut socket1: UdpSocket, mut socket2: UdpSoc
     assert!(socket2.take_error().unwrap().is_none());
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/740"
-)]
 #[test]
 fn set_get_ttl() {
     let socket1 = UdpSocket::bind(any_local_address()).unwrap();
@@ -321,10 +302,6 @@ fn get_multicast_loop_v6_without_previous_set() {
         .expect("unable to get multicast_loop_v6 for UDP socket");
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/740"
-)]
 #[test]
 fn connected_udp_socket_ipv4() {
     let socket1 = UdpSocket::bind(any_local_address()).unwrap();
@@ -339,10 +316,6 @@ fn connected_udp_socket_ipv4() {
     smoke_test_connected_udp_socket(socket1, socket2);
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/740"
-)]
 #[test]
 fn connected_udp_socket_ipv6() {
     let socket1 = UdpSocket::bind(any_local_ipv6_address()).unwrap();
@@ -357,10 +330,6 @@ fn connected_udp_socket_ipv6() {
     smoke_test_connected_udp_socket(socket1, socket2);
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/740"
-)]
 #[test]
 fn connected_udp_socket_std() {
     let socket1 = net::UdpSocket::bind(any_local_address()).unwrap();
@@ -386,11 +355,12 @@ fn connected_udp_socket_std() {
 fn smoke_test_connected_udp_socket(mut socket1: UdpSocket, mut socket2: UdpSocket) {
     let (mut poll, mut events) = init_with_poll();
 
+    assert_socket_non_blocking(&socket1);
+    assert_socket_non_blocking(&socket2);
+
     #[cfg(not(target_os = "wasi"))]
     {
-        assert_socket_non_blocking(&socket1);
         assert_socket_close_on_exec(&socket1);
-        assert_socket_non_blocking(&socket2);
         assert_socket_close_on_exec(&socket2);
     }
 
@@ -449,10 +419,6 @@ fn smoke_test_connected_udp_socket(mut socket1: UdpSocket, mut socket2: UdpSocke
     assert!(socket2.take_error().unwrap().is_none());
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/bytecodealliance/wasmtime/pull/12595"
-)]
 #[test]
 fn reconnect_udp_socket_sending() {
     let (mut poll, mut events) = init_with_poll();
@@ -516,10 +482,6 @@ fn reconnect_udp_socket_sending() {
     assert!(socket3.take_error().unwrap().is_none());
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/bytecodealliance/wasmtime/pull/12595"
-)]
 #[test]
 fn reconnect_udp_socket_receiving() {
     let (mut poll, mut events) = init_with_poll();
@@ -604,10 +566,6 @@ fn reconnect_udp_socket_receiving() {
     assert!(socket3.take_error().unwrap().is_none());
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/740"
-)]
 #[test]
 fn unconnected_udp_socket_connected_methods() {
     let (mut poll, mut events) = init_with_poll();
@@ -666,10 +624,6 @@ fn unconnected_udp_socket_connected_methods() {
     assert!(socket2.take_error().unwrap().is_none());
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/740"
-)]
 #[test]
 fn connected_udp_socket_unconnected_methods() {
     let (mut poll, mut events) = init_with_poll();
@@ -765,10 +719,6 @@ fn udp_socket_raw_fd() {
     assert_eq!(socket.local_addr().unwrap(), address);
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/740"
-)]
 #[test]
 fn udp_socket_register() {
     let (mut poll, mut events) = init_with_poll();
@@ -973,10 +923,6 @@ fn connected_sockets() -> (UdpSocket, UdpSocket) {
     (tx, rx)
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/bytecodealliance/wasmtime/pull/12629"
-)]
 #[test]
 pub fn udp_socket() {
     init();
@@ -987,10 +933,6 @@ pub fn udp_socket() {
     send_recv_udp(tx, rx, false);
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/bytecodealliance/wasmtime/pull/12629"
-)]
 #[test]
 pub fn udp_socket_send_recv() {
     init();
@@ -1000,10 +942,6 @@ pub fn udp_socket_send_recv() {
     send_recv_udp(tx, rx, true);
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/bytecodealliance/wasmtime/pull/12629"
-)]
 #[test]
 pub fn udp_socket_discard() {
     init();
@@ -1162,10 +1100,6 @@ pub fn multicast() {
     }
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/740"
-)]
 #[test]
 fn et_behavior_recv() {
     let (mut poll, mut events) = init_with_poll();
@@ -1220,10 +1154,6 @@ fn et_behavior_recv() {
     expect_read!(socket2.recv(&mut buf), DATA1);
 }
 
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/740"
-)]
 #[test]
 fn et_behavior_recv_from() {
     let (mut poll, mut events) = init_with_poll();

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -224,13 +224,22 @@ pub fn assert_socket_non_blocking<S>(_: &S) {
 }
 
 /// Assert that `CLOEXEC` is set on `socket`.
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "wasi"))]
 pub fn assert_socket_close_on_exec<S>(socket: &S)
 where
     S: AsRawFd,
 {
-    let flags = unsafe { libc::fcntl(socket.as_raw_fd(), libc::F_GETFD) };
-    assert!(flags & libc::FD_CLOEXEC != 0, "socket flag CLOEXEC not set");
+    #[cfg(target_os = "wasi")]
+    {
+        // WASI does not current support `exec` or `FD_CLOEXEC`
+        _ = socket;
+    }
+
+    #[cfg(not(target_os = "wasi"))]
+    {
+        let flags = unsafe { libc::fcntl(socket.as_raw_fd(), libc::F_GETFD) };
+        assert!(flags & libc::FD_CLOEXEC != 0, "socket flag CLOEXEC not set");
+    }
 }
 
 #[cfg(windows)]

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -6,7 +6,7 @@
 use std::mem::size_of;
 use std::net::SocketAddr;
 use std::ops::BitOr;
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "wasi"))]
 use std::os::fd::AsRawFd;
 #[cfg(not(target_os = "wasi"))]
 use std::path::PathBuf;
@@ -209,9 +209,7 @@ pub fn assert_would_block<T>(result: io::Result<T>) {
 }
 
 /// Assert that `NONBLOCK` is set on `socket`.
-// Once https://github.com/WebAssembly/wasi-libc/pull/742 lands and makes
-// it into Rust std, we can enable this for `target_os = "wasi"` as well.
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "wasi"))]
 pub fn assert_socket_non_blocking<S>(socket: &S)
 where
     S: AsRawFd,


### PR DESCRIPTION
A number of tests were temporarily disabled for WASI while `wasi-libc` and `wasmtime` patches made their way into releases.  Now that Rust is using the latest `wasi-sdk` (and thus `wasi-libc`) release, we can finally enable them and cut down on the `cfg` noise.

- remove `if cfg!(target_os = "wasi") { return Ok(()) }` from `UdpSocket` doctest in `src/net/udp.rs`
- use `fcntl` instead of `ioctl` for WASI in `src/sys/unix/tcp.rs`
- enable temporarily-disabled-on-WASI tests in `tests/registering.rs`, `tests/tcp.rs`, and `tests/udp_socket.rs`
- ungate `assert_socket_non_blocking` for WASI in `tests/util/mod.rs`, `tests/tcp_listener.rs`, `tests/tcp_stream.rs`, and `tests/udp_socket.rs`

Closes #1932