### PR TITLE
ci: run tests with Miri using forced poll selector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,11 @@ jobs:
         run: cargo miri test --doc --all-features --no-fail-fast
         env:
           MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-strict-provenance
+      - name: Run tests with Miri using poll selector
+        run: cargo miri test --all-features --test '*' --no-fail-fast
+        env:
+          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-strict-provenance
+          RUSTFLAGS: --cfg mio_unsupported_force_poll_poll
   CheckTargets:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
As mentioned in https://github.com/tokio-rs/mio/pull/1978, this PR adds an additional step to the Miri CI job which runs the test suite with Miri using the forced `poll` selector. 