### PR TITLE
Allow CI failures in tier 2 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,8 @@ jobs:
   CheckTier2:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Don't want to fail the CI for tier 2 jobs.
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
A lot of these OS fail to build the standard library at various points (see the issues list). For those cases we don't want to fail the CI any more.