### PR TITLE
Fix UDS listener re-arming with poll

### DIFF
--- a/src/net/uds/listener.rs
+++ b/src/net/uds/listener.rs
@@ -41,7 +41,7 @@ impl UnixListener {
     /// The call is responsible for ensuring that the listening socket is in
     /// non-blocking mode.
     pub fn accept(&self) -> io::Result<(UnixStream, SocketAddr)> {
-        sys::uds::listener::accept(&self.inner)
+        self.inner.do_io(sys::uds::listener::accept)
     }
 
     /// Returns the local socket address of this listener.

--- a/tests/unix_listener.rs
+++ b/tests/unix_listener.rs
@@ -5,7 +5,7 @@ use mio::{Interest, Token};
 use std::io::{self, Read};
 use std::os::unix::net;
 use std::path::{Path, PathBuf};
-use std::sync::{mpsc, Arc, Barrier};
+use std::sync::{Arc, Barrier};
 use std::thread;
 
 #[macro_use]
@@ -127,14 +127,13 @@ fn unix_listener_reregisters_after_would_block() {
         .register(&mut listener, TOKEN_1, Interest::READABLE)
         .unwrap();
 
-    let first_accepted = Arc::new(Barrier::new(2));
-    let (start_second_tx, start_second_rx) = mpsc::channel();
+    let barrier = Arc::new(Barrier::new(2));
     let handle = thread::spawn({
-        let first_accepted = first_accepted.clone();
+        let barrier = barrier.clone();
         move || {
             let first = net::UnixStream::connect(&path).unwrap();
-            first_accepted.wait();
-            start_second_rx.recv().unwrap();
+            barrier.wait();
+            barrier.wait();
             let second = net::UnixStream::connect(&path).unwrap();
             drop((first, second));
         }
@@ -146,10 +145,10 @@ fn unix_listener_reregisters_after_would_block() {
         vec![ExpectEvent::new(TOKEN_1, Interest::READABLE)],
     );
     listener.accept().unwrap();
-    first_accepted.wait();
+    barrier.wait();
     assert_would_block(listener.accept());
 
-    start_second_tx.send(()).unwrap();
+    barrier.wait();
     expect_events(
         &mut poll,
         &mut events,

--- a/tests/unix_listener.rs
+++ b/tests/unix_listener.rs
@@ -5,7 +5,7 @@ use mio::{Interest, Token};
 use std::io::{self, Read};
 use std::os::unix::net;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Barrier};
+use std::sync::{mpsc, Arc, Barrier};
 use std::thread;
 
 #[macro_use]
@@ -115,6 +115,47 @@ fn unix_listener_reregister() {
     listener.accept().unwrap();
 
     barrier.wait();
+    handle.join().unwrap();
+}
+
+#[test]
+fn unix_listener_reregisters_after_would_block() {
+    let (mut poll, mut events) = init_with_poll();
+    let path = temp_file("unix_listener_reregisters_after_would_block");
+    let mut listener = UnixListener::bind(&path).unwrap();
+    poll.registry()
+        .register(&mut listener, TOKEN_1, Interest::READABLE)
+        .unwrap();
+
+    let first_accepted = Arc::new(Barrier::new(2));
+    let (start_second_tx, start_second_rx) = mpsc::channel();
+    let handle = thread::spawn({
+        let first_accepted = first_accepted.clone();
+        move || {
+            let first = net::UnixStream::connect(&path).unwrap();
+            first_accepted.wait();
+            start_second_rx.recv().unwrap();
+            let second = net::UnixStream::connect(&path).unwrap();
+            drop((first, second));
+        }
+    });
+
+    expect_events(
+        &mut poll,
+        &mut events,
+        vec![ExpectEvent::new(TOKEN_1, Interest::READABLE)],
+    );
+    listener.accept().unwrap();
+    first_accepted.wait();
+    assert_would_block(listener.accept());
+
+    start_second_tx.send(()).unwrap();
+    expect_events(
+        &mut poll,
+        &mut events,
+        vec![ExpectEvent::new(TOKEN_1, Interest::READABLE)],
+    );
+    listener.accept().unwrap();
     handle.join().unwrap();
 }
 


### PR DESCRIPTION
Howdy, we encountered an indefinite stall through Tokio under AIX, which uses the `poll(2)` backend by default. This presented as a first connection being accepted, being drained up to the point of hitting `WouldBlock`, and then subsequent connections are never accepted and instead stall. We were able to extend our reproduction to Linux builds through `mio_unsupported_force_poll_poll` and provide a regression test here and update the UnixListener `accept` path to follow the pattern from the TcpListener which does not exhibit the stalling behavior.

_AI content follows..._

## Summary

Fix Unix-domain listener re-arming when Mio uses its `poll(2)` selector.

The poll selector removes an interest after delivering its event and relies on `IoSource::do_io` to re-register that interest when a later operation returns `WouldBlock`. `UnixListener::accept` bypassed `do_io`, so accepting one connection followed by `WouldBlock` left the listener without `POLLIN` interest. A later client could connect successfully but would not produce another Mio readiness event.

Route `UnixListener::accept` through `IoSource::do_io`, matching `TcpListener::accept`, and add a regression test for that sequence.

## Linux reproduction

The regression is portable to Linux by forcing Mio's poll selector, as CI's `TestPoll` job does.

To observe the failure with this PR's regression test and the pre-fix implementation:

```bash
git clone https://github.com/tokio-rs/mio.git
cd mio
git fetch origin pull/1998/head:uds-listener-rearm
git checkout uds-listener-rearm

# Keep the regression test from this PR, but restore the pre-fix implementation.
git checkout origin/master -- src/net/uds/listener.rs
RUSTFLAGS='--cfg mio_unsupported_force_poll_poll' \
  cargo test --features 'net os-poll os-ext' --test unix_listener \
  unix_listener_reregisters_after_would_block -- --exact
```

The test times out waiting for the second `READABLE` event. Restore the PR implementation and rerun it to verify the fix:

```bash
git checkout HEAD -- src/net/uds/listener.rs
RUSTFLAGS='--cfg mio_unsupported_force_poll_poll' \
  cargo test --features 'net os-poll os-ext' --test unix_listener \
  unix_listener_reregisters_after_would_block -- --exact
```

## Validation

- `RUSTFLAGS='--cfg mio_unsupported_force_poll_poll' cargo test --features 'net os-poll os-ext' --test unix_listener unix_listener_reregisters_after_would_block -- --exact` (50 iterations)
- `RUSTFLAGS='--cfg mio_unsupported_force_poll_poll' cargo test --features 'net os-poll os-ext' --test unix_listener`
- `cargo test --features 'net os-poll os-ext' --test unix_listener`
- `RUSTFLAGS='--cfg mio_unsupported_force_poll_poll' cargo test --features 'net os-poll os-ext' --test tcp_listener`
- AIX: the original Tokio `UnixListener` two-client reproducer accepted both connections after building with the candidate Mio source.

## AIX context

AIX uses the same Mio poll selector and exposed the issue. This patch is intentionally selector- and platform-neutral: the Linux forced-poll test exercises the relevant behavior without adding AIX-specific code or CI requirements.
