### PR TITLE
Reuse IoSourceState between poll and event_port implementations

### DIFF
--- a/src/sys/unix/selector/event_ports.rs
+++ b/src/sys/unix/selector/event_ports.rs
@@ -721,130 +721,6 @@ pub mod event {
     }
 }
 
-cfg_io_source! {
-    use crate::Registry;
-
-    struct InternalState {
-        selector: Selector,
-        token: Token,
-        interests: Interest,
-        fd: RawFd,
-        shared_record: Arc<RegistrationRecord>,
-    }
-
-    impl Drop for InternalState {
-        fn drop(&mut self) {
-            if self.shared_record.is_registered() {
-                let _ = self.selector.deregister(self.fd);
-            }
-        }
-    }
-
-    pub(crate) struct IoSourceState {
-        inner: Option<Box<InternalState>>,
-    }
-
-    impl IoSourceState {
-        pub fn new() -> IoSourceState {
-            IoSourceState { inner: None }
-        }
-
-        pub fn do_io<T, F, R>(&self, f: F, io: &T) -> io::Result<R>
-        where
-            F: FnOnce(&T) -> io::Result<R>,
-        {
-            let result = f(io);
-
-            if let Err(err) = &result {
-                if err.kind() == io::ErrorKind::WouldBlock {
-                    self.inner.as_ref().map_or(Ok(()), |state| {
-                        state
-                            .selector
-                            .reregister(state.fd, state.token, state.interests)
-                    })?;
-                }
-            }
-
-            result
-        }
-
-        pub fn register(
-            &mut self,
-            registry: &Registry,
-            token: Token,
-            interests: Interest,
-            fd: RawFd,
-        ) -> io::Result<()> {
-            if self.inner.is_some() {
-                Err(io::ErrorKind::AlreadyExists.into())
-            } else {
-                let selector = registry.selector().try_clone()?;
-
-                selector.register_internal(fd, token, interests).map(move |shared_record| {
-                    let state = InternalState {
-                        selector,
-                        token,
-                        interests,
-                        fd,
-                        shared_record,
-                    };
-
-                    self.inner = Some(Box::new(state));
-                })
-            }
-        }
-
-        pub fn reregister(
-            &mut self,
-            registry: &Registry,
-            token: Token,
-            interests: Interest,
-            fd: RawFd,
-        ) -> io::Result<()> {
-            match self.inner.as_mut() {
-                Some(state) => registry.selector().reregister(fd, token, interests).map(|()| {
-                    state.token = token;
-                    state.interests = interests;
-                }),
-                None => Err(io::ErrorKind::NotFound.into()),
-            }
-        }
-
-        pub fn deregister(&mut self, registry: &Registry, fd: RawFd) -> io::Result<()> {
-            if let Some(state) = self.inner.take() {
-                state.shared_record.mark_unregistered();
-            }
-
-            registry.selector().deregister(fd)
-        }
-    }
-}
-
-cfg_io_source! {
-use std::sync::atomic::AtomicBool;
-
-#[derive(Debug)]
-pub(crate) struct RegistrationRecord {
-    is_unregistered: AtomicBool,
-}
-
-impl RegistrationRecord {
-    pub fn new() -> Self {
-        Self {
-            is_unregistered: AtomicBool::new(false),
-        }
-    }
-
-    pub fn mark_unregistered(&self) {
-        self.is_unregistered.store(true, Ordering::Relaxed);
-    }
-
-    pub fn is_registered(&self) -> bool {
-        !self.is_unregistered.load(Ordering::Relaxed)
-    }
-}
-}
-
 impl AsFd for Selector {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.port.as_fd()
@@ -855,4 +731,10 @@ impl AsRawFd for Selector {
     fn as_raw_fd(&self) -> RawFd {
         self.port.as_raw_fd()
     }
+}
+
+cfg_io_source! {
+    mod registered_io_source;
+    pub(crate) use registered_io_source::IoSourceState;
+    use registered_io_source::RegistrationRecord;
 }

--- a/src/sys/unix/selector/poll.rs
+++ b/src/sys/unix/selector/poll.rs
@@ -11,7 +11,7 @@ use std::os::fd::RawFd;
 // can use `std::os::fd` and be merged with the above.
 #[cfg(target_os = "hermit")]
 use std::os::hermit::io::RawFd;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 use std::{cmp, fmt, io};
@@ -52,7 +52,7 @@ impl Selector {
         self.state.register(fd, token, interests)
     }
 
-    #[allow(dead_code)]
+    cfg_io_source! {
     pub(crate) fn register_internal(
         &self,
         fd: RawFd,
@@ -60,6 +60,7 @@ impl Selector {
         interests: Interest,
     ) -> io::Result<Arc<RegistrationRecord>> {
         self.state.register_internal(fd, token, interests)
+    }
     }
 
     cfg_any_os_ext! {
@@ -463,34 +464,6 @@ impl SelectorState {
     }
 }
 
-/// Shared record between IoSourceState and SelectorState that allows us to internally
-/// deregister partially or fully closed fds (i.e. when we get POLLHUP or PULLERR) without
-/// confusing IoSourceState and trying to deregister twice.  This isn't strictly
-/// required as technically deregister is idempotent but it is confusing
-/// when trying to debug behaviour as we get imbalanced calls to register/deregister and
-/// superfluous NotFound errors.
-#[derive(Debug)]
-pub(crate) struct RegistrationRecord {
-    is_unregistered: AtomicBool,
-}
-
-impl RegistrationRecord {
-    pub fn new() -> Self {
-        Self {
-            is_unregistered: AtomicBool::new(false),
-        }
-    }
-
-    pub fn mark_unregistered(&self) {
-        self.is_unregistered.store(true, Ordering::Relaxed);
-    }
-
-    #[allow(dead_code)]
-    pub fn is_registered(&self) -> bool {
-        !self.is_unregistered.load(Ordering::Relaxed)
-    }
-}
-
 #[cfg(not(target_os = "horizon"))]
 type PollFlagInt = libc::c_short;
 #[cfg(target_os = "horizon")]
@@ -695,106 +668,9 @@ impl Waker {
     }
 }
 
+mod registered_io_source;
+use registered_io_source::RegistrationRecord;
+
 cfg_io_source! {
-    use crate::Registry;
-
-    struct InternalState {
-        selector: Selector,
-        token: Token,
-        interests: Interest,
-        fd: RawFd,
-        shared_record: Arc<RegistrationRecord>,
-    }
-
-    impl Drop for InternalState {
-        fn drop(&mut self) {
-            if self.shared_record.is_registered() {
-                let _ = self.selector.deregister(self.fd);
-            }
-        }
-    }
-
-    pub(crate) struct IoSourceState {
-        inner: Option<Box<InternalState>>,
-    }
-
-    impl IoSourceState {
-        pub fn new() -> IoSourceState {
-            IoSourceState { inner: None }
-        }
-
-        pub fn do_io<T, F, R>(&self, f: F, io: &T) -> io::Result<R>
-        where
-        F: FnOnce(&T) -> io::Result<R>,
-        {
-            let result = f(io);
-
-            if let Err(err) = &result {
-                if err.kind() == io::ErrorKind::WouldBlock {
-                    self.inner.as_ref().map_or(Ok(()), |state| {
-                        state
-                        .selector
-                        .reregister(state.fd, state.token, state.interests)
-                    })?;
-                }
-            }
-
-            result
-        }
-
-        pub fn register(
-            &mut self,
-            registry: &Registry,
-            token: Token,
-            interests: Interest,
-            fd: RawFd,
-        ) -> io::Result<()> {
-            if self.inner.is_some() {
-                Err(io::ErrorKind::AlreadyExists.into())
-            } else {
-                let selector = registry.selector().try_clone()?;
-
-                selector.register_internal(fd, token, interests).map(move |shared_record| {
-                    let state = InternalState {
-                        selector,
-                        token,
-                        interests,
-                        fd,
-                        shared_record,
-                    };
-
-                    self.inner = Some(Box::new(state));
-                })
-            }
-        }
-
-        pub fn reregister(
-            &mut self,
-            registry: &Registry,
-            token: Token,
-            interests: Interest,
-            fd: RawFd,
-        ) -> io::Result<()> {
-            match self.inner.as_mut() {
-                Some(state) => registry
-                .selector()
-                .reregister(fd, token, interests)
-                .map(|()| {
-                    state.token = token;
-                    state.interests = interests;
-                }),
-                None => Err(io::ErrorKind::NotFound.into()),
-            }
-        }
-
-        pub fn deregister(&mut self, registry: &Registry, fd: RawFd) -> io::Result<()> {
-            if let Some(state) = self.inner.take() {
-                // Marking unregistered will short circuit the drop behaviour of calling
-                // deregister so the call to deregister below is strictly required.
-                state.shared_record.mark_unregistered();
-            }
-
-            registry.selector().deregister(fd)
-        }
-    }
+    pub(crate) use registered_io_source::IoSourceState;
 }

--- a/src/sys/unix/selector/registered_io_source.rs
+++ b/src/sys/unix/selector/registered_io_source.rs
@@ -1,0 +1,151 @@
+//! Both `poll(2)` and `event_port(2)` need to hold per-fd states.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+cfg_io_source! {
+use std::io;
+#[cfg(not(target_os = "hermit"))]
+use std::os::fd::RawFd;
+// TODO: once <https://github.com/rust-lang/rust/issues/126198> is fixed this
+// can use `std::os::fd` and be merged with the above.
+#[cfg(target_os = "hermit")]
+use std::os::hermit::io::RawFd;
+use std::sync::Arc;
+
+use crate::sys::Selector;
+use crate::{Interest, Registry, Token};
+}
+
+/// Shared record between IoSourceState and SelectorState that allows us to
+/// internally deregister partially or fully closed fds (i.e. when we get
+/// POLLHUP or PULLERR) without confusing IoSourceState and trying to deregister
+/// twice.  This isn't strictly required as technically deregister is idempotent
+/// but it is confusing when trying to debug behaviour as we get imbalanced
+/// calls to register/deregister and superfluous NotFound errors.
+#[derive(Debug)]
+pub(crate) struct RegistrationRecord {
+    is_unregistered: AtomicBool,
+}
+
+impl RegistrationRecord {
+    pub(crate) fn new() -> RegistrationRecord {
+        RegistrationRecord {
+            is_unregistered: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) fn mark_unregistered(&self) {
+        self.is_unregistered.store(true, Ordering::Relaxed);
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_registered(&self) -> bool {
+        !self.is_unregistered.load(Ordering::Relaxed)
+    }
+}
+
+cfg_io_source! {
+pub(crate) struct IoSourceState {
+    inner: Option<Box<InternalState>>,
+}
+
+struct InternalState {
+    selector: Selector,
+    token: Token,
+    interests: Interest,
+    fd: RawFd,
+    shared_record: Arc<RegistrationRecord>,
+}
+}
+
+cfg_io_source! {
+impl IoSourceState {
+    pub(crate) fn new() -> IoSourceState {
+        IoSourceState { inner: None }
+    }
+
+    pub(crate) fn do_io<T, F, R>(&self, f: F, io: &T) -> io::Result<R>
+    where
+        F: FnOnce(&T) -> io::Result<R>,
+    {
+        let result = f(io);
+
+        if let Err(err) = &result {
+            if err.kind() == io::ErrorKind::WouldBlock {
+                self.inner.as_ref().map_or(Ok(()), |state| {
+                    state
+                        .selector
+                        .reregister(state.fd, state.token, state.interests)
+                })?;
+            }
+        }
+
+        result
+    }
+
+    pub(crate) fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+        fd: RawFd,
+    ) -> io::Result<()> {
+        if self.inner.is_some() {
+            Err(io::ErrorKind::AlreadyExists.into())
+        } else {
+            let selector = registry.selector().try_clone()?;
+
+            selector
+                .register_internal(fd, token, interests)
+                .map(move |shared_record| {
+                    let state = InternalState {
+                        selector,
+                        token,
+                        interests,
+                        fd,
+                        shared_record,
+                    };
+
+                    self.inner = Some(Box::new(state));
+                })
+        }
+    }
+
+    pub(crate) fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+        fd: RawFd,
+    ) -> io::Result<()> {
+        match self.inner.as_mut() {
+            Some(state) => registry
+                .selector()
+                .reregister(fd, token, interests)
+                .map(|()| {
+                    state.token = token;
+                    state.interests = interests;
+                }),
+            None => Err(io::ErrorKind::NotFound.into()),
+        }
+    }
+
+    pub(crate) fn deregister(&mut self, registry: &Registry, fd: RawFd) -> io::Result<()> {
+        if let Some(state) = self.inner.take() {
+            // Marking unregistered will short circuit the drop behaviour of calling
+            // deregister so the call to deregister below is strictly required.
+            state.shared_record.mark_unregistered();
+        }
+
+        registry.selector().deregister(fd)
+    }
+}
+
+impl Drop for InternalState {
+    fn drop(&mut self) {
+        if self.shared_record.is_registered() {
+            let _ = self.selector.deregister(self.fd);
+        }
+    }
+}
+}


### PR DESCRIPTION
The two implementations were exactly the same, so reuse them between the two selector implementations.