### PR TITLE
Remove outdated comment about epoll_create1 emulation

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -289,11 +289,7 @@ impl Poll {
         /// with the error.
         ///
         /// close-on-exec flag is set on the file descriptors used by the selector to prevent
-        /// leaking it to executed processes. However, on some systems such as
-        /// old Linux systems that don't support `epoll_create1` syscall it is done
-        /// non-atomically, so a separate thread executing in parallel to this
-        /// function may accidentally leak the file descriptor if it executes a
-        /// new process before this function returns.
+        /// leaking it to executed processes.
         ///
         /// See [struct] level docs for more details.
         ///


### PR DESCRIPTION
The work around was removed in 7074b4771313a9da8c20da391c718987bd629708