### PR TITLE
Fix unix socket accept for named peers on Darwin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ wasi = "0.11.0"
 env_logger = { version = "0.11", default-features = false }
 rand = "0.9"
 
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2.183"
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ env_logger = { version = "0.11", default-features = false }
 rand = "0.9"
 
 [target.'cfg(unix)'.dev-dependencies]
-libc = "0.2.183"
+socket2 = { version = "0.5", features = ["all"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/sys/unix/uds/listener.rs
+++ b/src/sys/unix/uds/listener.rs
@@ -141,12 +141,17 @@ pub(crate) fn accept(listener: &net::UnixListener) -> io::Result<(UnixStream, So
         path_len = 0;
     }
     // SAFETY: going from i8 to u8 is fine in this context.
-    let mut path =
+    let path =
         unsafe { &*(&sockaddr.sun_path[..path_len] as *const [libc::c_char] as *const [u8]) };
-    // Remove last null as `SocketAddr::from_pathname` doesn't accept it.
-    if let Some(0) = path.last() {
-        path = &path[..path.len() - 1];
-    }
+    // On Darwin, accept(2) reports the length of the entire sockaddr_un
+    // structure, leaving the path padded with null bytes. Other systems report
+    // the length of the path including at most one null terminator. Either
+    // way, `SocketAddr::from_pathname` doesn't accept (interior) null bytes,
+    // so truncate the path at the first null byte.
+    let path = match path.iter().position(|&byte| byte == 0) {
+        Some(null) => &path[..null],
+        None => path,
+    };
     let address = SocketAddr::from_pathname(Path::new(OsStr::from_bytes(path)))?;
     Ok((socket, address))
 }

--- a/tests/unix_listener.rs
+++ b/tests/unix_listener.rs
@@ -2,6 +2,7 @@
 
 use mio::net::UnixListener;
 use mio::{Interest, Token};
+use socket2::{Domain, SockAddr, Socket, Type};
 use std::io::{self, Read};
 use std::os::unix::net;
 use std::path::{Path, PathBuf};
@@ -78,74 +79,14 @@ fn unix_listener_local_addr() {
 
 /// Connect to the unix socket at `connect_path` from a socket that is itself
 /// bound to `bind_path`. Mio (and std) don't expose bind-before-connect for
-/// `UnixStream`, so this uses libc directly.
-#[cfg(unix)]
+/// `UnixStream`, so this uses socket2 directly.
 fn connect_from_bound_socket(bind_path: &Path, connect_path: &Path) -> net::UnixStream {
-    use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::io::FromRawFd;
-
-    fn pack_sockaddr_un(path: &Path) -> libc::sockaddr_un {
-        let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
-        addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
-        let bytes = path.as_os_str().as_bytes();
-        assert!(bytes.len() < addr.sun_path.len());
-        // SAFETY: sun_path is large enough (checked above) and doesn't
-        // overlap with the path bytes.
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                bytes.as_ptr(),
-                addr.sun_path.as_mut_ptr().cast(),
-                bytes.len(),
-            );
-        }
-        #[cfg(any(
-            target_os = "macos",
-            target_os = "ios",
-            target_os = "tvos",
-            target_os = "watchos",
-            target_os = "visionos",
-            target_os = "freebsd",
-            target_os = "dragonfly",
-            target_os = "netbsd",
-            target_os = "openbsd",
-        ))]
-        {
-            addr.sun_len = std::mem::size_of::<libc::sockaddr_un>() as u8;
-        }
-        addr
-    }
-
-    unsafe {
-        let fd = libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0);
-        assert!(
-            fd >= 0,
-            "failed to create socket: {}",
-            io::Error::last_os_error()
-        );
-
-        let bind_addr = pack_sockaddr_un(bind_path);
-        let len = std::mem::size_of::<libc::sockaddr_un>() as libc::socklen_t;
-        let res = libc::bind(
-            fd,
-            &bind_addr as *const libc::sockaddr_un as *const libc::sockaddr,
-            len,
-        );
-        assert!(res == 0, "failed to bind: {}", io::Error::last_os_error());
-
-        let connect_addr = pack_sockaddr_un(connect_path);
-        let res = libc::connect(
-            fd,
-            &connect_addr as *const libc::sockaddr_un as *const libc::sockaddr,
-            len,
-        );
-        assert!(
-            res == 0,
-            "failed to connect: {}",
-            io::Error::last_os_error()
-        );
-
-        net::UnixStream::from_raw_fd(fd)
-    }
+    let socket = Socket::new(Domain::UNIX, Type::STREAM, None).unwrap();
+    socket.bind(&SockAddr::unix(bind_path).unwrap()).unwrap();
+    socket
+        .connect(&SockAddr::unix(connect_path).unwrap())
+        .unwrap();
+    net::UnixStream::from(socket)
 }
 
 /// On Darwin, accept(2) reports the length of the entire sockaddr_un

--- a/tests/unix_listener.rs
+++ b/tests/unix_listener.rs
@@ -76,6 +76,109 @@ fn unix_listener_local_addr() {
     handle.join().unwrap();
 }
 
+/// Connect to the unix socket at `connect_path` from a socket that is itself
+/// bound to `bind_path`. Mio (and std) don't expose bind-before-connect for
+/// `UnixStream`, so this uses libc directly.
+#[cfg(unix)]
+fn connect_from_bound_socket(bind_path: &Path, connect_path: &Path) -> net::UnixStream {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::io::FromRawFd;
+
+    fn pack_sockaddr_un(path: &Path) -> libc::sockaddr_un {
+        let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+        addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
+        let bytes = path.as_os_str().as_bytes();
+        assert!(bytes.len() < addr.sun_path.len());
+        // SAFETY: sun_path is large enough (checked above) and doesn't
+        // overlap with the path bytes.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                addr.sun_path.as_mut_ptr().cast(),
+                bytes.len(),
+            );
+        }
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "visionos",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+            target_os = "netbsd",
+            target_os = "openbsd",
+        ))]
+        {
+            addr.sun_len = std::mem::size_of::<libc::sockaddr_un>() as u8;
+        }
+        addr
+    }
+
+    unsafe {
+        let fd = libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0);
+        assert!(
+            fd >= 0,
+            "failed to create socket: {}",
+            io::Error::last_os_error()
+        );
+
+        let bind_addr = pack_sockaddr_un(bind_path);
+        let len = std::mem::size_of::<libc::sockaddr_un>() as libc::socklen_t;
+        let res = libc::bind(
+            fd,
+            &bind_addr as *const libc::sockaddr_un as *const libc::sockaddr,
+            len,
+        );
+        assert!(res == 0, "failed to bind: {}", io::Error::last_os_error());
+
+        let connect_addr = pack_sockaddr_un(connect_path);
+        let res = libc::connect(
+            fd,
+            &connect_addr as *const libc::sockaddr_un as *const libc::sockaddr,
+            len,
+        );
+        assert!(
+            res == 0,
+            "failed to connect: {}",
+            io::Error::last_os_error()
+        );
+
+        net::UnixStream::from_raw_fd(fd)
+    }
+}
+
+/// On Darwin, accept(2) reports the length of the entire sockaddr_un
+/// structure (with the peer path padded with null bytes) rather than the
+/// length of the peer path. Accepting a connection from a peer bound to a
+/// named path must still work.
+#[test]
+fn unix_listener_accept_named_peer() {
+    let (mut poll, mut events) = init_with_poll();
+
+    let listener_path = temp_file("unix_listener_accept_named_peer_listener");
+    let client_path = temp_file("unix_listener_accept_named_peer_client");
+    let mut listener = UnixListener::bind(&listener_path).unwrap();
+    poll.registry()
+        .register(&mut listener, TOKEN_1, Interest::READABLE)
+        .unwrap();
+
+    let client = connect_from_bound_socket(&client_path, &listener_path);
+
+    expect_events(
+        &mut poll,
+        &mut events,
+        vec![ExpectEvent::new(TOKEN_1, Interest::READABLE)],
+    );
+
+    let (_stream, addr) = listener.accept().unwrap();
+    // getting pathname isn't supported on GNU/Hurd
+    #[cfg(not(target_os = "hurd"))]
+    assert_eq!(addr.as_pathname().unwrap(), &client_path);
+
+    drop(client);
+}
+
 #[test]
 fn unix_listener_register() {
     let (mut poll, mut events) = init_with_poll();


### PR DESCRIPTION
AI disclaimer: This PR (code _and_ description) was written by AI (Claude Code), on my request. I ran into failing tests from some Ruby/Rails code that ships logs to the [Vector](https://github.com/vectordotdev/vector) agent → Tokio → Mio – Vector logged `Failed to accept socket. error=paths must not contain interior null bytes`. Claude traced the failure and suggested this fix.

## Summary

- On Darwin, `accept(2)` reports the length of the entire `sockaddr_un` structure, so a named peer's path in `sun_path` is followed by null padding up to the full length.
- `uds::listener::accept` removed at most one trailing null byte (sufficient on Linux, where the reported length covers only the path and its null terminator), leaving interior null bytes that made `SocketAddr::from_pathname` fail with `paths must not contain interior null bytes` — failing `accept()` itself for any peer bound to a named path.
- Truncate the path at the first null byte instead, which handles both layouts.

## Impact

Any client that binds its unix socket to a named path before connecting has its connections rejected on macOS. We hit this with [Vector](https://vector.dev): its unix socket sources report the peer's bound path as the event's `host`, so applications logging to Vector bind their client sockets to named paths to tell connections apart — and on macOS every such connection is dropped with `Failed to accept socket. error=paths must not contain interior null bytes`. Reproducible with a plain `tokio::net::UnixListener` (tokio delegates to mio's `accept`), so this affects all mio-based unix socket servers on Darwin.

## Test

- Added `unix_listener_accept_named_peer`, which connects from a socket bound to a named path. Neither std nor mio expose bind-before-connect for `UnixStream` (the same limitation noted in #1817), so the test uses `libc` directly, added as a unix-only dev-dependency.
- Verified the test fails on master on macOS 15 and passes with this fix; it passes on Linux with and without the fix.
- Full test suite (`--features os-poll,net`), `cargo fmt --check`, and `clippy` pass.