### PR TITLE
ci: add Miri to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ env:
   RUST_BACKTRACE: full
   CI: true
   WASMTIME_VERSION: 47.0.0
+  # Pin a specific miri version
+  rust_miri_nightly: nightly-2026-05-30
+  MIO_MIRI_FEATURES: log,os-ext,os-poll,net
 
 permissions:
   contents: read #  to fetch code (actions/checkout)
@@ -138,6 +141,40 @@ jobs:
       # So instead we run `rustfmt` directly on each file.
       #cargo fmt --all -- --check
       run: find src tests examples -type f -iname "*.rs" | xargs rustfmt --check
+  MiriTest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust ${{ env.rust_miri_nightly }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.rust_miri_nightly }}
+          components: miri
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - uses: Swatinem/rust-cache@v2
+      - name: miri
+        run: |
+          cargo miri nextest run --features $MIO_MIRI_FEATURES --test '*' --no-fail-fast
+        env:
+          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-strict-provenance
+  MiriDocs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust ${{ env.rust_miri_nightly }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.rust_miri_nightly }}
+          components: miri
+      - uses: Swatinem/rust-cache@v2
+      - name: miri-doc-test
+        run: |
+          cargo miri test --doc --features $MIO_MIRI_FEATURES --no-fail-fast
+        env:
+          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-strict-provenance
   CheckTargets:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -311,6 +348,8 @@ jobs:
       - Clippy
       - Docs
       - Rustfmt
+      - MiriTest
+      - MiriDocs
       - CheckTargets
       - TestFreeBSD
       - TestSolaris

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,8 +331,7 @@ jobs:
       - Clippy
       - Docs
       - Rustfmt
-      - MiriTest
-      - MiriDocs
+      - Miri
       - CheckTargets
       - TestFreeBSD
       - TestSolaris

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   CI: true
   WASMTIME_VERSION: 47.0.0
   # Pin a specific miri version
-  rust_miri_nightly: nightly-2026-05-30
+  rust_miri_nightly: nightly-2026-07-20
   MIO_MIRI_FEATURES: log,os-ext,os-poll,net
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ env:
   WASMTIME_VERSION: 47.0.0
   # Pin a specific miri version
   rust_miri_nightly: nightly-2026-07-20
-  MIO_MIRI_FEATURES: log,os-ext,os-poll,net
 
 permissions:
   contents: read #  to fetch code (actions/checkout)
@@ -141,7 +140,7 @@ jobs:
       # So instead we run `rustfmt` directly on each file.
       #cargo fmt --all -- --check
       run: find src tests examples -type f -iname "*.rs" | xargs rustfmt --check
-  MiriTest:
+  Miri:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -150,29 +149,13 @@ jobs:
         with:
           toolchain: ${{ env.rust_miri_nightly }}
           components: miri
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
       - uses: Swatinem/rust-cache@v2
-      - name: miri
-        run: |
-          cargo miri nextest run --features $MIO_MIRI_FEATURES --test '*' --no-fail-fast
+      - name: Run tests with Miri
+        run: cargo miri test --all-features --test '*' --no-fail-fast
         env:
           MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-strict-provenance
-  MiriDocs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install Rust ${{ env.rust_miri_nightly }}
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.rust_miri_nightly }}
-          components: miri
-      - uses: Swatinem/rust-cache@v2
-      - name: miri-doc-test
-        run: |
-          cargo miri test --doc --features $MIO_MIRI_FEATURES --no-fail-fast
+      - name: Check docs with Miri
+        run: cargo miri test --doc --all-features --no-fail-fast
         env:
           MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-strict-provenance
   CheckTargets:

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -32,7 +32,7 @@ use crate::{event, sys, Interest, Registry, Token};
 /// # Examples
 ///
 #[cfg_attr(all(feature = "os-poll", not(miri)), doc = "```")]
-#[cfg_attr(any(not(feature = "os-poll"), miri), doc = "```ignore")] // Miri doesn't support UDP sockets.
+#[cfg_attr(not(all(feature = "os-poll", not(miri))), doc = "```ignore")] // Miri doesn't support UDP sockets.
 /// # use std::error::Error;
 /// #
 /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -102,7 +102,7 @@ impl UdpSocket {
     /// # Examples
     ///
     #[cfg_attr(all(feature = "os-poll", not(miri)), doc = "```")]
-    #[cfg_attr(any(not(feature = "os-poll"), miri), doc = "```ignore")] // Miri doesn't support UDP sockets.
+    #[cfg_attr(not(all(feature = "os-poll", not(miri))), doc = "```ignore")] // Miri doesn't support UDP sockets.
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -150,7 +150,7 @@ impl UdpSocket {
         doc = "```"
     )]
     #[cfg_attr(
-        any(not(feature = "os-poll"), target_os = "freebsd", miri), // Miri doesn't support UDP sockets.
+        not(all(feature = "os-poll", not(target_os = "freebsd"), not(miri))), // Miri doesn't support UDP sockets.
         doc = "```ignore"
     )]
     /// # use std::error::Error;
@@ -173,7 +173,7 @@ impl UdpSocket {
     /// # Examples
     ///
     #[cfg_attr(all(feature = "os-poll", not(miri)), doc = "```")]
-    #[cfg_attr(any(not(feature = "os-poll"), miri), doc = "```ignore")] // Miri doesn't support UDP sockets.
+    #[cfg_attr(not(all(feature = "os-poll", not(miri))), doc = "```ignore")] // Miri doesn't support UDP sockets.
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -343,7 +343,7 @@ impl UdpSocket {
     /// # Examples
     ///
     #[cfg_attr(all(feature = "os-poll", not(miri)), doc = "```")]
-    #[cfg_attr(any(not(feature = "os-poll"), miri), doc = "```ignore")] // Miri doesn't support UDP sockets.
+    #[cfg_attr(not(all(feature = "os-poll", not(miri))), doc = "```ignore")] // Miri doesn't support UDP sockets.
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -375,7 +375,7 @@ impl UdpSocket {
     /// # Examples
     ///
     #[cfg_attr(all(feature = "os-poll", not(miri)), doc = "```")]
-    #[cfg_attr(any(not(feature = "os-poll"), miri), doc = "```ignore")] // Miri doesn't support UDP sockets.
+    #[cfg_attr(not(all(feature = "os-poll", not(miri))), doc = "```ignore")] // Miri doesn't support UDP sockets.
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -458,7 +458,7 @@ impl UdpSocket {
     /// # Examples
     ///
     #[cfg_attr(all(feature = "os-poll", not(miri)), doc = "```")]
-    #[cfg_attr(any(not(feature = "os-poll"), miri), doc = "```ignore")] // Miri doesn't support UDP sockets.
+    #[cfg_attr(not(all(feature = "os-poll", not(miri))), doc = "```ignore")] // Miri doesn't support UDP sockets.
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -487,7 +487,7 @@ impl UdpSocket {
     /// # Examples
     ///
     #[cfg_attr(all(feature = "os-poll", not(miri)), doc = "```")]
-    #[cfg_attr(any(not(feature = "os-poll"), miri), doc = "```ignore")] // Miri doesn't support UDP sockets.
+    #[cfg_attr(not(all(feature = "os-poll", not(miri))), doc = "```ignore")] // Miri doesn't support UDP sockets.
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -31,8 +31,8 @@ use crate::{event, sys, Interest, Registry, Token};
 ///
 /// # Examples
 ///
-#[cfg_attr(feature = "os-poll", doc = "```")]
-#[cfg_attr(not(feature = "os-poll"), doc = "```ignore")]
+#[cfg_attr(all(feature = "os-poll", not(miri)), doc = "```")]
+#[cfg_attr(any(not(feature = "os-poll"), miri), doc = "```ignore")] // Miri doesn't support UDP sockets.
 /// # use std::error::Error;
 /// #
 /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -101,8 +101,8 @@ impl UdpSocket {
     ///
     /// # Examples
     ///
-    #[cfg_attr(feature = "os-poll", doc = "```")]
-    #[cfg_attr(not(feature = "os-poll"), doc = "```ignore")]
+    #[cfg_attr(all(feature = "os-poll", not(miri)), doc = "```")]
+    #[cfg_attr(any(not(feature = "os-poll"), miri), doc = "```ignore")] // Miri doesn't support UDP sockets.
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -145,9 +145,12 @@ impl UdpSocket {
     // This assertion is almost, but not quite, universal.  It fails on
     // shared-IP FreeBSD jails.  It's hard for mio to know whether we're jailed,
     // so simply disable the test on FreeBSD.
-    #[cfg_attr(all(feature = "os-poll", not(target_os = "freebsd")), doc = "```")]
     #[cfg_attr(
-        any(not(feature = "os-poll"), target_os = "freebsd"),
+        all(feature = "os-poll", not(target_os = "freebsd"), not(miri)),
+        doc = "```"
+    )]
+    #[cfg_attr(
+        any(not(feature = "os-poll"), target_os = "freebsd", miri), // Miri doesn't support UDP sockets.
         doc = "```ignore"
     )]
     /// # use std::error::Error;
@@ -169,8 +172,8 @@ impl UdpSocket {
     ///
     /// # Examples
     ///
-    #[cfg_attr(feature = "os-poll", doc = "```")]
-    #[cfg_attr(not(feature = "os-poll"), doc = "```ignore")]
+    #[cfg_attr(all(feature = "os-poll", not(miri)), doc = "```")]
+    #[cfg_attr(any(not(feature = "os-poll"), miri), doc = "```ignore")] // Miri doesn't support UDP sockets.
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -339,8 +342,8 @@ impl UdpSocket {
     ///
     /// # Examples
     ///
-    #[cfg_attr(feature = "os-poll", doc = "```")]
-    #[cfg_attr(not(feature = "os-poll"), doc = "```ignore")]
+    #[cfg_attr(all(feature = "os-poll", not(miri)), doc = "```")]
+    #[cfg_attr(any(not(feature = "os-poll"), miri), doc = "```ignore")] // Miri doesn't support UDP sockets.
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -371,8 +374,8 @@ impl UdpSocket {
     ///
     /// # Examples
     ///
-    #[cfg_attr(feature = "os-poll", doc = "```")]
-    #[cfg_attr(not(feature = "os-poll"), doc = "```ignore")]
+    #[cfg_attr(all(feature = "os-poll", not(miri)), doc = "```")]
+    #[cfg_attr(any(not(feature = "os-poll"), miri), doc = "```ignore")] // Miri doesn't support UDP sockets.
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -454,8 +457,8 @@ impl UdpSocket {
     ///
     /// # Examples
     ///
-    #[cfg_attr(feature = "os-poll", doc = "```")]
-    #[cfg_attr(not(feature = "os-poll"), doc = "```ignore")]
+    #[cfg_attr(all(feature = "os-poll", not(miri)), doc = "```")]
+    #[cfg_attr(any(not(feature = "os-poll"), miri), doc = "```ignore")] // Miri doesn't support UDP sockets.
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -483,8 +486,8 @@ impl UdpSocket {
     ///
     /// # Examples
     ///
-    #[cfg_attr(feature = "os-poll", doc = "```")]
-    #[cfg_attr(not(feature = "os-poll"), doc = "```ignore")]
+    #[cfg_attr(all(feature = "os-poll", not(miri)), doc = "```")]
+    #[cfg_attr(any(not(feature = "os-poll"), miri), doc = "```ignore")] // Miri doesn't support UDP sockets.
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {

--- a/src/net/uds/datagram.rs
+++ b/src/net/uds/datagram.rs
@@ -130,7 +130,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(not(miri), doc = "```")]
+    #[cfg_attr(miri, doc = "```ignore")] // Miri doesn't support Unix domain sockets.
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {

--- a/src/net/uds/stream.rs
+++ b/src/net/uds/stream.rs
@@ -95,7 +95,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(not(miri), doc = "```")]
+    #[cfg_attr(miri, doc = "```ignore")] // Miri doesn't support Unix domain sockets.
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {

--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -291,6 +291,7 @@ pub fn registry_ops_flow(
     target_os = "wasi",
     ignore = "WASI does not yet support multithreading"
 )]
+#[cfg_attr(miri, ignore = "Miri doesn't support UDP sockets")]
 #[test]
 fn registry_operations_are_thread_safe() {
     let (mut poll, mut events) = init_with_poll();
@@ -381,6 +382,7 @@ fn registry_operations_are_thread_safe() {
     target_os = "wasi",
     ignore = "WASI does not yet support multithreading"
 )]
+#[cfg_attr(miri, ignore = "Miri doesn't support UDP sockets")]
 #[test]
 fn register_during_poll() {
     let (mut poll, mut events) = init_with_poll();
@@ -430,6 +432,7 @@ fn register_during_poll() {
 // - `reregister` can use different token from `register`
 // - multiple `reregister` are ok
 #[test]
+#[cfg_attr(miri, ignore = "Miri doesn't support UDP sockets")]
 fn reregister_interest_token_usage() {
     let (mut poll, mut events) = init_with_poll();
 

--- a/tests/registering.rs
+++ b/tests/registering.rs
@@ -194,6 +194,7 @@ fn tcp_register_multiple_event_loops() {
 
 #[test]
 #[cfg(debug_assertions)] // Check is only present when debug assertions are enabled.
+#[cfg_attr(miri, ignore = "Miri doesn't support UDP sockets")]
 fn udp_register_multiple_event_loops() {
     init();
 

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -110,6 +110,7 @@ fn issue_1205() {
 
 #[test]
 #[cfg(unix)]
+#[cfg_attr(miri, ignore = "Miri doesn't support Unix domain sockets")]
 fn issue_1403() {
     use mio::net::UnixDatagram;
     use util::temp_file;

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -483,6 +483,7 @@ fn multiple_writes_immediate_success() {
     handle.join().unwrap();
 }
 
+#[cfg_attr(miri, ignore = "Miri doesn't support lingering")]
 #[test]
 fn connection_reset_by_peer() {
     init();

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -874,6 +874,7 @@ fn start_listener(
     target_os = "wasi",
     ignore = "WASI does not yet support `POLLHUP` or `POLLRDHUP`"
 )]
+#[cfg_attr(miri, ignore = "Miri doesn't support lingering")]
 #[test]
 fn hup_event_on_disconnect() {
     use mio::net::TcpListener;
@@ -918,6 +919,7 @@ fn hup_event_on_disconnect() {
     );
 }
 
+#[cfg_attr(miri, ignore = "Miri doesn't support `Interest::PRIORITY`")]
 #[test]
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn priority_event_on_oob_data() {

--- a/tests/udp_socket.rs
+++ b/tests/udp_socket.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "os-poll", feature = "net"))]
+#![cfg(all(feature = "os-poll", feature = "net", not(miri)))] // Miri doesn't support UDP sockets.
 
 use log::{debug, info};
 use mio::net::UdpSocket;

--- a/tests/unix_datagram.rs
+++ b/tests/unix_datagram.rs
@@ -1,4 +1,4 @@
-#![cfg(all(unix, feature = "os-poll", feature = "net"))]
+#![cfg(all(unix, feature = "os-poll", feature = "net", not(miri)))] // Miri doesn't support Unix domain sockets.
 
 use mio::net::UnixDatagram;
 use mio::{Interest, Token};

--- a/tests/unix_listener.rs
+++ b/tests/unix_listener.rs
@@ -1,4 +1,4 @@
-#![cfg(all(unix, feature = "os-poll", feature = "net"))]
+#![cfg(all(unix, feature = "os-poll", feature = "net", not(miri)))] // Miri doesn't support Unix domain sockets.
 
 use mio::net::UnixListener;
 use mio::{Interest, Token};

--- a/tests/unix_pipe.rs
+++ b/tests/unix_pipe.rs
@@ -136,6 +136,7 @@ fn event_when_receiver_is_dropped() {
     any(target_os = "hurd", target_os = "nto", target_os = "cygwin"),
     ignore = "Writer fd close events do not trigger POLLHUP on nto and GNU/Hurd targets"
 )]
+#[cfg_attr(miri, ignore = "Miri doesn't support process spawning")]
 fn from_child_process_io() {
     // `cat` simply echo everything that we write via standard in.
     let mut child = Command::new("cat")
@@ -183,6 +184,7 @@ fn from_child_process_io() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Miri doesn't support process spawning")]
 fn nonblocking_child_process_io() {
     // `cat` simply echo everything that we write via standard in.
     let mut child = Command::new("cat")

--- a/tests/unix_stream.rs
+++ b/tests/unix_stream.rs
@@ -1,4 +1,4 @@
-#![cfg(all(unix, feature = "os-poll", feature = "net"))]
+#![cfg(all(unix, feature = "os-poll", feature = "net", not(miri)))] // Miri doesn't support Unix domain sockets.
 
 use mio::net::UnixStream;
 use mio::{Interest, Token};


### PR DESCRIPTION
Hi,

This pull request adds a CI job to run the test suite, as well as the doc comments on Miri.
With the addition of the TCP socket and `poll` shims, Miri now supports a large enough portion of mio (and its test suite) that I thought it might be worth adding a CI job.

Also, in Miri we currently can't nicely test tokio with the `poll` selector as an integration test. We thought that it might be an option to add another job which runs the mio test suite with the `mio_unsupported_force_poll_poll` flag on a Linux target (even though that would be testing behavior this is not officially supported). What do you think of this?