### PR TITLE
windows: only re-arm the direction that blocked

### DIFF
--- a/src/io_source.rs
+++ b/src/io_source.rs
@@ -69,6 +69,39 @@ impl<T> IoSource<T> {
         self.state.do_io(f, &self.inner)
     }
 
+    /// Same as [`do_io`], for an operation known to only involve `interest`.
+    ///
+    /// Selectors that have to re-arm a source after a blocked operation re-arm
+    /// only `interest`, instead of everything the source is registered for.
+    /// Re-arming a direction the caller did not block on can raise readiness
+    /// nothing asked for: on Windows a blocked read would otherwise re-request
+    /// write readiness, which the AFD poll completes immediately for a writable
+    /// socket.
+    ///
+    /// Only use this when the direction is actually known. An operation driven
+    /// by a caller-supplied closure, such as `try_io`, must keep using
+    /// [`do_io`].
+    ///
+    /// [`do_io`]: IoSource::do_io
+    #[cfg(feature = "net")]
+    pub(crate) fn do_io_with<F, R>(&self, interest: Interest, f: F) -> io::Result<R>
+    where
+        F: FnOnce(&T) -> io::Result<R>,
+    {
+        #[cfg(windows)]
+        {
+            self.state.do_io_with(interest, f, &self.inner)
+        }
+
+        // No other selector re-arms in a way that can raise readiness for the
+        // direction the caller did not block on, so this is exactly `do_io`.
+        #[cfg(not(windows))]
+        {
+            let _ = interest;
+            self.state.do_io(f, &self.inner)
+        }
+    }
+
     /// Returns the I/O source, dropping the state.
     ///
     /// # Notes

--- a/src/io_source.rs
+++ b/src/io_source.rs
@@ -93,8 +93,13 @@ impl<T> IoSource<T> {
             self.state.do_io_with(interest, f, &self.inner)
         }
 
-        // No other selector re-arms in a way that can raise readiness for the
-        // direction the caller did not block on, so this is exactly `do_io`.
+        // `epoll(7)` and `kqueue(2)` are edge triggered and never re-arm, so
+        // there is nothing to narrow for them.
+        //
+        // `poll(2)` and `event_ports(2)` do re-arm the full interest and have
+        // the same problem, but narrowing them means giving each selector a
+        // re-arm that adds to the requested events rather than replacing them.
+        // That is not done yet, so they still go through `do_io`. See #1963.
         #[cfg(not(windows))]
         {
             let _ = interest;

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -116,7 +116,7 @@ impl TcpListener {
     /// If an accepted stream is returned, the remote address of the peer is
     /// returned along with it.
     pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
-        self.inner.do_io(|inner| {
+        self.inner.do_io_with(Interest::READABLE, |inner| {
             sys::tcp::accept(inner).map(|(stream, addr)| (TcpStream::from_std(stream), addr))
         })
     }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -214,7 +214,8 @@ impl TcpStream {
     pub fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
         // Need to re-register if `peek` returns `WouldBlock`
         // to ensure the socket will receive more events once it is ready again.
-        self.inner.do_io(|inner| inner.peek(buf))
+        self.inner
+            .do_io_with(Interest::READABLE, |inner| inner.peek(buf))
     }
 
     /// Execute an I/O operation ensuring that the socket receives more events
@@ -272,55 +273,67 @@ impl TcpStream {
     where
         F: FnOnce() -> io::Result<T>,
     {
+        // The closure is opaque, so the direction that may block is not known
+        // here. Keep re-arming everything the stream is registered for.
         self.inner.do_io(|_| f())
     }
 }
 
 impl Read for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.inner.do_io(|mut inner| inner.read(buf))
+        self.inner
+            .do_io_with(Interest::READABLE, |mut inner| inner.read(buf))
     }
 
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-        self.inner.do_io(|mut inner| inner.read_vectored(bufs))
+        self.inner
+            .do_io_with(Interest::READABLE, |mut inner| inner.read_vectored(bufs))
     }
 }
 
 impl Read for &'_ TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.inner.do_io(|mut inner| inner.read(buf))
+        self.inner
+            .do_io_with(Interest::READABLE, |mut inner| inner.read(buf))
     }
 
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-        self.inner.do_io(|mut inner| inner.read_vectored(bufs))
+        self.inner
+            .do_io_with(Interest::READABLE, |mut inner| inner.read_vectored(bufs))
     }
 }
 
 impl Write for TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.inner.do_io(|mut inner| inner.write(buf))
+        self.inner
+            .do_io_with(Interest::WRITABLE, |mut inner| inner.write(buf))
     }
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        self.inner.do_io(|mut inner| inner.write_vectored(bufs))
+        self.inner
+            .do_io_with(Interest::WRITABLE, |mut inner| inner.write_vectored(bufs))
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.inner.do_io(|mut inner| inner.flush())
+        self.inner
+            .do_io_with(Interest::WRITABLE, |mut inner| inner.flush())
     }
 }
 
 impl Write for &'_ TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.inner.do_io(|mut inner| inner.write(buf))
+        self.inner
+            .do_io_with(Interest::WRITABLE, |mut inner| inner.write(buf))
     }
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        self.inner.do_io(|mut inner| inner.write_vectored(bufs))
+        self.inner
+            .do_io_with(Interest::WRITABLE, |mut inner| inner.write_vectored(bufs))
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.inner.do_io(|mut inner| inner.flush())
+        self.inner
+            .do_io_with(Interest::WRITABLE, |mut inner| inner.flush())
     }
 }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -216,7 +216,8 @@ impl UdpSocket {
     /// # }
     /// ```
     pub fn send_to(&self, buf: &[u8], target: SocketAddr) -> io::Result<usize> {
-        self.inner.do_io(|inner| inner.send_to(buf, target))
+        self.inner
+            .do_io_with(Interest::WRITABLE, |inner| inner.send_to(buf, target))
     }
 
     /// Receives data from the socket. On success, returns the number of bytes
@@ -251,7 +252,8 @@ impl UdpSocket {
     /// # }
     /// ```
     pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
-        self.inner.do_io(|inner| inner.recv_from(buf))
+        self.inner
+            .do_io_with(Interest::READABLE, |inner| inner.recv_from(buf))
     }
 
     /// Receives data from the socket, without removing it from the input queue.
@@ -287,13 +289,15 @@ impl UdpSocket {
     /// # }
     /// ```
     pub fn peek_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
-        self.inner.do_io(|inner| inner.peek_from(buf))
+        self.inner
+            .do_io_with(Interest::READABLE, |inner| inner.peek_from(buf))
     }
 
     /// Sends data on the socket to the address previously bound via connect(). On success,
     /// returns the number of bytes written.
     pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
-        self.inner.do_io(|inner| inner.send(buf))
+        self.inner
+            .do_io_with(Interest::WRITABLE, |inner| inner.send(buf))
     }
 
     /// Receives data from the socket previously bound with connect(). On success, returns
@@ -307,7 +311,8 @@ impl UdpSocket {
     /// Make sure to always use a sufficiently large buffer to hold the
     /// maximum UDP packet size, which can be up to 65536 bytes in size.
     pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.inner.do_io(|inner| inner.recv(buf))
+        self.inner
+            .do_io_with(Interest::READABLE, |inner| inner.recv(buf))
     }
 
     /// Receives data from the socket, without removing it from the input queue.
@@ -321,7 +326,8 @@ impl UdpSocket {
     /// Make sure to always use a sufficiently large buffer to hold the
     /// maximum UDP packet size, which can be up to 65536 bytes in size.
     pub fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.inner.do_io(|inner| inner.peek(buf))
+        self.inner
+            .do_io_with(Interest::READABLE, |inner| inner.peek(buf))
     }
 
     /// Connects the UDP socket setting the default destination for `send()`
@@ -619,6 +625,8 @@ impl UdpSocket {
     where
         F: FnOnce() -> io::Result<T>,
     {
+        // The closure is opaque, so the direction that may block is not known
+        // here. Keep re-arming everything the socket is registered for.
         self.inner.do_io(|_| f())
     }
 }

--- a/src/sys/shell/mod.rs
+++ b/src/sys/shell/mod.rs
@@ -48,6 +48,21 @@ cfg_io_source! {
             // return.
             f(io)
         }
+
+        #[cfg(feature = "net")]
+        pub fn do_io_with<T, F, R>(
+            &self,
+            _interest: crate::Interest,
+            f: F,
+            io: &T,
+        ) -> io::Result<R>
+        where
+            F: FnOnce(&T) -> io::Result<R>,
+        {
+            // We don't hold state, so we can just call the function and
+            // return.
+            f(io)
+        }
     }
 
     #[cfg(any(unix, target_os = "hermit"))]

--- a/src/sys/shell/mod.rs
+++ b/src/sys/shell/mod.rs
@@ -49,13 +49,9 @@ cfg_io_source! {
             f(io)
         }
 
-        #[cfg(feature = "net")]
-        pub fn do_io_with<T, F, R>(
-            &self,
-            _interest: crate::Interest,
-            f: F,
-            io: &T,
-        ) -> io::Result<R>
+        // `IoSource::do_io_with` only forwards to the backend on Windows.
+        #[cfg(all(windows, feature = "net"))]
+        pub fn do_io_with<T, F, R>(&self, _interest: Interest, f: F, io: &T) -> io::Result<R>
         where
             F: FnOnce(&T) -> io::Result<R>,
         {

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -98,6 +98,46 @@ cfg_io_source! {
             result
         }
 
+        /// Same as [`do_io`], for an operation known to only involve
+        /// `interest`.
+        ///
+        /// Re-arming the full registered interest after a blocked read also
+        /// re-requests write readiness. The AFD poll completes immediately for
+        /// a writable socket, so that produces a writable event the caller
+        /// never asked for, on every blocked read. See #1963.
+        ///
+        /// [`do_io`]: IoSourceState::do_io
+        #[cfg(feature = "net")]
+        pub fn do_io_with<T, F, R>(&self, interest: Interest, f: F, io: &T) -> io::Result<R>
+        where
+            F: FnOnce(&T) -> io::Result<R>,
+        {
+            let result = f(io);
+            if let Err(ref e) = result {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    self.inner.as_ref().map_or(Ok(()), |state| {
+                        // Never re-arm more than the source is registered for.
+                        // If the blocked direction is not registered at all
+                        // there is nothing to narrow to, so fall back to the
+                        // full interest, which is what `do_io` would do.
+                        let interests = match (
+                            interest.is_readable() && state.interests.is_readable(),
+                            interest.is_writable() && state.interests.is_writable(),
+                        ) {
+                            (true, false) => Interest::READABLE,
+                            (false, true) => Interest::WRITABLE,
+                            _ => state.interests,
+                        };
+
+                        state
+                            .selector
+                            .rearm(state.sock_state.clone(), state.token, interests)
+                    })?;
+                }
+            }
+            result
+        }
+
         pub fn register(
             &mut self,
             registry: &Registry,

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -285,6 +285,29 @@ cfg_io_source! {
 
             (events & !self.pending_evts) != 0
         }
+
+        /// Like `set_event`, but *adds* to the events already being waited for
+        /// instead of replacing them.
+        ///
+        /// Replacing is right when the user changes the interest they
+        /// registered, but wrong when re-arming after a blocked operation:
+        /// re-arming a single direction must not drop readiness the caller is
+        /// still waiting for in the other one.
+        ///
+        /// This composes with `feed_event`, which clears delivered events from
+        /// `user_evts`, so re-arming restores exactly what was consumed.
+        ///
+        /// True if need to be added on update queue, false otherwise.
+        #[cfg(feature = "net")]
+        fn add_event(&mut self, ev: Event) -> bool {
+            /* afd::POLL_CONNECT_FAIL and afd::POLL_ABORT are always reported, even when not requested by the caller. */
+            let events = self.user_evts | ev.flags | afd::POLL_CONNECT_FAIL | afd::POLL_ABORT;
+
+            self.user_evts = events;
+            self.user_data = ev.data;
+
+            (events & !self.pending_evts) != 0
+        }
     }
 }
 
@@ -577,6 +600,34 @@ cfg_io_source! {
                 };
 
                 state.lock().unwrap().set_event(event);
+            }
+
+            // FIXME: a sock which has_error true should not be re-added to
+            // the update queue because it's already there.
+            self.queue_state(state);
+            unsafe { self.update_sockets_events_if_polling() }
+        }
+
+        // Directly accessed in `IoSourceState::do_io_with`.
+        //
+        // Unlike `reregister` this adds `interests` to the events the socket is
+        // already waiting for rather than replacing them, so re-arming a single
+        // direction after a blocked operation cannot drop readiness the caller
+        // still wants in the other one.
+        #[cfg(feature = "net")]
+        pub(super) fn rearm(
+            &self,
+            state: Pin<Arc<Mutex<SockState>>>,
+            token: Token,
+            interests: Interest,
+        ) -> io::Result<()> {
+            {
+                let event = Event {
+                    flags: interests_to_afd_flags(interests),
+                    data: token.0 as u64,
+                };
+
+                state.lock().unwrap().add_event(event);
             }
 
             // FIXME: a sock which has_error true should not be re-added to

--- a/tests/rearm.rs
+++ b/tests/rearm.rs
@@ -21,7 +21,16 @@ const ID1: Token = Token(0);
 /// re-requests write readiness after a blocked *read*, and for a writable
 /// socket that is reported straight back, producing a writable event on every
 /// blocked read.
+///
+/// The `poll(2)` selector re-arms the same way and still has this problem:
+/// `SelectorState::reregister` overwrites the `pollfd` event mask, so narrowing
+/// the re-arm there needs a separate change. It is shared with `event_ports(2)`
+/// and left for a follow-up, so this test does not run against it.
 #[test]
+#[cfg_attr(
+    mio_unsupported_force_poll_poll,
+    ignore = "the poll(2) selector re-arms the full interest, see #1963"
+)]
 fn read_would_block_does_not_produce_a_writable_event() {
     let (mut poll, mut events) = init_with_poll();
 

--- a/tests/rearm.rs
+++ b/tests/rearm.rs
@@ -1,0 +1,55 @@
+#![cfg(all(feature = "os-poll", feature = "net"))]
+
+use std::io::Read;
+use std::net;
+
+use mio::net::TcpStream;
+use mio::{Interest, Token};
+
+mod util;
+use util::{
+    any_local_address, assert_would_block, expect_events, expect_no_events, init_with_poll,
+    ExpectEvent,
+};
+
+const ID1: Token = Token(0);
+
+/// Regression test for #1963.
+///
+/// Re-arming a source after a blocked operation must only re-arm the direction
+/// that actually blocked. Re-arming everything the source is registered for
+/// re-requests write readiness after a blocked *read*, and for a writable
+/// socket that is reported straight back, producing a writable event on every
+/// blocked read.
+#[test]
+fn read_would_block_does_not_produce_a_writable_event() {
+    let (mut poll, mut events) = init_with_poll();
+
+    let listener = net::TcpListener::bind(any_local_address()).unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let mut stream = TcpStream::connect(addr).unwrap();
+    // Hold on to the peer for the duration of the test. It never sends
+    // anything, so the stream stays connected but never becomes readable.
+    let (_peer, _) = listener.accept().unwrap();
+
+    poll.registry()
+        .register(&mut stream, ID1, Interest::READABLE | Interest::WRITABLE)
+        .unwrap();
+
+    // The stream is connected, so it is writable.
+    expect_events(
+        &mut poll,
+        &mut events,
+        vec![ExpectEvent::new(ID1, Interest::WRITABLE)],
+    );
+
+    // Nothing has been sent, so this blocks. This is what re-arms the source.
+    let mut buf = [0; 16];
+    assert_would_block(stream.read(&mut buf));
+
+    // Nothing changed since the writable event was handled: the peer sent
+    // nothing, and no write ever blocked. Re-arming the read must not raise
+    // write readiness again.
+    expect_no_events(&mut poll, &mut events);
+}

--- a/tests/rearm.rs
+++ b/tests/rearm.rs
@@ -22,14 +22,23 @@ const ID1: Token = Token(0);
 /// socket that is reported straight back, producing a writable event on every
 /// blocked read.
 ///
-/// The `poll(2)` selector re-arms the same way and still has this problem:
-/// `SelectorState::reregister` overwrites the `pollfd` event mask, so narrowing
-/// the re-arm there needs a separate change. It is shared with `event_ports(2)`
-/// and left for a follow-up, so this test does not run against it.
+/// `epoll(7)` and `kqueue(2)` are edge triggered and never re-arm, so they
+/// already hold to this. The selectors that do re-arm all replace the
+/// requested events rather than adding to them, so narrowing them needs a
+/// change per selector; only the Windows one is done here. The test is skipped
+/// on the others rather than dropping the invariant:
+///
+///   - `poll(2)`, via `--cfg mio_unsupported_force_poll_poll` and on WASI
+///   - `event_ports(2)`, on Solaris and illumos
 #[test]
 #[cfg_attr(
-    mio_unsupported_force_poll_poll,
-    ignore = "the poll(2) selector re-arms the full interest, see #1963"
+    any(
+        mio_unsupported_force_poll_poll,
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "wasi",
+    ),
+    ignore = "selector re-arms the full interest, see #1963"
 )]
 fn read_would_block_does_not_produce_a_writable_event() {
     let (mut poll, mut events) = init_with_poll();

--- a/tests/rearm.rs
+++ b/tests/rearm.rs
@@ -1,6 +1,6 @@
 #![cfg(all(feature = "os-poll", feature = "net"))]
 
-use std::io::Read;
+use std::io::{Read, Write};
 use std::net;
 
 use mio::net::TcpStream;
@@ -14,22 +14,38 @@ use util::{
 
 const ID1: Token = Token(0);
 
-/// Regression test for #1963.
-///
-/// Re-arming a source after a blocked operation must only re-arm the direction
-/// that actually blocked. Re-arming everything the source is registered for
-/// re-requests write readiness after a blocked *read*, and for a writable
-/// socket that is reported straight back, producing a writable event on every
-/// blocked read.
-///
-/// `epoll(7)` and `kqueue(2)` are edge triggered and never re-arm, so they
-/// already hold to this. The selectors that do re-arm all replace the
-/// requested events rather than adding to them, so narrowing them needs a
-/// change per selector; only the Windows one is done here. The test is skipped
-/// on the others rather than dropping the invariant:
-///
-///   - `poll(2)`, via `--cfg mio_unsupported_force_poll_poll` and on WASI
-///   - `event_ports(2)`, on Solaris and illumos
+// Regression tests for #1963.
+//
+// Re-arming a source after a blocked operation must only re-arm the direction
+// that actually blocked. Re-arming everything the source is registered for
+// re-requests write readiness after a blocked *read*, and for a writable
+// socket that is reported straight back, producing a writable event on every
+// blocked read.
+//
+// `epoll(7)` and `kqueue(2)` are edge triggered and never re-arm, so they
+// already hold to this. The selectors that do re-arm all replace the requested
+// events rather than adding to them, so narrowing them needs a change per
+// selector; only the Windows one is done so far. These tests are skipped on
+// the others rather than dropping the invariant:
+//
+//   - `poll(2)`, via `--cfg mio_unsupported_force_poll_poll` and on WASI
+//   - `event_ports(2)`, on Solaris and illumos
+
+macro_rules! skip_unnarrowed_selectors {
+    () => {
+        #[cfg_attr(
+            any(
+                mio_unsupported_force_poll_poll,
+                target_os = "solaris",
+                target_os = "illumos",
+                target_os = "wasi",
+            ),
+            ignore = "selector re-arms the full interest, see #1963"
+        )]
+    };
+}
+
+/// A blocked read must not raise write readiness.
 #[test]
 #[cfg_attr(
     any(
@@ -70,4 +86,54 @@ fn read_would_block_does_not_produce_a_writable_event() {
     // nothing, and no write ever blocked. Re-arming the read must not raise
     // write readiness again.
     expect_no_events(&mut poll, &mut events);
+}
+
+/// ... and the direction that did block must still be armed afterwards.
+///
+/// On its own the test above would also pass if the re-arm did nothing at all,
+/// so check that the read the source was narrowed to still arrives.
+#[test]
+#[cfg_attr(
+    any(
+        mio_unsupported_force_poll_poll,
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "wasi",
+    ),
+    ignore = "selector re-arms the full interest, see #1963"
+)]
+fn read_would_block_still_arms_the_read() {
+    let (mut poll, mut events) = init_with_poll();
+
+    let listener = net::TcpListener::bind(any_local_address()).unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let mut stream = TcpStream::connect(addr).unwrap();
+    let (mut peer, _) = listener.accept().unwrap();
+
+    poll.registry()
+        .register(&mut stream, ID1, Interest::READABLE | Interest::WRITABLE)
+        .unwrap();
+
+    expect_events(
+        &mut poll,
+        &mut events,
+        vec![ExpectEvent::new(ID1, Interest::WRITABLE)],
+    );
+
+    let mut buf = [0; 16];
+    assert_would_block(stream.read(&mut buf));
+
+    // Now there is something to read, which the re-armed read interest must
+    // still report.
+    peer.write_all(b"hello").unwrap();
+
+    expect_events(
+        &mut poll,
+        &mut events,
+        vec![ExpectEvent::new(ID1, Interest::READABLE)],
+    );
+
+    let n = stream.read(&mut buf).unwrap();
+    assert_eq!(&buf[..n], b"hello");
 }

--- a/tests/rearm.rs
+++ b/tests/rearm.rs
@@ -31,20 +31,6 @@ const ID1: Token = Token(0);
 //   - `poll(2)`, via `--cfg mio_unsupported_force_poll_poll` and on WASI
 //   - `event_ports(2)`, on Solaris and illumos
 
-macro_rules! skip_unnarrowed_selectors {
-    () => {
-        #[cfg_attr(
-            any(
-                mio_unsupported_force_poll_poll,
-                target_os = "solaris",
-                target_os = "illumos",
-                target_os = "wasi",
-            ),
-            ignore = "selector re-arms the full interest, see #1963"
-        )]
-    };
-}
-
 /// A blocked read must not raise write readiness.
 #[test]
 #[cfg_attr(


### PR DESCRIPTION
A socket registered `READABLE | WRITABLE` gets a writable event on every blocked read: `do_io` reregisters the full stored interest, `set_event` re-adds `POLL_SEND`, and the AFD poll completes with it immediately. Downstream this livelocks a tokio reader (tokio-rs/tokio#8054).

`do_io_with` re-arms only the direction the caller operated on, through a new `rearm` that adds to the events already being waited for rather than replacing them — narrowing one direction must not drop readiness still wanted in the other. Applied to `TcpStream`, `TcpListener` and `UdpSocket`, the types that reach this path on Windows. `try_io` keeps using `do_io`, since a caller-supplied closure has no known direction. No public API change.

Verified on Windows CI: the added test fails on `master` and passes with this change.

The tests also fail on `poll(2)`, `event_ports(2)` and WASI, which re-arm the same way; they are skipped there and left for a follow-up.

Fixes #1963
