### PR TITLE
Don't treat submitted Windows named pipe I/O as failed to submit

### DIFF
--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -218,6 +218,9 @@ impl Inner {
             }
         }
 
+        #[cfg(test)]
+        tests::run_submit_hook();
+
         let mut bytes = 0;
         let res = GetOverlappedResult(self.handle.raw(), overlapped, &mut bytes, 0);
         if res == 0 {
@@ -279,6 +282,9 @@ impl Inner {
                 return Err(err);
             }
         }
+
+        #[cfg(test)]
+        tests::run_submit_hook();
 
         let mut bytes = 0;
         let res = GetOverlappedResult(self.handle.raw(), overlapped, &mut bytes, 0);
@@ -1107,5 +1113,199 @@ impl BufferPool {
             }
             self.pool.push(buf);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Every submitted overlapped operation must reserve the strong reference
+    //! that its completion callback unconditionally consumes - even when the
+    //! operation fails while it is being submitted.
+
+    use super::*;
+    use std::cell::RefCell;
+    use std::fs::{File, OpenOptions};
+    use std::time::Duration;
+
+    // A buggy completion callback can over-release at most one strong
+    // reference per dispatched packet, and `deliver_completions` dispatches
+    // at most one batch of this size per call. `connected` leaks this many
+    // padding references so `Inner` stays allocated even then, making a
+    // regression fail with a readable assertion instead of a use-after-free.
+    // The padding is never returned: giving it back after a miscount would
+    // itself double-free.
+    const DISPATCH_BATCH: usize = 4;
+
+    thread_local! {
+        // One-shot hook that `read_overlapped` / `write_overlapped` run after
+        // submitting the operation, right before peeking at its result.
+        static SUBMIT_HOOK: RefCell<Option<Box<dyn FnMut()>>> = RefCell::new(None);
+    }
+
+    pub(super) fn run_submit_hook() {
+        if let Some(mut hook) = SUBMIT_HOOK.with(|hook| hook.borrow_mut().take()) {
+            hook();
+        }
+    }
+
+    /// A server pipe with a connected client, registered to a completion port
+    /// that the test drains manually, playing the selector's role.
+    struct TestPipe {
+        pipe: NamedPipe,
+        cp: Arc<CompletionPort>,
+        client: RefCell<Option<File>>,
+        baseline_refs: usize,
+    }
+
+    impl TestPipe {
+        fn connected(name: &str) -> TestPipe {
+            // A pipe name unique to this process and test, so parallel test
+            // runs cannot collide.
+            let name = format!(
+                r"\\.\pipe\mio-named-pipe-test-{}-{}",
+                std::process::id(),
+                name
+            );
+
+            // Create the server end and associate it with a completion port,
+            // so the kernel delivers its completion packets there.
+            let pipe = NamedPipe::new(&name).unwrap();
+            let cp = Arc::new(CompletionPort::new(1).unwrap());
+            cp.add_handle(1, &pipe).unwrap();
+
+            // Mirror what `Source::register` does, without going through a
+            // `Poll`: record the port and hand out a token so the pipe can
+            // schedule I/O and generate readiness notifications.
+            {
+                let mut io = pipe.inner.io.lock().unwrap();
+                io.cp = Some(cp.clone());
+                io.token = Some(Token(1));
+            }
+
+            // Deliberately leaked padding; see `DISPATCH_BATCH`.
+            for _ in 0..DISPATCH_BATCH {
+                mem::forget(pipe.inner.clone());
+            }
+
+            // The client end; `fail_next_submission_before_the_peek` drops it
+            // to fail the operation in flight at that point.
+            let client = OpenOptions::new().read(true).write(true).open(&name).unwrap();
+            let baseline_refs = Arc::strong_count(&pipe.inner);
+            TestPipe {
+                pipe,
+                cp,
+                client: RefCell::new(Some(client)),
+                baseline_refs,
+            }
+        }
+
+        /// Arranges the interleaving under test: the next submitted operation
+        /// fails (the client disconnects) and its completion is dequeued
+        /// before the submitter peeks at the result - dequeuing is what
+        /// publishes the failure into the OVERLAPPED, making it visible to
+        /// the peek. The packet is re-posted so `deliver_completions` can
+        /// consume it later, the way the selector would.
+        fn fail_next_submission_before_the_peek(&self) {
+            let mut client = self.client.borrow_mut().take();
+            let cp = self.cp.clone();
+            SUBMIT_HOOK.with(|hook| {
+                *hook.borrow_mut() = Some(Box::new(move || {
+                    drop(client.take());
+                    let mut statuses = [CompletionStatus::zero()];
+                    let timeout = Some(Duration::from_secs(10));
+                    assert_eq!(cp.get_many(&mut statuses, timeout).unwrap().len(), 1);
+                    cp.post(statuses[0]).unwrap();
+                }));
+            });
+        }
+
+        /// Strong references currently held beyond the baseline, i.e. the
+        /// references reserved for in-flight completions. Negative means a
+        /// reference was released that was never reserved.
+        fn reserved_refs(&self) -> isize {
+            Arc::strong_count(&self.pipe.inner) as isize - self.baseline_refs as isize
+        }
+
+        fn schedule_read(&self) -> bool {
+            let mut io = self.pipe.inner.io.lock().unwrap();
+            Inner::schedule_read(&self.pipe.inner, &mut io, None)
+        }
+
+        fn read_is_pending(&self) -> bool {
+            matches!(self.pipe.inner.io.lock().unwrap().read, State::Pending(..))
+        }
+
+        fn read_failed(&self) -> bool {
+            matches!(self.pipe.inner.io.lock().unwrap().read, State::Err(_))
+        }
+
+        fn write_failed(&self) -> bool {
+            matches!(self.pipe.inner.io.lock().unwrap().write, State::Err(_))
+        }
+
+        /// Dispatches queued packets the way `Selector::feed_events` does.
+        fn deliver_completions(&self) -> usize {
+            let mut statuses = [CompletionStatus::zero(); DISPATCH_BATCH];
+            let mut events = Vec::new();
+            let statuses = self.cp.get_many(&mut statuses, Some(Duration::from_secs(10))).unwrap();
+            for status in statuses.iter() {
+                let callback = unsafe { (*(status.overlapped() as *mut Overlapped)).callback };
+                callback(status.entry(), Some(&mut events));
+            }
+            statuses.len()
+        }
+    }
+
+    #[test]
+    fn submitted_read_that_fails_before_the_peek_reserves_a_reference() {
+        let pipe = TestPipe::connected("read");
+        pipe.fail_next_submission_before_the_peek();
+
+        // The read stays tracked as in flight, with one reference reserved
+        // for the already-dispatched completion packet.
+        assert!(pipe.schedule_read());
+        assert!(
+            pipe.read_is_pending(),
+            "a submitted read was treated as failed-to-submit, leaving its \
+             completion packet without a reserved reference"
+        );
+        assert_eq!(pipe.reserved_refs(), 1);
+
+        // Delivering the packet redeems exactly that reference and still
+        // surfaces the read's failure.
+        assert_eq!(pipe.deliver_completions(), 1);
+        assert_eq!(
+            pipe.reserved_refs(),
+            0,
+            "the completion must redeem exactly the reserved reference"
+        );
+        assert!(pipe.read_failed(), "the read's failure must still be delivered");
+    }
+
+    #[test]
+    fn submitted_write_that_fails_before_the_peek_reserves_a_reference() {
+        let pipe = TestPipe::connected("write");
+        pipe.fail_next_submission_before_the_peek();
+
+        // Larger than the pipe's outbound buffer, so the write must pend; the
+        // caller still sees it as accepted, with one reference reserved for
+        // the already-dispatched completion packet.
+        let data = vec![0u8; 128 * 1024];
+        let written = (&pipe.pipe).write(&data).expect(
+            "a submitted write must be reported as accepted; its failure \
+             arrives via the completion",
+        );
+        assert_eq!(written, data.len());
+        assert_eq!(pipe.reserved_refs(), 1);
+
+        // Delivering the packet redeems exactly that reference and still
+        // surfaces the write's failure.
+        assert_eq!(pipe.deliver_completions(), 1);
+        assert_eq!(
+            pipe.reserved_refs(),
+            0,
+            "the completion must redeem exactly the reserved reference"
+        );
+        assert!(pipe.write_failed(), "the write's failure must still be delivered");
     }
 }

--- a/src/sys/windows/named_pipe.rs
+++ b/src/sys/windows/named_pipe.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use std::{fmt, mem, slice};
 
 use windows_sys::Win32::Foundation::{
-    ERROR_BROKEN_PIPE, ERROR_IO_INCOMPLETE, ERROR_IO_PENDING, ERROR_MORE_DATA, ERROR_NO_DATA,
+    ERROR_BROKEN_PIPE, ERROR_IO_PENDING, ERROR_MORE_DATA, ERROR_NO_DATA,
     ERROR_PIPE_CONNECTED, ERROR_PIPE_LISTENING, HANDLE, INVALID_HANDLE_VALUE,
 };
 use windows_sys::Win32::Storage::FileSystem::{
@@ -221,12 +221,14 @@ impl Inner {
         let mut bytes = 0;
         let res = GetOverlappedResult(self.handle.raw(), overlapped, &mut bytes, 0);
         if res == 0 {
-            let err = io::Error::last_os_error();
-            if err.raw_os_error() == Some(ERROR_IO_INCOMPLETE as i32) {
-                Ok(None)
-            } else {
-                Err(err)
-            }
+            // The operation was submitted (`ReadFile` returned success or
+            // ERROR_IO_PENDING above), so a completion packet will reach the
+            // port no matter how the operation ends; the status is not even
+            // written into the OVERLAPPED until that packet is dequeued.
+            // Returning `Err` here would make the caller skip reserving the
+            // strong reference that the completion callback unconditionally
+            // consumes, corrupting the reference count of `Inner`.
+            Ok(None)
         } else {
             Ok(Some(bytes as usize))
         }
@@ -281,12 +283,10 @@ impl Inner {
         let mut bytes = 0;
         let res = GetOverlappedResult(self.handle.raw(), overlapped, &mut bytes, 0);
         if res == 0 {
-            let err = io::Error::last_os_error();
-            if err.raw_os_error() == Some(ERROR_IO_INCOMPLETE as i32) {
-                Ok(None)
-            } else {
-                Err(err)
-            }
+            // See `read_overlapped`: the operation was submitted, so its
+            // completion packet is in flight and the caller must reserve the
+            // reference that the completion callback consumes.
+            Ok(None)
         } else {
             Ok(Some(bytes as usize))
         }


### PR DESCRIPTION
Fixes the root cause behind #1819-style `unreachable!()` panics, and a use-after-free, in Windows named pipes.

## The bug

Every submitted overlapped operation reserves one strong reference of `Inner` (`mem::forget` in `schedule_read` / `maybe_schedule_write`), and the completion callback unconditionally redeems one (`Arc::from_raw` + drop). The schedulers treat `Err` from `read_overlapped` / `write_overlapped` as "failed synchronously, no completion packet coming" and skip the reservation.

But once `ReadFile`/`WriteFile` has returned `ERROR_IO_PENDING` a completion packet is guaranteed no matter how the operation ends - and the `GetOverlappedResult(bWait = FALSE)` peek that follows can still observe the operation's failure and return `Err`: one packet in flight, zero reservations. When that packet is dispatched:

* **read path** - `schedule_read` parked `State::Err`; `read_done` (since the #1819 fix) restores it and releases the reference - one release too many. `Inner` is freed while `NamedPipe` still points at it, and the next legitimate drop double-frees (`STATUS_HEAP_CORRUPTION` at `Arc<Inner>::drop_slow`).
* **write path** - the `Err` propagates out of `Write::write`, `io.write` stays `State::None`, and `write_done` hits `unreachable!()`.

The window is tiny but the outcome is guaranteed: per the [I/O Completion Ports docs](https://learn.microsoft.com/en-us/windows/win32/fileio/i-o-completion-ports), the status block "will not be updated until the packet is removed from the completion port", so the peek can only see the failure after the selector thread has already dequeued the packet - meaning the callback is already dispatched and waiting on the `io` mutex. Hitting it requires the peer to fail the operation right after submission (e.g. a disconnect completing a pending read with `ERROR_BROKEN_PIPE`) and the submitting thread to lose the CPU before the peek - preemption or suspend/resume. #1819 matches exactly: `read_done` found `State::Err` (os error 109), reproducibly around laptop sleep/wake.

## The fix

Once the operation has been submitted, never return `Err` - report it as in flight (`Ok(None)`) so the caller reserves the reference; the callback picks up the real result via `GetOverlappedResult` and the error is still delivered through readiness as `State::Err`. This is identical to the overwhelmingly common interleaving where the peek returns `ERROR_IO_INCOMPLETE`. Synchronous submission failures (no packet) still return `Err`.

## Reproduction

The dequeue must land between the submission and the peek, which cannot be forced from outside, so the second commit adds a `#[cfg(test)]`-only hook at exactly that seam, plus two regression tests: each submits a real read/write on a connected pipe, and the hook drops the client and dequeues the resulting error completion before the peek runs. The tests were written first and verified failing on the unfixed code; the fix commit is independently green, so the history bisects.

On Windows: `cargo test --all-features submitted_` - passes on this branch; cherry-pick the test commit alone onto master and both fail:

```
a submitted read was treated as failed-to-submit, leaving its completion packet without a reserved reference

a submitted write must be reported as accepted; its failure arrives via the completion: Os { code: 109, kind: BrokenPipe, ... }
```

<details>
<summary>Standalone demonstration of the deferred-status behavior</summary>

1. Create a named pipe server (`FILE_FLAG_OVERLAPPED`), associate it with a completion port, connect a client.
2. `ReadFile` on the server with no data buffered -> `FALSE`, `ERROR_IO_PENDING`.
3. Close the client handle -> the pending read completes with `ERROR_BROKEN_PIPE`.
4. `GetOverlappedResult(bWait = FALSE)` keeps returning `ERROR_IO_INCOMPLETE`, indefinitely - the failure is not yet visible.
5. `GetQueuedCompletionStatus` dequeues the packet (operation error 109).
6. The same `GetOverlappedResult(bWait = FALSE)` **now** returns `ERROR_BROKEN_PIPE`.

Steps 4 vs 6 show the deferral: the peek can only see the error after the packet has been dequeued - i.e. only after the selector has already dispatched the callback that will consume a reservation.
</details>
