### PR TITLE
fix(event): report remaining events from Iter::size_hint and count (#1990)

### DIFF
--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -214,12 +214,12 @@ impl<'a> Iterator for Iter<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let size = self.inner.inner.len();
+        let size = self.inner.inner.len().saturating_sub(self.pos);
         (size, Some(size))
     }
 
     fn count(self) -> usize {
-        self.inner.inner.len()
+        self.inner.inner.len().saturating_sub(self.pos)
     }
 }
 

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -51,3 +51,32 @@ fn is_event_send_sync() {
     assert_send::<Events>();
     assert_sync::<Events>();
 }
+
+#[test]
+fn iter_size_hint_and_count() {
+    let (mut poll, mut events) = init_with_poll();
+    let waker = Waker::new(poll.registry(), WAKE_TOKEN).unwrap();
+
+    waker.wake().expect("unable to wake");
+    poll.poll(&mut events, Some(Duration::from_millis(100)))
+        .unwrap();
+
+    let total = events.iter().count();
+    assert!(total > 0);
+
+    let mut iter = events.iter();
+    assert_eq!(iter.size_hint(), (total, Some(total)));
+    assert_eq!(iter.by_ref().count(), total);
+
+    let mut iter = events.iter();
+    assert!(iter.next().is_some());
+    let remaining = total - 1;
+    assert_eq!(iter.size_hint(), (remaining, Some(remaining)));
+    assert_eq!(iter.count(), remaining);
+
+    let mut iter = events.iter();
+    while iter.next().is_some() {}
+    // Beyond exhaustion
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+    assert_eq!(iter.count(), 0);
+}


### PR DESCRIPTION
Fixes #1990.

`Iter::size_hint` and `Iter::count` previously returned the container's total length rather than the number of items remaining. After partial consumption or upon exhaustion, they over-reported the remaining items.

This updates both methods to use `self.inner.inner.len().saturating_sub(self.pos)` so remaining items are correctly reported, including when `pos` advances past the end. Added test coverage in `tests/events.rs`.